### PR TITLE
fix: robust date parsing to handle unexpected timestamps

### DIFF
--- a/agent/base_agent/base_agent.py
+++ b/agent/base_agent/base_agent.py
@@ -587,14 +587,14 @@ class BaseAgent:
                     if max_date is None:
                         max_date = current_date
                     else:
-                        current_date_obj = datetime.strptime(current_date, "%Y-%m-%d")
-                        max_date_obj = datetime.strptime(max_date, "%Y-%m-%d")
+                        current_date_obj = datetime.strptime(current_date.split(' ')[0], "%Y-%m-%d")
+                        max_date_obj = datetime.strptime(max_date.split(' ')[0], "%Y-%m-%d")
                         if current_date_obj > max_date_obj:
                             max_date = current_date
 
         # Check if new dates need to be processed
-        max_date_obj = datetime.strptime(max_date, "%Y-%m-%d")
-        end_date_obj = datetime.strptime(end_date, "%Y-%m-%d")
+        max_date_obj = datetime.strptime(max_date.split(' ')[0], "%Y-%m-%d")
+        end_date_obj = datetime.strptime(end_date.split(' ')[0], "%Y-%m-%d")
 
         if end_date_obj <= max_date_obj:
             return []

--- a/main.py
+++ b/main.py
@@ -156,7 +156,7 @@ async def main(config_path=None):
         INIT_DATE_obj = datetime.strptime(INIT_DATE, "%Y-%m-%d %H:%M:%S")
     else:
         INIT_DATE_obj = datetime.strptime(INIT_DATE, "%Y-%m-%d")
-    
+    INIT_DATE = INIT_DATE_obj.strftime("%Y-%m-%d")    
     if ' ' in END_DATE:
         END_DATE_obj = datetime.strptime(END_DATE, "%Y-%m-%d %H:%M:%S")
     else:
@@ -165,7 +165,7 @@ async def main(config_path=None):
     if INIT_DATE_obj > END_DATE_obj:
         print("❌ INIT_DATE is greater than END_DATE")
         exit(1)
-
+    END_DATE = END_DATE_obj.strftime("%Y-%m-%d")
     # Get model list from configuration file (only select enabled models)
     enabled_models = [model for model in config["models"] if model.get("enabled", True)]
 


### PR DESCRIPTION
Fixed the `unconverted data remains: 11:00:00` error by implementing more robust date parsing using `.split(' ')[0]` in `main.py` and `base_agent.py` . This ensures the agent handles date strings even if they contain unexpected timestamps.