### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/agent_tools/start_mcp_services.py
+++ b/agent_tools/start_mcp_services.py
@@ -66,7 +66,7 @@ class MCPServiceManager:
             result = sock.connect_ex(("localhost", port))
             sock.close()
             return result != 0  # Port is available if connection failed
-        except:
+        except Exception:
             return False
 
     def check_port_conflicts(self):
@@ -154,7 +154,7 @@ class MCPServiceManager:
             result = sock.connect_ex(("localhost", port))
             sock.close()
             return result == 0
-        except:
+        except Exception:
             return False
 
     def start_all_services(self):


### PR DESCRIPTION
## What
Replace 2 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.