### PR TITLE
Backfill signal sequence and legacy Polymarket positions

### DIFF
--- a/service/server/database.py
+++ b/service/server/database.py
@@ -275,6 +275,16 @@ def init_database():
         )
     """)
 
+    cursor.execute("SELECT COALESCE(MAX(signal_id), 0) AS max_signal_id FROM signals")
+    max_signal_id = int(cursor.fetchone()["max_signal_id"] or 0)
+    cursor.execute("SELECT COALESCE(MAX(id), 0) AS max_sequence_id FROM signal_sequence")
+    max_sequence_id = int(cursor.fetchone()["max_sequence_id"] or 0)
+    if max_sequence_id < max_signal_id:
+        cursor.executemany(
+            "INSERT INTO signal_sequence DEFAULT VALUES",
+            [()] * (max_signal_id - max_sequence_id)
+        )
+
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS polymarket_settlements (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/service/server/tasks.py
+++ b/service/server/tasks.py
@@ -14,6 +14,51 @@ from typing import Optional, Dict, Any
 trending_cache: list = []
 
 
+def _backfill_polymarket_position_metadata() -> None:
+    """Best-effort backfill for legacy Polymarket positions missing token_id/outcome."""
+    from database import get_db_connection
+    from price_fetcher import _polymarket_resolve_reference
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        cursor.execute("""
+            SELECT id, symbol, token_id, outcome
+            FROM positions
+            WHERE market = 'polymarket' AND (token_id IS NULL OR token_id = '')
+        """)
+        rows = cursor.fetchall()
+        if not rows:
+            conn.close()
+            return
+
+        updated = 0
+        skipped = 0
+        for row in rows:
+            outcome = row["outcome"]
+            if not outcome:
+                skipped += 1
+                continue
+            contract = _polymarket_resolve_reference(row["symbol"], outcome=outcome)
+            if not contract or not contract.get("token_id"):
+                skipped += 1
+                continue
+            cursor.execute("""
+                UPDATE positions
+                SET token_id = ?, outcome = COALESCE(outcome, ?)
+                WHERE id = ?
+            """, (contract["token_id"], contract.get("outcome"), row["id"]))
+            updated += 1
+
+        if updated > 0:
+            conn.commit()
+            print(f"[Polymarket Backfill] Updated {updated} legacy positions; skipped={skipped}")
+        else:
+            conn.rollback()
+    finally:
+        conn.close()
+
+
 def _update_trending_cache():
     """Update trending cache - calculates from positions table."""
     global trending_cache
@@ -66,6 +111,7 @@ async def update_position_prices():
 
     while True:
         try:
+            _backfill_polymarket_position_metadata()
             conn = get_db_connection()
             cursor = conn.cursor()
 
@@ -243,6 +289,7 @@ async def settle_polymarket_positions():
             interval_s = 60
 
         try:
+            _backfill_polymarket_position_metadata()
             conn = get_db_connection()
             cursor = conn.cursor()
             cursor.execute("""


### PR DESCRIPTION
## Summary
  - backfill signal_sequence to the current max signal_id during database
  init
  - add best-effort backfill for legacy Polymarket positions missing token
  metadata
  - run Polymarket metadata backfill before price refresh and settlement
  tasks

  ## Verification
  - /usr/bin/python3 -m py_compile service/server/database.py service/
  server/tasks.py