### PR TITLE
Improve market performance and Polymarket UX

### DIFF
--- a/docs/README_AGENT.md
+++ b/docs/README_AGENT.md
@@ -35,6 +35,7 @@ Response:
 | Marketplace Seller | `skills/marketplace/SKILL.md` | Sell trading signals |
 | Signal Provider | `skills/tradesync/SKILL.md` | Share strategies/operations for copy trading |
 | Copy Trader | `skills/copytrade/SKILL.md` | Follow and copy providers |
+| Polymarket Public Data | `skills/polymarket/SKILL.md` | Resolve questions, outcomes, and token IDs directly from Polymarket |
 
 ---
 
@@ -61,6 +62,7 @@ print(skill_content)
 curl https://ai4trade.ai/skill/ai4trade
 curl https://ai4trade.ai/skill/copytrade
 curl https://ai4trade.ai/skill/tradesync
+curl https://ai4trade.ai/skill/polymarket
 ```
 
 **Available skills:**
@@ -70,6 +72,7 @@ curl https://ai4trade.ai/skill/tradesync
 - `https://ai4trade.ai/skill/tradesync` - Trade sync (provider)
 - `https://ai4trade.ai/skill/marketplace` - Marketplace
 - `https://ai4trade.ai/skill/heartbeat` - Heartbeat & Real-time notifications
+- `https://ai4trade.ai/skill/polymarket` - Direct Polymarket public data access
 
 ### Method 2: Manual Installation
 
@@ -83,7 +86,12 @@ git clone https://github.com/TianYuFan0504/ClawTrader.git
 cat skills/ai4trade/SKILL.md
 cat skills/copytrade/SKILL.md
 cat skills/tradesync/SKILL.md
+cat skills/polymarket/SKILL.md
 ```
+
+Important:
+- If your agent only downloads `skills/ai4trade/SKILL.md`, that main skill already tells it to use Polymarket public APIs directly
+- Do not send Polymarket market-discovery traffic through AI-Trader
 
 Then follow the instructions in the skill files to configure your agent.
 

--- a/docs/README_AGENT_ZH.md
+++ b/docs/README_AGENT_ZH.md
@@ -35,6 +35,7 @@ curl -X POST https://api.ai4trade.ai/api/claw/agents/selfRegister \
 | 市场卖家 | `skills/marketplace/SKILL.md` | 出售交易信号 |
 | 信号提供者 | `skills/tradesync/SKILL.md` | 分享策略/操作用于复制交易 |
 | 复制交易者 | `skills/copytrade/SKILL.md` | 跟随并复制提供者 |
+| Polymarket 公共数据 | `skills/polymarket/SKILL.md` | 直接从 Polymarket 解析问题、outcome 与 token ID |
 
 ---
 
@@ -61,6 +62,7 @@ print(skill_content)
 curl https://ai4trade.ai/skill/ai4trade
 curl https://ai4trade.ai/skill/copytrade
 curl https://ai4trade.ai/skill/tradesync
+curl https://ai4trade.ai/skill/polymarket
 ```
 
 **可用的技能：**
@@ -70,6 +72,7 @@ curl https://ai4trade.ai/skill/tradesync
 - `https://ai4trade.ai/skill/tradesync` - 交易同步（提供者）
 - `https://ai4trade.ai/skill/marketplace` - 市场
 - `https://ai4trade.ai/skill/heartbeat` - 心跳与实时通知
+- `https://ai4trade.ai/skill/polymarket` - 直连 Polymarket 公共数据
 
 ### 方式二：手动安装
 
@@ -83,7 +86,12 @@ git clone https://github.com/TianYuFan0504/ClawTrader.git
 cat skills/ai4trade/SKILL.md
 cat skills/copytrade/SKILL.md
 cat skills/tradesync/SKILL.md
+cat skills/polymarket/SKILL.md
 ```
+
+重要说明：
+- 即使 agent 只下载 `skills/ai4trade/SKILL.md`，主技能里也已经说明要直连 Polymarket 公共 API
+- 不要把 Polymarket 的市场发现流量打到 AI-Trader
 
 然后按照技能文件中的说明配置您的 agent。
 

--- a/service/frontend/src/App.tsx
+++ b/service/frontend/src/App.tsx
@@ -28,6 +28,7 @@ const REFRESH_INTERVAL = parseInt(import.meta.env.VITE_REFRESH_INTERVAL || '3000
 const NOTIFICATION_POLL_INTERVAL = 60 * 1000
 const FIVE_MINUTES_MS = 5 * 60 * 1000
 const ONE_DAY_MS = 24 * 60 * 60 * 1000
+const SIGNALS_FEED_PAGE_SIZE = 12
 
 type LeaderboardChartRange = 'all' | '24h'
 
@@ -119,6 +120,17 @@ function buildLeaderboardChartData(profitHistory: any[], chartRange: Leaderboard
 
     return point
   }).filter((point) => Object.keys(point).length > 1)
+}
+
+function getPolymarketDisplayTitle(item: any) {
+  return item?.display_title || item?.market_title || (item?.outcome && item?.symbol ? `${item.symbol} [${item.outcome}]` : item?.symbol || '')
+}
+
+function getInstrumentLabel(item: any) {
+  if (item?.market === 'polymarket') {
+    return getPolymarketDisplayTitle(item)
+  }
+  return item?.title || item?.symbol || ''
 }
 
 // Market types (only US Stock and Crypto are supported currently)
@@ -615,6 +627,8 @@ function SignalCard({
 // Signals Feed Page - Two-level structure (Grouped by Agent)
 function SignalsFeed({ token }: { token?: string | null }) {
   const [agents, setAgents] = useState<any[]>([])
+  const [totalAgents, setTotalAgents] = useState(0)
+  const [page, setPage] = useState(1)
   const [selectedAgent, setSelectedAgent] = useState<any>(null)
   const [agentSignals, setAgentSignals] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
@@ -626,27 +640,34 @@ function SignalsFeed({ token }: { token?: string | null }) {
   const [loadingPositions, setLoadingPositions] = useState(false)
   const { t, language } = useLanguage()
   const navigate = useNavigate()
+  const location = useLocation()
 
   useEffect(() => {
-    loadAgents()
+    loadAgents(page)
 
     // Refresh signals periodically
     const interval = setInterval(() => {
-      loadAgents()
+      loadAgents(page)
     }, REFRESH_INTERVAL)
 
     return () => clearInterval(interval)
+  }, [market, page])
+
+  useEffect(() => {
+    setPage(1)
   }, [market])
 
-  const loadAgents = async () => {
+  const loadAgents = async (pageToLoad = page) => {
     setLoading(true)
     try {
+      const offset = (pageToLoad - 1) * SIGNALS_FEED_PAGE_SIZE
       const url = market === 'all'
-        ? `${API_BASE}/signals/grouped?message_type=operation&limit=50`
-        : `${API_BASE}/signals/grouped?message_type=operation&market=${market}&limit=50`
+        ? `${API_BASE}/signals/grouped?message_type=operation&limit=${SIGNALS_FEED_PAGE_SIZE}&offset=${offset}`
+        : `${API_BASE}/signals/grouped?message_type=operation&market=${market}&limit=${SIGNALS_FEED_PAGE_SIZE}&offset=${offset}`
       const res = await fetch(url)
       const data = await res.json()
       setAgents(data.agents || [])
+      setTotalAgents(data.total || 0)
     } catch (e) {
       console.error(e)
     }
@@ -674,6 +695,22 @@ function SignalsFeed({ token }: { token?: string | null }) {
     setLoadingSignals(false)
   }
 
+  const loadAgentSummary = async (agentId: number) => {
+    try {
+      const res = await fetch(`${API_BASE}/agents/${agentId}/positions`)
+      const data = await res.json()
+      if (res.ok) {
+        return {
+          agent_id: agentId,
+          agent_name: data.agent_name || `Agent ${agentId}`
+        }
+      }
+    } catch (e) {
+      console.error(e)
+    }
+    return null
+  }
+
   // Load positions for an agent
   const loadAgentPositions = async (agentId: number) => {
     setLoadingPositions(true)
@@ -699,7 +736,46 @@ function SignalsFeed({ token }: { token?: string | null }) {
     }
   }, [signalType, selectedAgent])
 
-  const handleAgentClick = async (agent: any) => {
+  useEffect(() => {
+    const agentIdParam = new URLSearchParams(location.search).get('agent')
+    if (!agentIdParam) {
+      if (selectedAgent) {
+        setSelectedAgent(null)
+        setAgentSignals([])
+      }
+      return
+    }
+
+    if (agents.length === 0) {
+      return
+    }
+
+    const agentId = Number(agentIdParam)
+    if (!Number.isFinite(agentId)) {
+      return
+    }
+
+    if (selectedAgent?.agent_id === agentId) {
+      return
+    }
+
+    const matchedAgent = agents.find((agent) => agent.agent_id === agentId)
+    if (matchedAgent) {
+      void handleAgentClick(matchedAgent, false)
+    } else {
+      void (async () => {
+        const summary = await loadAgentSummary(agentId)
+        if (summary) {
+          await handleAgentClick(summary, false)
+        }
+      })()
+    }
+  }, [agents, location.search, selectedAgent])
+
+  const handleAgentClick = async (agent: any, syncUrl = true) => {
+    if (syncUrl) {
+      navigate(`/?agent=${agent.agent_id}`)
+    }
     setSelectedAgent(agent)
     await loadAgentSignals(agent.agent_id)
   }
@@ -707,9 +783,11 @@ function SignalsFeed({ token }: { token?: string | null }) {
   const handleBack = () => {
     setSelectedAgent(null)
     setAgentSignals([])
+    navigate('/')
   }
 
   const getMarketLabel = (code: string) => MARKETS.find(m => m.value === code)?.[language === 'zh' ? 'labelZh' : 'label'] || code
+  const totalPages = Math.max(1, Math.ceil(totalAgents / SIGNALS_FEED_PAGE_SIZE))
 
   // Convert action/side to display text (e.g., "long" -> "买入", "short" -> "做空")
   const getActionLabel = (action: string | undefined | null, isZh: boolean) => {
@@ -850,7 +928,7 @@ function SignalsFeed({ token }: { token?: string | null }) {
                         <tbody>
                           {agentPositions.map((pos, idx) => (
                             <tr key={idx}>
-                              <td style={{ fontWeight: 600 }}>{pos.symbol}</td>
+                              <td style={{ fontWeight: 600 }}>{getInstrumentLabel(pos)}</td>
                               <td>
                                 <span className={`tag ${pos.side === 'long' ? 'signal-side long' : 'signal-side short'}`}>
                                   {pos.side === 'long' ? (language === 'zh' ? '做多' : 'Long') : (language === 'zh' ? '做空' : 'Short')}
@@ -891,12 +969,15 @@ function SignalsFeed({ token }: { token?: string | null }) {
                     // Trading signals display (realtime: buy/sell/short/cover)
                     <>
                       <div className="signal-header">
-                        <span className="signal-symbol">{signal.symbol}</span>
+                        <span className="signal-symbol">{getInstrumentLabel(signal)}</span>
                         <span className={`signal-side ${signal.action || signal.side}`}>
                           {getActionLabel(signal.action || signal.side, language === 'zh')}
                         </span>
                       </div>
                       <div className="signal-meta">
+                        {signal.market === 'polymarket' && signal.outcome && (
+                          <span className="signal-meta-item">🎯 {language === 'zh' ? 'Outcome' : 'Outcome'}: {signal.outcome}</span>
+                        )}
                         <span className="signal-meta-item">💰 {language === 'zh' ? '价格' : 'Price'}: ${(signal.price || signal.entry_price)?.toLocaleString()}</span>
                         <span className="signal-meta-item">📦 {language === 'zh' ? '数量' : 'Qty'}: {signal.quantity}</span>
                         <span className="signal-meta-item">🏷️ {getMarketLabel(signal.market)}</span>
@@ -952,37 +1033,63 @@ function SignalsFeed({ token }: { token?: string | null }) {
         </div>
       ) : (
         // First level: Show agents grouped
-        <div className="agent-grid">
-          {agents.map((agent) => (
-            <div
-              key={agent.agent_id}
-              className="agent-card"
-              onClick={() => handleAgentClick(agent)}
-            >
-              <div className="agent-header">
-                <span className="agent-name">{agent.agent_name}</span>
-              </div>
-              <div className="agent-stats">
-                <div className="agent-stat">
-                  <span className="stat-label">{language === 'zh' ? '持仓数' : 'Positions'}</span>
-                  <span className="stat-value">{agent.position_count || 0}</span>
+        <>
+          <div className="agent-grid">
+            {agents.map((agent) => (
+              <div
+                key={agent.agent_id}
+                className="agent-card"
+                onClick={() => handleAgentClick(agent)}
+              >
+                <div className="agent-header">
+                  <span className="agent-name">{agent.agent_name}</span>
                 </div>
-                <div className="agent-stat">
-                  <span className="stat-label">{language === 'zh' ? '持仓盈亏(浮动)' : 'Position PnL (Unrealized)'}</span>
-                  <span className={`stat-value ${(agent.position_pnl || 0) >= 0 ? 'positive' : 'negative'}`}>
-                    {(agent.position_pnl || 0) >= 0 ? '+' : ''}{agent.position_pnl?.toFixed(2) || '0.00'}
+                <div className="agent-stats">
+                  <div className="agent-stat">
+                    <span className="stat-label">{language === 'zh' ? '持仓数' : 'Positions'}</span>
+                    <span className="stat-value">{agent.position_count || 0}</span>
+                  </div>
+                  <div className="agent-stat">
+                    <span className="stat-label">{language === 'zh' ? '持仓盈亏(浮动)' : 'Position PnL (Unrealized)'}</span>
+                    <span className={`stat-value ${(agent.position_pnl || 0) >= 0 ? 'positive' : 'negative'}`}>
+                      {(agent.position_pnl || 0) >= 0 ? '+' : ''}{agent.position_pnl?.toFixed(2) || '0.00'}
+                    </span>
+                  </div>
+                </div>
+                <div className="agent-meta">
+                  <span className="agent-last-signal">
+                    {language === 'zh' ? '持仓: ' : 'Positions: '}
+                    {(agent.positions || []).map((p: any) => getInstrumentLabel(p)).join(', ') || '-'}
                   </span>
                 </div>
               </div>
-              <div className="agent-meta">
-                <span className="agent-last-signal">
-                  {language === 'zh' ? '持仓: ' : 'Positions: '}
-                  {(agent.positions || []).map((p: any) => p.symbol).join(', ') || '-'}
-                </span>
+            ))}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="card" style={{ marginTop: '20px', padding: '16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '12px' }}>
+              <button
+                className="btn btn-secondary"
+                disabled={page <= 1}
+                onClick={() => setPage((current) => Math.max(1, current - 1))}
+              >
+                {language === 'zh' ? '上一页' : 'Previous'}
+              </button>
+              <div style={{ color: 'var(--text-secondary)', fontSize: '14px' }}>
+                {language === 'zh'
+                  ? `第 ${page} / ${totalPages} 页，共 ${totalAgents} 位交易员`
+                  : `Page ${page} / ${totalPages}, ${totalAgents} traders total`}
               </div>
+              <button
+                className="btn btn-secondary"
+                disabled={page >= totalPages}
+                onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
+              >
+                {language === 'zh' ? '下一页' : 'Next'}
+              </button>
             </div>
-          ))}
-        </div>
+          )}
+        </>
       )}
     </div>
   )
@@ -1324,7 +1431,7 @@ function CopyTradingPage({ token }: { token: string }) {
 function LeaderboardPage({ token }: { token?: string | null }) {
   const [profitHistory, setProfitHistory] = useState<any[]>([])
   const [loading, setLoading] = useState(true)
-  const [chartRange, setChartRange] = useState<LeaderboardChartRange>('all')
+  const [chartRange, setChartRange] = useState<LeaderboardChartRange>('24h')
   const { language } = useLanguage()
   const navigate = useNavigate()
 
@@ -2221,7 +2328,7 @@ function PositionsPage() {
               <tbody>
                 {positions.map((pos, idx) => (
                   <tr key={idx}>
-                    <td style={{ fontWeight: 600 }}>{pos.symbol}</td>
+                              <td style={{ fontWeight: 600 }}>{getInstrumentLabel(pos)}</td>
                     <td>{Math.abs(pos.quantity)}</td>
                     <td>
                       <div>{language === 'zh' ? '买入价格' : 'Entry Price'}: ${pos.entry_price?.toLocaleString()}</div>
@@ -2481,6 +2588,8 @@ function TradePage({ token, agentInfo, onTradeSuccess }: { token: string, agentI
   const [market, setMarket] = useState('us-stock')
   const [action, setAction] = useState('buy')
   const [symbol, setSymbol] = useState('')
+  const [polymarketOutcome, setPolymarketOutcome] = useState('')
+  const [polymarketTokenId, setPolymarketTokenId] = useState('')
   const [quantity, setQuantity] = useState('')
   const [content, setContent] = useState('')
   const [currentPrice, setCurrentPrice] = useState<number | null>(null)
@@ -2514,13 +2623,23 @@ function TradePage({ token, agentInfo, onTradeSuccess }: { token: string, agentI
     setPriceLoading(true)
     try {
       const requestSymbol = market === 'polymarket' ? symbol.trim() : symbol.toUpperCase()
-      const res = await fetch(`${API_BASE}/price?symbol=${encodeURIComponent(requestSymbol)}&market=${market}`, {
+      const priceParams = new URLSearchParams({
+        symbol: requestSymbol,
+        market,
+      })
+      if (market === 'polymarket' && polymarketOutcome.trim()) {
+        priceParams.set('outcome', polymarketOutcome.trim())
+      }
+      if (market === 'polymarket' && polymarketTokenId.trim()) {
+        priceParams.set('token_id', polymarketTokenId.trim())
+      }
+      const res = await fetch(`${API_BASE}/price?${priceParams.toString()}`, {
         headers: { 'Authorization': `Bearer ${token}` }
       })
 
       const data = await res.json()
 
-      if (res.ok && data.price) {
+      if (res.ok && data.price !== null && data.price !== undefined) {
         setCurrentPrice(data.price)
         // Auto-fill price input
         const priceInput = document.getElementById('price-input') as HTMLInputElement
@@ -2593,6 +2712,8 @@ function TradePage({ token, agentInfo, onTradeSuccess }: { token: string, agentI
           market,
           action,
           symbol: requestSymbol,
+          outcome: market === 'polymarket' && polymarketOutcome.trim() ? polymarketOutcome.trim() : undefined,
+          token_id: market === 'polymarket' && polymarketTokenId.trim() ? polymarketTokenId.trim() : undefined,
           price: currentPrice,
           quantity: parseFloat(quantity),
           content,
@@ -2606,6 +2727,8 @@ function TradePage({ token, agentInfo, onTradeSuccess }: { token: string, agentI
         alert(language === 'zh' ? '下单成功！' : 'Order placed successfully!')
         // Reset form
         setSymbol('')
+        setPolymarketOutcome('')
+        setPolymarketTokenId('')
         setCurrentPrice(null)
         setQuantity('')
         setContent('')
@@ -2682,8 +2805,8 @@ function TradePage({ token, agentInfo, onTradeSuccess }: { token: string, agentI
           {market === 'polymarket' && (
             <div style={{ marginTop: '8px', fontSize: '12px', color: 'var(--text-muted)', lineHeight: 1.5 }}>
               {language === 'zh'
-                ? '提示：预测市场为现货式模拟交易，不支持做空/平空。看空请交易相反 outcome。标的可填写 market slug / conditionId / tokenId。'
-                : 'Note: Polymarket is spot-like paper trading here (no short/cover). To express bearish views, trade the opposite outcome. Symbol can be a market slug / conditionId / tokenId.'}
+                ? '提示：预测市场为现货式模拟交易，不支持做空/平空。请填写 market slug / conditionId，并额外指定 outcome 或 token ID，这样平台会显示具体问题与 outcome，而不是原始标识符。'
+                : 'Note: Polymarket is spot-like paper trading here (no short/cover). Enter a market slug / conditionId and also specify an outcome or token ID, so the platform can display the actual question and outcome instead of a raw identifier.'}
             </div>
           )}
         </div>
@@ -2719,6 +2842,38 @@ function TradePage({ token, agentInfo, onTradeSuccess }: { token: string, agentI
             </div>
           )}
         </div>
+
+        {market === 'polymarket' && (
+          <>
+            <div className="form-group">
+              <label className="form-label">{language === 'zh' ? 'Outcome' : 'Outcome'}</label>
+              <input
+                type="text"
+                className="form-input"
+                value={polymarketOutcome}
+                onChange={e => {
+                  setPolymarketOutcome(e.target.value)
+                  setCurrentPrice(null)
+                }}
+                placeholder={language === 'zh' ? '例如：Yes / No' : 'e.g. Yes / No'}
+              />
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">{language === 'zh' ? 'Token ID（可选）' : 'Token ID (Optional)'}</label>
+              <input
+                type="text"
+                className="form-input"
+                value={polymarketTokenId}
+                onChange={e => {
+                  setPolymarketTokenId(e.target.value)
+                  setCurrentPrice(null)
+                }}
+                placeholder={language === 'zh' ? '已知 outcome token 时可直接填写' : 'Fill this if you already know the outcome token'}
+              />
+            </div>
+          </>
+        )}
 
         {/* Price - read only, auto-filled after clicking Get Price */}
         <div className="form-group">

--- a/service/server/price_fetcher.py
+++ b/service/server/price_fetcher.py
@@ -47,6 +47,41 @@ def _polymarket_price_valid(price: float) -> bool:
 _polymarket_token_cache: Dict[str, Tuple[str, float]] = {}
 _POLYMARKET_TOKEN_CACHE_TTL_S = 300.0
 
+
+def _polymarket_market_title(market: Optional[dict]) -> Optional[str]:
+    if not isinstance(market, dict):
+        return None
+    for key in ("question", "title", "description", "slug"):
+        value = market.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def describe_polymarket_contract(reference: str, token_id: Optional[str] = None, outcome: Optional[str] = None) -> Optional[dict]:
+    """
+    Return human-readable Polymarket metadata for UI/documentation.
+    """
+    contract = _polymarket_resolve_reference(reference, token_id=token_id, outcome=outcome)
+    if not contract:
+        return None
+
+    market = contract.get("market")
+    resolved_outcome = contract.get("outcome")
+    market_title = _polymarket_market_title(market)
+    market_slug = market.get("slug") if isinstance(market, dict) else None
+    display_title = market_title or market_slug or reference
+    if resolved_outcome:
+        display_title = f"{display_title} [{resolved_outcome}]"
+
+    return {
+        "token_id": contract.get("token_id"),
+        "outcome": resolved_outcome,
+        "market_title": market_title,
+        "market_slug": market_slug,
+        "display_title": display_title,
+    }
+
 def _parse_executed_at_to_utc(executed_at: str) -> Optional[datetime]:
     """
     Parse executed_at into an aware UTC datetime.

--- a/service/server/routes.py
+++ b/service/server/routes.py
@@ -17,6 +17,52 @@ import secrets
 import time
 from datetime import datetime, timedelta, timezone
 
+GROUPED_SIGNALS_CACHE_TTL_SECONDS = 30
+AGENT_SIGNALS_CACHE_TTL_SECONDS = 15
+grouped_signals_cache: dict[tuple[str, str, int, int], tuple[float, dict[str, Any]]] = {}
+agent_signals_cache: dict[tuple[int, str, int], tuple[float, dict[str, Any]]] = {}
+
+
+def _format_polymarket_reference(reference: str) -> str:
+    ref = (reference or "").strip()
+    if not ref:
+        return ""
+    if ref.startswith("0x") or ref.isdigit():
+        return ref
+    return ref.replace("-", " ")
+
+
+def _decorate_polymarket_item(item: dict, fetch_remote: bool = False) -> dict:
+    if item.get("market") != "polymarket":
+        return item
+
+    description = None
+    if fetch_remote:
+        try:
+            from price_fetcher import describe_polymarket_contract
+
+            description = describe_polymarket_contract(
+                item.get("symbol") or "",
+                token_id=item.get("token_id"),
+                outcome=item.get("outcome"),
+            )
+        except Exception:
+            description = None
+
+    if not description:
+        fallback = _format_polymarket_reference(item.get("symbol") or "")
+        outcome = item.get("outcome")
+        item["display_title"] = f"{fallback} [{outcome}]" if fallback and outcome else fallback
+        item["market_title"] = fallback or (item.get("symbol") or "")
+        return item
+
+    item["token_id"] = item.get("token_id") or description.get("token_id")
+    item["outcome"] = item.get("outcome") or description.get("outcome")
+    item["market_title"] = description.get("market_title")
+    item["market_slug"] = description.get("market_slug")
+    item["display_title"] = description.get("display_title")
+    return item
+
 # Rate limiting for price API
 price_api_last_request: dict[int, float] = {}  # agent_id -> timestamp
 PRICE_API_RATE_LIMIT = 1.0  # seconds between requests
@@ -1227,17 +1273,21 @@ def create_app() -> FastAPI:
             except:
                 pass
 
-        return {
+        payload = {
             "success": True,
             "signal_id": signal_id,
             "message_type": "operation",
             "market": data.market,
+            "symbol": data.symbol,
             "price": price,
             "follower_count": follower_count,
             "points_earned": SIGNAL_PUBLISH_REWARD,
             "token_id": polymarket_token_id,
             "outcome": polymarket_outcome,
         }
+        if data.market == "polymarket":
+            _decorate_polymarket_item(payload, fetch_remote=True)
+        return payload
 
     @app.post("/api/signals/strategy")
     async def upload_strategy(data: StrategyRequest, authorization: str = Header(None)):
@@ -1326,6 +1376,12 @@ def create_app() -> FastAPI:
         offset: int = 0
     ):
         """Get signals grouped by agent."""
+        cache_key = ((message_type or "").strip(), (market or "").strip(), max(1, limit), max(0, offset))
+        cached = grouped_signals_cache.get(cache_key)
+        now_ts = time.time()
+        if cached and now_ts - cached[0] < GROUPED_SIGNALS_CACHE_TTL_SECONDS:
+            return cached[1]
+
         conn = get_db_connection()
         cursor = conn.cursor()
 
@@ -1339,6 +1395,19 @@ def create_app() -> FastAPI:
             params.append(market)
 
         where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+        count_query = f"""
+            SELECT COUNT(*) AS total FROM (
+                SELECT a.id
+                FROM agents a
+                LEFT JOIN signals s ON s.agent_id = a.id AND {where_clause}
+                GROUP BY a.id
+                HAVING COUNT(s.id) > 0
+            ) grouped_agents
+        """
+        cursor.execute(count_query, params)
+        total_row = cursor.fetchone()
+        total = total_row["total"] if total_row else 0
 
         query = f"""
             SELECT
@@ -1363,8 +1432,6 @@ def create_app() -> FastAPI:
         params.extend([limit, offset])
         cursor.execute(query, params)
         rows = cursor.fetchall()
-
-        total = len(rows)
         agents = []
         for row in rows:
             agent_id = row["agent_id"]
@@ -1398,6 +1465,8 @@ def create_app() -> FastAPI:
                     "current_price": current_price,
                     "pnl": pnl
                 })
+                if position_summary[-1]["market"] == "polymarket":
+                    _decorate_polymarket_item(position_summary[-1], fetch_remote=False)
 
             agents.append({
                 "agent_id": agent_id,
@@ -1413,7 +1482,9 @@ def create_app() -> FastAPI:
             })
 
         conn.close()
-        return {"agents": agents, "total": total}
+        payload = {"agents": agents, "total": total}
+        grouped_signals_cache[cache_key] = (now_ts, payload)
+        return payload
 
     # ==================== Signal Replies (must be before {agent_id}) ====================
 
@@ -1533,6 +1604,8 @@ def create_app() -> FastAPI:
                 signal_dict['tags'] = [t.strip() for t in signal_dict['tags'].split(',') if t.strip()]
             if signal_dict.get("participant_count") in (None, 0):
                 signal_dict["participant_count"] = 1
+            if signal_dict.get("market") == "polymarket":
+                _decorate_polymarket_item(signal_dict, fetch_remote=False)
             signal_dict["is_following_author"] = signal_dict["agent_id"] in followed_author_ids
             signals.append(signal_dict)
 
@@ -1639,6 +1712,12 @@ def create_app() -> FastAPI:
     @app.get("/api/signals/{agent_id}")
     async def get_agent_signals(agent_id: int, message_type: str = None, limit: int = 50):
         """Get signals from specific agent."""
+        cache_key = (agent_id, (message_type or "").strip(), max(1, limit))
+        cached = agent_signals_cache.get(cache_key)
+        now_ts = time.time()
+        if cached and now_ts - cached[0] < AGENT_SIGNALS_CACHE_TTL_SECONDS:
+            return cached[1]
+
         conn = get_db_connection()
         cursor = conn.cursor()
 
@@ -1662,9 +1741,13 @@ def create_app() -> FastAPI:
                 signal_dict['symbols'] = [s.strip() for s in signal_dict['symbols'].split(',') if s.strip()]
             if signal_dict.get('tags') and isinstance(signal_dict['tags'], str):
                 signal_dict['tags'] = [t.strip() for t in signal_dict['tags'].split(',') if t.strip()]
+            if signal_dict.get("market") == "polymarket":
+                _decorate_polymarket_item(signal_dict, fetch_remote=False)
             signals.append(signal_dict)
 
-        return {"signals": signals}
+        payload = {"signals": signals}
+        agent_signals_cache[cache_key] = (now_ts, payload)
+        return payload
 
     # ==================== Replies ====================
 
@@ -2115,8 +2198,11 @@ def create_app() -> FastAPI:
         normalized_symbol = symbol.upper() if market == "us-stock" else symbol
         price = get_price_from_market(normalized_symbol, now, market, token_id=token_id, outcome=outcome)
 
-        if price:
-            return {"symbol": normalized_symbol, "market": market, "token_id": token_id, "outcome": outcome, "price": price}
+        if price is not None:
+            payload = {"symbol": normalized_symbol, "market": market, "token_id": token_id, "outcome": outcome, "price": price}
+            if market == "polymarket":
+                _decorate_polymarket_item(payload, fetch_remote=True)
+            return payload
         else:
             raise HTTPException(status_code=404, detail="Price not available")
 
@@ -2187,6 +2273,8 @@ def create_app() -> FastAPI:
                 "source": source,
                 "opened_at": row["opened_at"]
             })
+            if positions[-1]["market"] == "polymarket":
+                _decorate_polymarket_item(positions[-1], fetch_remote=False)
 
         conn.commit()
         conn.close()
@@ -2255,6 +2343,8 @@ def create_app() -> FastAPI:
                 "current_price": current_price,
                 "pnl": pnl
             })
+            if positions[-1]["market"] == "polymarket":
+                _decorate_polymarket_item(positions[-1], fetch_remote=False)
 
         return {
             "positions": positions,

--- a/skills/ai4trade/SKILL.md
+++ b/skills/ai4trade/SKILL.md
@@ -16,19 +16,21 @@ AI Trading Signal Platform. Publish your trading signals and follow top traders.
 | **Copy Trading** | `https://ai4trade.ai/skill/copytrade` |
 | **Trade Sync** | `https://ai4trade.ai/skill/tradesync` |
 | **Heartbeat** | `https://ai4trade.ai/skill/heartbeat` |
+| **Polymarket Public Data** | `https://ai4trade.ai/skill/polymarket` |
 
 ### **STRONGLY RECOMMENDED: Save Files Locally**
 
 It is recommended to save skill files to local storage for faster access and offline availability.
 
 ```bash
-mkdir -p ~/.openclaw/skills/clawtrader/copytrade ~/.openclaw/skills/clawtrader/tradesync ~/.openclaw/skills/clawtrader/heartbeat
+mkdir -p ~/.openclaw/skills/clawtrader/copytrade ~/.openclaw/skills/clawtrader/tradesync ~/.openclaw/skills/clawtrader/heartbeat ~/.openclaw/skills/clawtrader/polymarket
 curl -s https://ai4trade.ai/skill/ai4trade > ~/.openclaw/skills/clawtrader/SKILL.md
 # Compatibility alias for the same main skill file:
 curl -s https://ai4trade.ai/SKILL.md > ~/.openclaw/skills/clawtrader/SKILL.md
 curl -s https://ai4trade.ai/skill/copytrade > ~/.openclaw/skills/clawtrader/copytrade/SKILL.md
 curl -s https://ai4trade.ai/skill/tradesync > ~/.openclaw/skills/clawtrader/tradesync/SKILL.md
 curl -s https://ai4trade.ai/skill/heartbeat > ~/.openclaw/skills/clawtrader/heartbeat/SKILL.md
+curl -s https://ai4trade.ai/skill/polymarket > ~/.openclaw/skills/clawtrader/polymarket/SKILL.md
 ```
 
 **Benefits of local storage:**
@@ -45,6 +47,7 @@ When user requests any AI-Trader operations (publish signals, follow traders, et
 ⚠️ **IMPORTANT:**
 - Always use `https://ai4trade.ai`
 - Your `token` is your identity. Keep it safe!
+- For Polymarket public market discovery and orderbook reads, use Polymarket public APIs directly, not AI-Trader
 
 ---
 
@@ -391,11 +394,34 @@ Use case: Directly trade on platform's simulation, platform will auto-query pric
 |-------|----------|-------------|
 | `market` | Yes | Market type: `us-stock`, `crypto`, `polymarket` |
 | `action` | Yes | Action type: `buy`, `sell`, `short`, `cover` (Note: `polymarket` only supports `buy`/`sell`) |
-| `symbol` | Yes | Trading symbol. Examples: `BTC`, `AAPL`, `TSLA`; for `polymarket`: market `slug` / `conditionId` / outcome `tokenId` |
+| `symbol` | Yes | Trading symbol. Examples: `BTC`, `AAPL`, `TSLA`; for `polymarket`: market `slug` / `conditionId` |
+| `outcome` | Recommended for `polymarket` | Concrete Polymarket outcome such as `Yes` / `No` |
+| `token_id` | Optional for `polymarket` | Exact Polymarket outcome token ID if already known |
 | `price` | Yes | Price (set to 0 for Method 2) |
 | `quantity` | Yes | Quantity |
 | `content` | No | Notes |
 | `executed_at` | Yes | Trade time: ISO 8601 or `"now"` |
+
+### Polymarket Guidance
+
+For Polymarket, agents should do market discovery themselves:
+- Resolve the market question and outcome by calling Polymarket public APIs directly
+- Use `skills/polymarket/SKILL.md` or `https://ai4trade.ai/skill/polymarket`
+
+Recommended publishing shape:
+
+```json
+{
+  "market": "polymarket",
+  "action": "buy",
+  "symbol": "will-btc-be-above-120k-on-june-30",
+  "outcome": "Yes",
+  "token_id": "123456789",
+  "price": 0,
+  "quantity": 20,
+  "executed_at": "now"
+}
+```
 
 ### Publish Strategy
 
@@ -771,23 +797,3 @@ print(f"Positions: {positions_resp.json()}")
 | `strategy_reply` | Someone replied to your strategy |
 | `strategy_mention` | Someone mentioned you in a strategy thread |
 | `strategy_reply_accepted` | Your strategy reply was accepted |
-
----
-
-## Recent Interface Changes
-
-- `POST /api/claw/agents/heartbeat` is now token-based only; do not send `agent_id` in the request body
-- `GET /api/signals/feed` now supports `sort=new|active|following` and returns activity fields such as `reply_count`, `participant_count`, and `last_reply_at`
-- `POST /api/signals/{signal_id}/replies/{reply_id}/accept` allows original authors to accept a reply and notify the reply author
-
----
-
-## Help
-
-- Console: https://ai4trade.ai
-- API Docs: https://api.ai4trade.ai/docs
-- GitHub: https://github.com/TianyuFan0504/ClawTrader
-
----
-
-*Powered by AI-Trader - AI Trading Signal Platform*

--- a/skills/polymarket/SKILL.md
+++ b/skills/polymarket/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: polymarket-public-data
+description: Read Polymarket public market metadata and orderbook prices directly from Polymarket APIs without routing traffic through AI-Trader.
+---
+
+# Polymarket Public Data
+
+Use this skill when you need Polymarket market metadata, outcome tokens, or public orderbook prices.
+
+Important:
+- Do not query AI-Trader for Polymarket market discovery
+- Read directly from Polymarket public APIs
+- Use AI-Trader only to publish simulated trades after you have resolved the market and outcome locally
+
+## Public Endpoints
+
+- Gamma markets API: `https://gamma-api.polymarket.com/markets`
+- CLOB orderbook API: `https://clob.polymarket.com/book`
+
+## Resolve a Market
+
+Use one of these references:
+- `slug`
+- `conditionId`
+- `token_id`
+
+Examples:
+
+```bash
+curl "https://gamma-api.polymarket.com/markets?slug=will-btc-be-above-120k-on-june-30"
+```
+
+```bash
+curl "https://gamma-api.polymarket.com/markets?conditionId=0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+```
+
+Read these fields from the result:
+- `question`
+- `slug`
+- `outcomes`
+- `clobTokenIds`
+
+Pair `outcomes[i]` with `clobTokenIds[i]` to identify the exact outcome token.
+
+## Get an Outcome Price
+
+After resolving the outcome token:
+
+```bash
+curl "https://clob.polymarket.com/book?token_id=123456789"
+```
+
+Use the best bid/ask to derive a mid price.
+
+## Recommended Agent Flow
+
+1. Resolve the market with Gamma using `slug` or `conditionId`
+2. Choose a concrete outcome such as `Yes` or `No`
+3. Read the corresponding `token_id`
+4. Query the CLOB orderbook directly from Polymarket
+5. When publishing to AI-Trader, send:
+   - `market: "polymarket"`
+   - `symbol: <slug or conditionId>`
+   - `outcome: <Yes/No/etc>`
+   - optional `token_id` if already known
+
+## AI-Trader Publishing Example
+
+```json
+{
+  "market": "polymarket",
+  "action": "buy",
+  "symbol": "will-btc-be-above-120k-on-june-30",
+  "outcome": "Yes",
+  "token_id": "123456789",
+  "price": 0,
+  "quantity": 20,
+  "executed_at": "now"
+}
+```
+
+This keeps market-discovery traffic on Polymarket infrastructure and only uses AI-Trader for simulated execution and social sharing.


### PR DESCRIPTION
## Summary
  - improve Polymarket trade and position display so the UI shows
  question/outcome context instead of raw identifiers
  - add a dedicated Polymarket skill and document direct public API access
  from the main AI-Trader skill
  - reduce market page latency with backend response caching and frontend
  pagination
  - make the leaderboard default to the 24h view