### PR TITLE
feat: add MiniMax provider support for stock analysis summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,15 @@ DB_PATH=service/server/data/clawtrader.db
 # ==================== API Keys ====================
 ALPHA_VANTAGE_API_KEY=demo
 
+# ==================== MiniMax AI (for stock analysis summaries) ====================
+# MINIMAX_API_KEY=your_minimax_api_key_here
+# MINIMAX_BASE_URL=https://api.minimax.io/v1
+# MINIMAX_MODEL=MiniMax-M2.7
+
+# ==================== OpenRouter AI (alternative for stock analysis summaries) ====================
+# OPENROUTER_API_KEY=your_openrouter_api_key_here
+# OPENROUTER_MODEL=openai/gpt-4o-mini
+
 
 # ==================== Frontend ====================
 # Frontend auto-refresh interval in milliseconds.

--- a/service/server/market_intel.py
+++ b/service/server/market_intel.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
@@ -28,6 +29,9 @@ from database import get_db_connection
 ALPHA_VANTAGE_BASE_URL = os.getenv("ALPHA_VANTAGE_BASE_URL", "https://www.alphavantage.co/query").strip()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "").strip()
 OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "").strip()
+MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY", "").strip()
+MINIMAX_BASE_URL = os.getenv("MINIMAX_BASE_URL", "https://api.minimax.io/v1").strip()
+MINIMAX_MODEL = os.getenv("MINIMAX_MODEL", "MiniMax-M2.7").strip()
 MARKET_NEWS_LOOKBACK_HOURS = int(os.getenv("MARKET_NEWS_LOOKBACK_HOURS", "48"))
 MARKET_NEWS_CATEGORY_LIMIT = int(os.getenv("MARKET_NEWS_CATEGORY_LIMIT", "12"))
 MARKET_NEWS_HISTORY_PER_CATEGORY = int(os.getenv("MARKET_NEWS_HISTORY_PER_CATEGORY", "96"))
@@ -132,6 +136,37 @@ def _alpha_vantage_get(params: dict[str, Any]) -> dict[str, Any]:
         if error_message:
             raise RuntimeError(str(error_message))
     return payload
+
+
+def _call_minimax(prompt: str) -> Optional[str]:
+    """Generate text using MiniMax via OpenAI-compatible API."""
+    if not MINIMAX_API_KEY:
+        return None
+    try:
+        response = requests.post(
+            f"{MINIMAX_BASE_URL}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {MINIMAX_API_KEY}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": MINIMAX_MODEL,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": 500,
+                "temperature": 1.0,
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        content = data["choices"][0]["message"]["content"]
+        if not isinstance(content, str):
+            return None
+        # Strip chain-of-thought reasoning tags if present
+        content = re.sub(r"<think>.*?</think>", "", content, flags=re.DOTALL).strip()
+        return content if content else None
+    except Exception:
+        return None
 
 
 def _extract_openrouter_text(response: Any) -> str:
@@ -246,8 +281,6 @@ def _build_stock_analysis_fallback_summary(analysis: dict[str, Any]) -> str:
 
 def _generate_stock_analysis_summary(analysis: dict[str, Any]) -> str:
     fallback_summary = _build_stock_analysis_fallback_summary(analysis)
-    if not OPENROUTER_API_KEY or not OPENROUTER_MODEL or OpenRouter is None:
-        return fallback_summary
 
     prompt = (
         "Write one concise market snapshot paragraph in English for a trading dashboard.\n"
@@ -270,6 +303,15 @@ def _generate_stock_analysis_summary(analysis: dict[str, Any]) -> str:
         f"Bullish factors: {json.dumps(analysis.get('bullish_factors') or [], ensure_ascii=True)}\n"
         f"Risk factors: {json.dumps(analysis.get('risk_factors') or [], ensure_ascii=True)}\n"
     )
+
+    # Try MiniMax first (OpenAI-compatible API)
+    minimax_result = _call_minimax(prompt)
+    if minimax_result:
+        return minimax_result[:500].strip()
+
+    # Fall back to OpenRouter
+    if not OPENROUTER_API_KEY or not OPENROUTER_MODEL or OpenRouter is None:
+        return fallback_summary
 
     try:
         with OpenRouter(api_key=OPENROUTER_API_KEY) as client:

--- a/service/server/tests/test_minimax_provider.py
+++ b/service/server/tests/test_minimax_provider.py
@@ -1,0 +1,264 @@
+"""
+Unit tests for MiniMax provider integration in market_intel.py.
+"""
+
+import json
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+# Add server directory to path so we can import market_intel without a full Django setup
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestCallMinimax(unittest.TestCase):
+    """Tests for _call_minimax function."""
+
+    def _import_call_minimax(self):
+        """Import _call_minimax with mocked dependencies."""
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import importlib
+            import market_intel
+            importlib.reload(market_intel)
+            return market_intel._call_minimax
+
+    def test_returns_none_when_no_api_key(self):
+        """Should return None immediately if MINIMAX_API_KEY is not set."""
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import importlib
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", ""):
+                result = market_intel._call_minimax("test prompt")
+            self.assertIsNone(result)
+
+    def test_calls_minimax_api_and_returns_content(self):
+        """Should call MiniMax API and return message content."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "NVDA looks bullish with strong momentum."}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import importlib
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", "test-key"), \
+                 patch.object(market_intel, "MINIMAX_BASE_URL", "https://api.minimax.io/v1"), \
+                 patch.object(market_intel, "MINIMAX_MODEL", "MiniMax-M2.7"), \
+                 patch("market_intel.requests.post", return_value=mock_response) as mock_post:
+                result = market_intel._call_minimax("Analyze NVDA")
+
+            mock_post.assert_called_once()
+            call_args = mock_post.call_args
+            # Verify URL
+            self.assertIn("https://api.minimax.io/v1/chat/completions", str(call_args))
+            # Verify headers contain Authorization
+            kwargs = call_args[1] if call_args[1] else {}
+            headers = kwargs.get("headers", {})
+            self.assertIn("Bearer test-key", headers.get("Authorization", ""))
+            # Verify request body
+            body = kwargs.get("json", {})
+            self.assertEqual(body["model"], "MiniMax-M2.7")
+            self.assertEqual(body["temperature"], 1.0)
+            self.assertNotIn("response_format", body)
+            # Verify result
+            self.assertEqual(result, "NVDA looks bullish with strong momentum.")
+
+    def test_uses_default_model_minimax_m2_7(self):
+        """Default model should be MiniMax-M2.7."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Test summary."}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import importlib
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", "test-key"), \
+                 patch.object(market_intel, "MINIMAX_MODEL", "MiniMax-M2.7"), \
+                 patch("market_intel.requests.post", return_value=mock_response) as mock_post:
+                market_intel._call_minimax("prompt")
+
+            body = mock_post.call_args[1]["json"]
+            self.assertEqual(body["model"], "MiniMax-M2.7")
+
+    def test_returns_none_on_api_error(self):
+        """Should return None when API call raises an exception."""
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", "test-key"), \
+                 patch("market_intel.requests.post", side_effect=Exception("Connection error")):
+                result = market_intel._call_minimax("test prompt")
+            self.assertIsNone(result)
+
+    def test_uses_default_base_url(self):
+        """Default base URL should be https://api.minimax.io/v1."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "Summary."}}]
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", "test-key"), \
+                 patch.object(market_intel, "MINIMAX_BASE_URL", "https://api.minimax.io/v1"), \
+                 patch("market_intel.requests.post", return_value=mock_response) as mock_post:
+                market_intel._call_minimax("prompt")
+
+            url = mock_post.call_args[0][0]
+            self.assertTrue(url.startswith("https://api.minimax.io/v1"))
+
+
+class TestGenerateStockAnalysisSummaryWithMinimax(unittest.TestCase):
+    """Tests for _generate_stock_analysis_summary with MiniMax priority."""
+
+    SAMPLE_ANALYSIS = {
+        "symbol": "NVDA",
+        "signal": "buy",
+        "trend_status": "bullish",
+        "signal_score": 3.5,
+        "current_price": 850.0,
+        "return_5d_pct": 3.2,
+        "return_20d_pct": 8.5,
+        "moving_averages": {"ma5": 840.0, "ma10": 830.0, "ma20": 800.0, "ma60": 750.0},
+        "support_levels": [820.0],
+        "resistance_levels": [900.0],
+        "bullish_factors": ["Price is above the 20-day moving average."],
+        "risk_factors": ["Price is approaching the recent resistance zone."],
+    }
+
+    def test_minimax_takes_priority_over_openrouter(self):
+        """MiniMax should be tried before OpenRouter."""
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", "minimax-key"), \
+                 patch.object(market_intel, "OPENROUTER_API_KEY", "openrouter-key"), \
+                 patch.object(market_intel, "OPENROUTER_MODEL", "some-model"), \
+                 patch.object(market_intel, "_call_minimax", return_value="MiniMax summary.") as mock_mm, \
+                 patch.object(market_intel, "_extract_openrouter_text") as mock_or:
+                result = market_intel._generate_stock_analysis_summary(self.SAMPLE_ANALYSIS)
+
+            mock_mm.assert_called_once()
+            mock_or.assert_not_called()
+            self.assertEqual(result, "MiniMax summary.")
+
+    def test_falls_back_to_openrouter_when_minimax_fails(self):
+        """Should fall back to OpenRouter when MiniMax returns None."""
+        mock_openrouter = MagicMock()
+        mock_openrouter.__enter__ = MagicMock(return_value=mock_openrouter)
+        mock_openrouter.__exit__ = MagicMock(return_value=False)
+
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(OpenRouter=MagicMock(return_value=mock_openrouter)),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", "minimax-key"), \
+                 patch.object(market_intel, "OPENROUTER_API_KEY", "openrouter-key"), \
+                 patch.object(market_intel, "OPENROUTER_MODEL", "gpt-4o-mini"), \
+                 patch.object(market_intel, "_call_minimax", return_value=None), \
+                 patch.object(market_intel, "_extract_openrouter_text", return_value="OpenRouter summary."):
+                result = market_intel._generate_stock_analysis_summary(self.SAMPLE_ANALYSIS)
+
+            self.assertEqual(result, "OpenRouter summary.")
+
+    def test_falls_back_to_rule_based_when_both_fail(self):
+        """Should fall back to deterministic summary when both MiniMax and OpenRouter fail."""
+        with patch.dict("sys.modules", {
+            "openrouter": MagicMock(),
+            "database": MagicMock(),
+            "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+        }):
+            import market_intel
+            with patch.object(market_intel, "MINIMAX_API_KEY", ""), \
+                 patch.object(market_intel, "OPENROUTER_API_KEY", ""), \
+                 patch.object(market_intel, "OPENROUTER_MODEL", ""):
+                result = market_intel._generate_stock_analysis_summary(self.SAMPLE_ANALYSIS)
+
+            self.assertIsInstance(result, str)
+            self.assertGreater(len(result), 0)
+            self.assertIn("NVDA", result)
+
+
+class TestMinimaxEnvironmentVariables(unittest.TestCase):
+    """Tests to verify MINIMAX_API_KEY environment variable is read correctly."""
+
+    def test_minimax_api_key_env_var(self):
+        """MINIMAX_API_KEY should be loaded from environment."""
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-test-key"}, clear=False):
+            with patch.dict("sys.modules", {
+                "openrouter": MagicMock(),
+                "database": MagicMock(),
+                "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+            }):
+                import importlib
+                import market_intel
+                importlib.reload(market_intel)
+                self.assertEqual(market_intel.MINIMAX_API_KEY, "env-test-key")
+
+    def test_minimax_model_defaults_to_m2_7(self):
+        """Default MINIMAX_MODEL should be MiniMax-M2.7."""
+        env = {k: v for k, v in os.environ.items() if k != "MINIMAX_MODEL"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.dict("sys.modules", {
+                "openrouter": MagicMock(),
+                "database": MagicMock(),
+                "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+            }):
+                import importlib
+                import market_intel
+                importlib.reload(market_intel)
+                self.assertEqual(market_intel.MINIMAX_MODEL, "MiniMax-M2.7")
+
+    def test_minimax_base_url_defaults_to_api_minimax_io(self):
+        """Default MINIMAX_BASE_URL should use api.minimax.io."""
+        env = {k: v for k, v in os.environ.items() if k != "MINIMAX_BASE_URL"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch.dict("sys.modules", {
+                "openrouter": MagicMock(),
+                "database": MagicMock(),
+                "config": MagicMock(ALPHA_VANTAGE_API_KEY="demo"),
+            }):
+                import importlib
+                import market_intel
+                importlib.reload(market_intel)
+                self.assertTrue(
+                    market_intel.MINIMAX_BASE_URL.startswith("https://api.minimax.io"),
+                    f"Expected URL to start with https://api.minimax.io, got {market_intel.MINIMAX_BASE_URL}"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add MiniMax chat model support (`MiniMax-M2.7`) via OpenAI-compatible API for AI-generated stock analysis summaries
- MiniMax is tried first when `MINIMAX_API_KEY` is set; falls back to OpenRouter if unavailable
- Strip chain-of-thought `<think>` tags from model responses automatically
- Add `MINIMAX_API_KEY`, `MINIMAX_BASE_URL` (default: `https://api.minimax.io/v1`), and `MINIMAX_MODEL` (default: `MiniMax-M2.7`) environment variables to `.env.example`
- Add unit tests (`service/server/tests/test_minimax_provider.py`) covering API calls, fallback behavior, and environment variable defaults

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Test plan

- [x] Unit tests: 11 tests pass (`python -m pytest service/server/tests/test_minimax_provider.py -v`)
- [x] Integration test: MiniMax API responds correctly with `MiniMax-M2.7` model
- [x] Fallback behavior: falls back to OpenRouter when `MINIMAX_API_KEY` is not set
- [x] Fallback behavior: falls back to rule-based summary when neither provider is configured