### PR TITLE
fix: use DST-aware timezone for US stock price lookups (fixes winter 1-hour offset error)

### DIFF
--- a/service/server/price_fetcher.py
+++ b/service/server/price_fetcher.py
@@ -13,6 +13,11 @@ from typing import Optional, Dict, Tuple, Any
 import re
 import time
 import json
+try:
+    from zoneinfo import ZoneInfo
+    _ET_ZONEINFO = ZoneInfo("America/New_York")
+except ImportError:
+    _ET_ZONEINFO = None  # Python < 3.9 fallback: use fixed offset below
 
 # Alpha Vantage API configuration
 ALPHA_VANTAGE_API_KEY = os.environ.get("ALPHA_VANTAGE_API_KEY", "demo")
@@ -32,8 +37,11 @@ PRICE_FETCH_RATE_LIMIT_COOLDOWN_SECONDS = max(0.0, float(os.environ.get("PRICE_F
 
 # 时区常量
 UTC = timezone.utc
-ET_OFFSET = timedelta(hours=-4)  # EDT is UTC-4
-ET_TZ = timezone(ET_OFFSET)
+# ET_TZ resolves to America/New_York (DST-aware) when zoneinfo is available.
+# Falling back to a fixed UTC-5 (EST) offset is conservative — it will be 1 hour
+# off during EDT (summer) but at least correct during the longer EST winter period.
+# The zoneinfo path is always preferred and available on Python 3.9+.
+ET_TZ = _ET_ZONEINFO if _ET_ZONEINFO is not None else timezone(timedelta(hours=-5))
 
 _POLYMARKET_CONDITION_ID_RE = re.compile(r"^0x[a-fA-F0-9]{64}$")
 _POLYMARKET_TOKEN_ID_RE = re.compile(r"^\d+$")


### PR DESCRIPTION
## Bug

`price_fetcher.py` hardcodes the US Eastern timezone as `UTC-4` (EDT, summer):

```python
ET_OFFSET = timedelta(hours=-4)  # EDT is UTC-4
ET_TZ = timezone(ET_OFFSET)
```

US Eastern time is actually **UTC-5 during winter (EST)** and UTC-4 during summer (EDT). The switch happens:
- EDT → EST: first Sunday of November (~5 months of the year)
- EST → EDT: second Sunday of March (~7 months of the year)

**Impact:** `_get_us_stock_price()` converts `executed_at` to Eastern time, then compares against Alpha Vantage's ET-labelled candle timestamps. During EST months (November – mid-March), every timestamp comparison is off by 1 hour — the function either misses an exact match or picks up the "closest previous" price from **the wrong candle**, silently returning an incorrect fill price for all US stock trades.

For an AI trading system that back-tests or records real trades, this introduces a systematic 1-hour price error for nearly half the calendar year.

## Fix

Use `zoneinfo.ZoneInfo("America/New_York")` from the Python 3.9+ stdlib for proper DST-aware conversion. Fall back to a fixed `UTC-5` (EST) offset on Python < 3.9 — conservative but at least correct for the majority of the year.

```python
try:
    from zoneinfo import ZoneInfo
    _ET_ZONEINFO = ZoneInfo("America/New_York")
except ImportError:
    _ET_ZONEINFO = None  # Python < 3.9 fallback

ET_TZ = _ET_ZONEINFO if _ET_ZONEINFO is not None else timezone(timedelta(hours=-5))
```

No new dependencies required — `zoneinfo` is in the standard library.

## Test plan

- [ ] Trade executed in EST period (e.g. `2025-01-15T14:30:00Z`): converts to `09:30 ET` (correct, not `10:30 ET`)
- [ ] Trade executed in EDT period (e.g. `2025-07-15T14:30:00Z`): converts to `10:30 ET` (unchanged)
- [ ] DST transition edge case: `2025-03-09T06:30:00Z` → `02:30 ET` (just after spring-forward)