### PR TITLE
Guard crypto and Polymarket trades with server pricing

### DIFF
--- a/service/server/routes_shared.py
+++ b/service/server/routes_shared.py
@@ -40,6 +40,12 @@ MENTION_PATTERN = re.compile(r'@([A-Za-z0-9_\-]{2,64})')
 def allow_sync_price_fetch_in_api() -> bool:
     return os.getenv('ALLOW_SYNC_PRICE_FETCH_IN_API', 'false').strip().lower() in {'1', 'true', 'yes', 'on'}
 
+def should_fetch_server_trade_price(market: str) -> bool:
+    normalized_market = (market or '').strip().lower()
+    if normalized_market in {'crypto', 'polymarket'}:
+        return True
+    return allow_sync_price_fetch_in_api()
+
 
 @dataclass
 class RouteContext:

--- a/service/server/routes_signals.py
+++ b/service/server/routes_signals.py
@@ -21,7 +21,6 @@ from routes_shared import (
     GROUPED_SIGNALS_CACHE_KEY_PREFIX,
     GROUPED_SIGNALS_CACHE_TTL_SECONDS,
     RouteContext,
-    allow_sync_price_fetch_in_api,
     decorate_polymarket_item,
     enforce_content_rate_limit,
     extract_mentions,
@@ -31,6 +30,7 @@ from routes_shared import (
     is_market_open,
     notify_followers_of_post,
     push_agent_message,
+    should_fetch_server_trade_price,
     utc_now_iso_z,
     validate_executed_at,
 )
@@ -50,7 +50,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
         now = utc_now_iso_z()
         side = data.action
         action_lower = side.lower()
-        fetch_price_in_request = allow_sync_price_fetch_in_api()
+        fetch_price_in_request = should_fetch_server_trade_price(data.market)
         polymarket_token_id = None
         polymarket_outcome = None
 

--- a/service/server/tests/test_routes_shared.py
+++ b/service/server/tests/test_routes_shared.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from routes_shared import should_fetch_server_trade_price
+
+
+class TradePriceSourceTests(unittest.TestCase):
+    def test_crypto_and_polymarket_always_use_server_prices(self) -> None:
+        with patch.dict(os.environ, {'ALLOW_SYNC_PRICE_FETCH_IN_API': 'false'}, clear=False):
+            self.assertTrue(should_fetch_server_trade_price('crypto'))
+            self.assertTrue(should_fetch_server_trade_price('polymarket'))
+            self.assertFalse(should_fetch_server_trade_price('us-stock'))
+
+    def test_env_flag_keeps_server_fetch_for_other_markets(self) -> None:
+        with patch.dict(os.environ, {'ALLOW_SYNC_PRICE_FETCH_IN_API': 'true'}, clear=False):
+            self.assertTrue(should_fetch_server_trade_price('us-stock'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- force crypto and Polymarket realtime trades to use server-side pricing even when sync price fetching is disabled for other markets
- keep the existing environment-flag behavior for other markets
- add a regression test for the market-specific trade-pricing guard

## Testing
- python3 -m unittest service/server/tests/test_routes_shared.py service/server/tests/test_services.py
- python3 -m py_compile service/server/routes_shared.py service/server/routes_signals.py service/server/tests/test_routes_shared.py