### PR TITLE
Add competition challenge system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ CLAUDE.md
 /service/server/data/
 /TODO
 change.md
+
+# Local agent config symlink
+.codex

--- a/service/frontend/src/App.tsx
+++ b/service/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import {
   DiscussionsPage,
   LeaderboardPage,
 } from './AppPages'
+import { ChallengePage } from './ChallengePage'
 import { Language, getT } from './i18n'
 
 
@@ -220,6 +221,8 @@ function AppRouter({
           <Routes>
             <Route path="/market" element={<SignalsFeed token={token} />} />
             <Route path="/leaderboard" element={<LeaderboardPage token={token} />} />
+            <Route path="/challenges" element={<ChallengePage token={token} />} />
+            <Route path="/challenges/:challengeKey" element={<ChallengePage token={token} />} />
             <Route path="/financial-events" element={<FinancialEventsPage />} />
             <Route path="/copytrading" element={token ? <CopyTradingPage token={token} /> : <Navigate to="/login" replace />} />
             <Route path="/strategies" element={<StrategiesPage />} />

--- a/service/frontend/src/AppPages.tsx
+++ b/service/frontend/src/AppPages.tsx
@@ -1715,6 +1715,7 @@ export function CopyTradingPage({ token }: { token: string }) {
 
   const providerTotalPages = Math.max(1, Math.ceil(providerTotal / COPY_TRADING_PAGE_SIZE))
   const followingTotalPages = Math.max(1, Math.ceil(followingTotal / COPY_TRADING_PAGE_SIZE))
+  const formatReturnPercent = (value: any) => `${Number(value || 0).toFixed(2)}%`
 
   if (loading) {
     return <div className="loading"><div className="spinner"></div></div>
@@ -1803,9 +1804,12 @@ export function CopyTradingPage({ token }: { token: string }) {
 
                   <div style={{ display: 'flex', gap: '24px', flexWrap: 'wrap', marginTop: '14px', marginBottom: '10px' }}>
                     <div>
-                      <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{language === 'zh' ? '累计收益' : 'Total Profit'}</div>
-                      <div style={{ fontWeight: 700, color: (provider.total_profit || 0) >= 0 ? '#22c55e' : '#ef4444' }}>
-                        ${(provider.total_profit || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      <div style={{ fontSize: '12px', color: 'var(--text-muted)' }}>{language === 'zh' ? '收益率' : 'Return'}</div>
+                      <div style={{ fontWeight: 700, color: (provider.total_profit_percent || 0) >= 0 ? '#22c55e' : '#ef4444' }}>
+                        {formatReturnPercent(provider.total_profit_percent)}
+                        <span style={{ color: 'var(--text-muted)', marginLeft: '6px', fontSize: '12px', fontWeight: 500 }}>
+                          ${(provider.total_profit || 0).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+                        </span>
                       </div>
                     </div>
                     <div>
@@ -1916,10 +1920,10 @@ export function CopyTradingPage({ token }: { token: string }) {
                     <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
                       {provider && (
                         <span style={{
-                          color: (provider.total_profit || 0) >= 0 ? '#22c55e' : '#ef4444',
+                          color: (provider.total_profit_percent || 0) >= 0 ? '#22c55e' : '#ef4444',
                           fontWeight: 600
                         }}>
-                          ${(provider.total_profit || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                          {formatReturnPercent(provider.total_profit_percent)}
                         </span>
                       )}
                       <button
@@ -1986,6 +1990,7 @@ export function LeaderboardPage({ token }: { token?: string | null }) {
   const [leaderboardPage, setLeaderboardPage] = useState(1)
   const [loading, setLoading] = useState(true)
   const [chartRange, setChartRange] = useState<LeaderboardChartRange>('24h')
+  const [activeChallengeCount, setActiveChallengeCount] = useState(0)
   const { language } = useLanguage()
   const navigate = useNavigate()
 
@@ -1996,6 +2001,21 @@ export function LeaderboardPage({ token }: { token?: string | null }) {
     }, REFRESH_INTERVAL)
     return () => clearInterval(interval)
   }, [chartRange, leaderboardPage])
+
+  useEffect(() => {
+    const loadActiveChallengeCount = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/challenges?status=active&limit=1`)
+        if (!res.ok) return
+        const data = await res.json()
+        setActiveChallengeCount(data.total || 0)
+      } catch (e) {
+        console.error(e)
+      }
+    }
+
+    loadActiveChallengeCount()
+  }, [])
 
   const loadProfitHistory = async (pageToLoad = leaderboardPage) => {
     try {
@@ -2022,6 +2042,7 @@ export function LeaderboardPage({ token }: { token?: string | null }) {
   const topChartAgents = useMemo(() => profitHistory.slice(0, 10), [profitHistory])
   const leaderboardTotalPages = Math.max(1, Math.ceil(totalTraders / LEADERBOARD_PAGE_SIZE))
   const leaderboardOffset = (leaderboardPage - 1) * LEADERBOARD_PAGE_SIZE
+  const formatReturnPercent = (value: any) => `${Number(value || 0).toFixed(2)}%`
 
   if (loading) {
     return <div className="loading"><div className="spinner"></div></div>
@@ -2034,7 +2055,7 @@ export function LeaderboardPage({ token }: { token?: string | null }) {
           <h1 className="header-title">{language === 'zh' ? '🏆 交易员排行榜' : '🏆 Top Traders'}</h1>
 
           <p className="header-subtitle">
-            {language === 'zh' ? '按累计收益排序（包含已实现和浮动盈亏）' : 'Ranked by cumulative profit (realized + unrealized)'}
+            {language === 'zh' ? '按收益率排序（已实现和浮动盈亏 / 初始本金与兑换本金）' : 'Ranked by return rate (realized + unrealized PnL / capital base)'}
           </p>
         </div>
       </div>
@@ -2052,12 +2073,26 @@ export function LeaderboardPage({ token }: { token?: string | null }) {
         </div>
       )}
 
+      {activeChallengeCount > 0 && (
+        <div className="card" style={{ marginBottom: '20px', padding: '16px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: '12px', flexWrap: 'wrap' }}>
+          <div>
+            <span className="challenge-badge">{language === 'zh' ? 'Challenge active' : 'Challenge active'}</span>
+            <span style={{ marginLeft: '10px', color: 'var(--text-secondary)', fontSize: '14px' }}>
+              {language === 'zh' ? `${activeChallengeCount} 个挑战正在计分` : `${activeChallengeCount} challenge leaderboards are scoring`}
+            </span>
+          </div>
+          <button className="btn btn-ghost" onClick={() => navigate('/challenges')}>
+            {language === 'zh' ? '打开挑战赛' : 'Open challenges'}
+          </button>
+        </div>
+      )}
+
       {/* Profit Chart */}
       {chartData.length > 0 && (
         <div className="card" style={{ marginBottom: '20px', padding: '16px' }}>
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px', flexWrap: 'wrap', gap: '12px' }}>
             <h3 style={{ fontSize: '16px', margin: 0 }}>
-              {language === 'zh' ? '收益曲线' : 'Profit Chart'}
+              {language === 'zh' ? '收益率曲线' : 'Return Chart'}
             </h3>
             <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
               <button
@@ -2105,7 +2140,7 @@ export function LeaderboardPage({ token }: { token?: string | null }) {
                 >
                   <CartesianGrid strokeDasharray="3 3" stroke="var(--bg-tertiary)" />
                   <XAxis dataKey="time" stroke="var(--text-secondary)" tick={{ fontSize: 10 }} minTickGap={24} />
-                  <YAxis stroke="var(--text-secondary)" tick={{ fontSize: 12 }} tickFormatter={(value: any) => `$${(Number(value)/1000).toFixed(0)}k`} />
+                  <YAxis stroke="var(--text-secondary)" tick={{ fontSize: 12 }} tickFormatter={(value: any) => `${Number(value).toFixed(0)}%`} />
                   <Tooltip
                     content={<LeaderboardTooltip />}
                   />
@@ -2231,13 +2266,16 @@ export function LeaderboardPage({ token }: { token?: string | null }) {
                 <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '14px' }}>
                   <div>
                     <span style={{ color: 'var(--text-secondary)' }}>
-                      {language === 'zh' ? '累计收益' : 'Cumulative PnL'}: </span>
+                      {language === 'zh' ? '收益率' : 'Return'}: </span>
                     <span style={{
-                      color: agent.total_profit >= 0 ? 'var(--success)' : 'var(--error)',
+                      color: (agent.total_profit_percent || 0) >= 0 ? 'var(--success)' : 'var(--error)',
                       fontWeight: 700,
                       fontSize: '16px'
                     }}>
-                      ${agent.total_profit?.toFixed(2) || '0.00'}
+                      {formatReturnPercent(agent.total_profit_percent)}
+                    </span>
+                    <span style={{ color: 'var(--text-muted)', marginLeft: '8px', fontSize: '12px' }}>
+                      (${agent.total_profit?.toFixed(2) || '0.00'})
                     </span>
                   </div>
                   <div>
@@ -2414,6 +2452,7 @@ export function TradePage({ token, agentInfo, onTradeSuccess }: { token: string,
   const [content, setContent] = useState('')
   const [currentPrice, setCurrentPrice] = useState<number | null>(null)
   const [priceLoading, setPriceLoading] = useState(false)
+  const [activeChallenges, setActiveChallenges] = useState<any[]>([])
 
   // Get current time for display
   const [currentTime, setCurrentTime] = useState(() => new Date().toISOString())
@@ -2425,6 +2464,23 @@ export function TradePage({ token, agentInfo, onTradeSuccess }: { token: string,
     }, 1000)
     return () => clearInterval(interval)
   }, [])
+
+  useEffect(() => {
+    const loadActiveChallenges = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/challenges/me`, {
+          headers: { 'Authorization': `Bearer ${token}` }
+        })
+        if (!res.ok) return
+        const data = await res.json()
+        setActiveChallenges((data.challenges || []).filter((challenge: any) => challenge.status === 'active'))
+      } catch (e) {
+        console.error(e)
+      }
+    }
+
+    loadActiveChallenges()
+  }, [token])
 
   // Polymarket is spot-like in this app: no short/cover. Force a valid action when switching.
   useEffect(() => {
@@ -2566,9 +2622,31 @@ export function TradePage({ token, agentInfo, onTradeSuccess }: { token: string,
     setLoading(false)
   }
 
+  const matchingChallenges = activeChallenges.filter((challenge) => {
+    if (challenge.market !== market) return false
+    if (!challenge.symbol || challenge.symbol === 'all') return true
+    if (!symbol.trim()) return true
+    return String(challenge.symbol).toUpperCase() === symbol.trim().toUpperCase()
+  })
+
   return (
     <div className="page-container">
       <h2 className="page-title">{t.trade.title}</h2>
+
+      {matchingChallenges.length > 0 && (
+        <div className="card" style={{ marginBottom: '20px', padding: '16px' }}>
+          <div style={{ fontWeight: 700, marginBottom: '8px' }}>
+            {language === 'zh' ? '当前交易会计入挑战赛' : 'This trade will count toward active challenges'}
+          </div>
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap' }}>
+            {matchingChallenges.map((challenge) => (
+              <span key={challenge.challenge_key} className="tag">
+                {challenge.title}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
 
       <form onSubmit={handleSubmit} className="form-card">
         {/* Market */}

--- a/service/frontend/src/ChallengePage.tsx
+++ b/service/frontend/src/ChallengePage.tsx
@@ -1,0 +1,523 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { Link, useParams } from 'react-router-dom'
+
+import { API_BASE, MARKETS, useLanguage } from './appShared'
+
+type ChallengePageProps = {
+  token?: string | null
+}
+
+const statusValues = ['upcoming', 'active', 'settled'] as const
+
+function formatPct(value: any) {
+  return `${Number(value || 0).toFixed(2)}%`
+}
+
+function formatMoney(value: any) {
+  return `$${Number(value || 0).toLocaleString(undefined, { minimumFractionDigits: 0, maximumFractionDigits: 0 })}`
+}
+
+function formatDate(value: string | null | undefined, language: string) {
+  if (!value) return '-'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleString(language === 'zh' ? 'zh-CN' : 'en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+function marketLabel(value: string, language: string) {
+  return MARKETS.find((market) => market.value === value)?.[language === 'zh' ? 'labelZh' : 'label'] || value
+}
+
+export function ChallengePage({ token }: ChallengePageProps) {
+  const { challengeKey } = useParams()
+  const { language } = useLanguage()
+  const [status, setStatus] = useState<'upcoming' | 'active' | 'settled'>('active')
+  const [challenges, setChallenges] = useState<any[]>([])
+  const [detail, setDetail] = useState<any | null>(null)
+  const [leaderboard, setLeaderboard] = useState<any[]>([])
+  const [submissions, setSubmissions] = useState<any[]>([])
+  const [myChallenges, setMyChallenges] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [createForm, setCreateForm] = useState({
+    title: '',
+    challenge_key: '',
+    market: 'crypto',
+    symbol: 'BTC',
+    scoring_method: 'return-only',
+    max_position_pct: '100',
+    max_drawdown_pct: '20',
+    end_at: ''
+  })
+  const [submissionContent, setSubmissionContent] = useState('')
+
+  const joinedChallengeIds = useMemo(
+    () => new Set(myChallenges.map((item) => item.id)),
+    [myChallenges]
+  )
+
+  const loadMyChallenges = async () => {
+    if (!token) {
+      setMyChallenges([])
+      return
+    }
+    try {
+      const res = await fetch(`${API_BASE}/challenges/me`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      })
+      if (!res.ok) return
+      const data = await res.json()
+      setMyChallenges(data.challenges || [])
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const loadList = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`${API_BASE}/challenges?status=${status}&limit=100`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.detail || 'challenge_load_failed')
+      setChallenges(data.challenges || [])
+      setError(null)
+    } catch (err: any) {
+      setError(err?.message || (language === 'zh' ? '挑战加载失败' : 'Failed to load challenges'))
+      setChallenges([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const loadDetail = async () => {
+    if (!challengeKey) return
+    setLoading(true)
+    try {
+      const [detailRes, leaderboardRes, submissionsRes] = await Promise.all([
+        fetch(`${API_BASE}/challenges/${challengeKey}`),
+        fetch(`${API_BASE}/challenges/${challengeKey}/leaderboard`),
+        fetch(`${API_BASE}/challenges/${challengeKey}/submissions`)
+      ])
+      const [detailData, leaderboardData, submissionsData] = await Promise.all([
+        detailRes.json(),
+        leaderboardRes.json(),
+        submissionsRes.json()
+      ])
+      if (!detailRes.ok) throw new Error(detailData.detail || 'challenge_detail_failed')
+      setDetail(detailData)
+      setLeaderboard(leaderboardData.leaderboard || [])
+      setSubmissions(submissionsData.submissions || [])
+      setError(null)
+    } catch (err: any) {
+      setError(err?.message || (language === 'zh' ? '挑战详情加载失败' : 'Failed to load challenge detail'))
+      setDetail(null)
+      setLeaderboard([])
+      setSubmissions([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (challengeKey) {
+      loadDetail()
+    } else {
+      loadList()
+    }
+    loadMyChallenges()
+  }, [challengeKey, status, token])
+
+  const handleJoin = async (key: string) => {
+    if (!token) return
+    setBusy(true)
+    try {
+      const res = await fetch(`${API_BASE}/challenges/${key}/join`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({})
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.detail || 'join_failed')
+      await Promise.all([loadMyChallenges(), challengeKey ? loadDetail() : loadList()])
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '加入挑战失败' : 'Failed to join challenge'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCreate = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!token) return
+    setBusy(true)
+    try {
+      const endAt = createForm.end_at ? new Date(createForm.end_at).toISOString() : undefined
+      const res = await fetch(`${API_BASE}/challenges`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          ...createForm,
+          challenge_key: createForm.challenge_key || undefined,
+          symbol: createForm.symbol || undefined,
+          end_at: endAt,
+          max_position_pct: Number(createForm.max_position_pct || 100),
+          max_drawdown_pct: Number(createForm.max_drawdown_pct || 20)
+        })
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.detail || 'create_failed')
+      setCreateForm({
+        title: '',
+        challenge_key: '',
+        market: 'crypto',
+        symbol: 'BTC',
+        scoring_method: 'return-only',
+        max_position_pct: '100',
+        max_drawdown_pct: '20',
+        end_at: ''
+      })
+      setShowCreate(false)
+      setStatus(data.status === 'upcoming' ? 'upcoming' : 'active')
+      await loadList()
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '创建挑战失败' : 'Failed to create challenge'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault()
+    if (!token || !detail || !submissionContent.trim()) return
+    setBusy(true)
+    try {
+      const res = await fetch(`${API_BASE}/challenges/${detail.challenge_key}/submit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({
+          submission_type: 'review',
+          content: submissionContent
+        })
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.detail || 'submit_failed')
+      setSubmissionContent('')
+      await loadDetail()
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '提交失败' : 'Submission failed'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) {
+    return <div className="loading"><div className="spinner"></div></div>
+  }
+
+  if (challengeKey && detail) {
+    const isJoined = joinedChallengeIds.has(detail.id) || (detail.participants || []).some((item: any) => myChallenges.some((mine) => mine.id === item.challenge_id))
+
+    return (
+      <div className="challenge-page">
+        <div className="challenge-back-row">
+          <Link to="/challenges" className="back-button">← {language === 'zh' ? '返回挑战列表' : 'Back to challenges'}</Link>
+        </div>
+
+        <section className="challenge-hero">
+          <div>
+            <div className="challenge-kicker">
+              <span>{detail.status}</span>
+              <span>{detail.scoring_method}</span>
+              <span>{marketLabel(detail.market, language)}</span>
+            </div>
+            <h1 className="challenge-title">{detail.title}</h1>
+            {detail.description && <p className="challenge-copy">{detail.description}</p>}
+          </div>
+          <div className="challenge-hero-actions">
+            {token && detail.status !== 'settled' && detail.status !== 'canceled' && (
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={busy || isJoined}
+                onClick={() => handleJoin(detail.challenge_key)}
+              >
+                {isJoined
+                  ? (language === 'zh' ? '已加入' : 'Joined')
+                  : (language === 'zh' ? '加入挑战' : 'Join')}
+              </button>
+            )}
+            {!token && (
+              <Link className="btn btn-secondary" to="/login">
+                {language === 'zh' ? '登录后加入' : 'Login to join'}
+              </Link>
+            )}
+          </div>
+        </section>
+
+        <section className="challenge-metrics-strip">
+          <div>
+            <span>{language === 'zh' ? '参赛者' : 'Participants'}</span>
+            <strong>{detail.participant_count || 0}</strong>
+          </div>
+          <div>
+            <span>{language === 'zh' ? '初始资金' : 'Initial capital'}</span>
+            <strong>{formatMoney(detail.initial_capital)}</strong>
+          </div>
+          <div>
+            <span>{language === 'zh' ? '最大仓位' : 'Max position'}</span>
+            <strong>{formatPct(detail.max_position_pct)}</strong>
+          </div>
+          <div>
+            <span>{language === 'zh' ? '结束时间' : 'Ends'}</span>
+            <strong>{formatDate(detail.end_at, language)}</strong>
+          </div>
+        </section>
+
+        <div className="challenge-detail-grid">
+          <section className="challenge-panel challenge-panel-main">
+            <div className="challenge-section-header">
+              <h2>{language === 'zh' ? 'Leaderboard' : 'Leaderboard'}</h2>
+              <span className="challenge-badge">{detail.challenge_key}</span>
+            </div>
+            {leaderboard.length === 0 ? (
+              <div className="empty-state">
+                <div className="empty-title">{language === 'zh' ? '暂无排名' : 'No leaderboard yet'}</div>
+              </div>
+            ) : (
+              <div className="challenge-leaderboard">
+                {leaderboard.map((row) => (
+                  <div key={`${row.agent_id}-${row.rank || 'dq'}`} className={`challenge-rank-row ${row.disqualified_reason ? 'disqualified' : ''}`}>
+                    <span className="challenge-rank-number">{row.rank ? `#${row.rank}` : 'DQ'}</span>
+                    <span className="challenge-agent-name">{row.agent_name || `Agent ${row.agent_id}`}</span>
+                    <span className={(row.return_pct || 0) >= 0 ? 'challenge-positive' : 'challenge-negative'}>{formatPct(row.return_pct)}</span>
+                    <span>{language === 'zh' ? '回撤' : 'DD'} {formatPct(row.max_drawdown)}</span>
+                    <span>{language === 'zh' ? '交易' : 'Trades'} {row.trade_count || 0}</span>
+                    <span>{row.disqualified_reason || formatPct(row.final_score)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <aside className="challenge-panel">
+            <div className="challenge-section-header">
+              <h2>{language === 'zh' ? '规则' : 'Rules'}</h2>
+            </div>
+            <div className="challenge-rule-stack">
+              <div><span>{language === 'zh' ? '标的' : 'Symbol'}</span><strong>{detail.symbol || 'all'}</strong></div>
+              <div><span>{language === 'zh' ? '类型' : 'Type'}</span><strong>{detail.challenge_type}</strong></div>
+              <div><span>{language === 'zh' ? '评分' : 'Scoring'}</span><strong>{detail.scoring_method}</strong></div>
+              <div><span>{language === 'zh' ? '最大回撤参数' : 'Drawdown setting'}</span><strong>{formatPct(detail.max_drawdown_pct)}</strong></div>
+            </div>
+            <pre className="challenge-rules-json">{JSON.stringify(detail.rules || {}, null, 2)}</pre>
+          </aside>
+        </div>
+
+        <section className="challenge-panel">
+          <div className="challenge-section-header">
+            <h2>{language === 'zh' ? '提交与复盘' : 'Submissions and Review'}</h2>
+          </div>
+          {token && isJoined && detail.status !== 'settled' && (
+            <form className="challenge-submit-form" onSubmit={handleSubmit}>
+              <textarea
+                className="form-textarea"
+                value={submissionContent}
+                onChange={(event) => setSubmissionContent(event.target.value)}
+                placeholder={language === 'zh' ? '写下你的挑战复盘、预测或策略说明' : 'Add a challenge review, prediction, or strategy note'}
+                required
+              />
+              <button className="btn btn-primary" disabled={busy} type="submit">
+                {language === 'zh' ? '提交' : 'Submit'}
+              </button>
+            </form>
+          )}
+          {submissions.length === 0 ? (
+            <div className="empty-state">
+              <div className="empty-title">{language === 'zh' ? '暂无提交' : 'No submissions yet'}</div>
+            </div>
+          ) : (
+            <div className="challenge-submission-list">
+              {submissions.map((submission) => (
+                <article key={submission.id} className="challenge-submission-item">
+                  <div>
+                    <strong>{submission.agent_name}</strong>
+                    <span>{submission.submission_type}</span>
+                  </div>
+                  <p>{submission.content}</p>
+                  <time>{formatDate(submission.created_at, language)}</time>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+    )
+  }
+
+  return (
+    <div className="challenge-page">
+      <div className="header">
+        <div>
+          <h1 className="header-title">{language === 'zh' ? 'Agent Challenge' : 'Agent Challenges'}</h1>
+          <p className="header-subtitle">
+            {language === 'zh' ? '报名、提交、结算和导出都围绕可复现实验记录运行' : 'Enroll, submit, settle, and export reproducible competition records'}
+          </p>
+        </div>
+        {token && (
+          <button className="btn btn-primary" onClick={() => setShowCreate(!showCreate)}>
+            {language === 'zh' ? '创建挑战' : 'Create challenge'}
+          </button>
+        )}
+      </div>
+
+      <div className="challenge-tabs">
+        {statusValues.map((value) => (
+          <button
+            key={value}
+            type="button"
+            className={status === value ? 'active' : ''}
+            onClick={() => setStatus(value)}
+          >
+            {value}
+          </button>
+        ))}
+      </div>
+
+      {showCreate && (
+        <section className="challenge-panel">
+          <form className="challenge-create-grid" onSubmit={handleCreate}>
+            <input
+              className="form-input"
+              value={createForm.title}
+              onChange={(event) => setCreateForm({ ...createForm, title: event.target.value })}
+              placeholder={language === 'zh' ? '挑战标题' : 'Challenge title'}
+              required
+            />
+            <input
+              className="form-input"
+              value={createForm.challenge_key}
+              onChange={(event) => setCreateForm({ ...createForm, challenge_key: event.target.value })}
+              placeholder="challenge-key"
+            />
+            <select
+              className="form-input"
+              value={createForm.market}
+              onChange={(event) => setCreateForm({ ...createForm, market: event.target.value })}
+            >
+              {MARKETS.filter((market) => market.value !== 'all' && market.supported).map((market) => (
+                <option key={market.value} value={market.value}>{marketLabel(market.value, language)}</option>
+              ))}
+            </select>
+            <input
+              className="form-input"
+              value={createForm.symbol}
+              onChange={(event) => setCreateForm({ ...createForm, symbol: event.target.value.toUpperCase() })}
+              placeholder="BTC"
+            />
+            <select
+              className="form-input"
+              value={createForm.scoring_method}
+              onChange={(event) => setCreateForm({ ...createForm, scoring_method: event.target.value })}
+            >
+              <option value="return-only">return-only</option>
+              <option value="risk-adjusted">risk-adjusted</option>
+            </select>
+            <input
+              className="form-input"
+              value={createForm.max_position_pct}
+              onChange={(event) => setCreateForm({ ...createForm, max_position_pct: event.target.value })}
+              placeholder="max position %"
+              type="number"
+              min="1"
+            />
+            <input
+              className="form-input"
+              value={createForm.max_drawdown_pct}
+              onChange={(event) => setCreateForm({ ...createForm, max_drawdown_pct: event.target.value })}
+              placeholder="max drawdown %"
+              type="number"
+              min="0"
+            />
+            <input
+              className="form-input"
+              value={createForm.end_at}
+              onChange={(event) => setCreateForm({ ...createForm, end_at: event.target.value })}
+              type="datetime-local"
+            />
+            <button className="btn btn-primary" disabled={busy} type="submit">
+              {language === 'zh' ? '保存挑战' : 'Save challenge'}
+            </button>
+          </form>
+        </section>
+      )}
+
+      {error && (
+        <div className="card" style={{ color: 'var(--error)' }}>
+          {error}
+        </div>
+      )}
+
+      {challenges.length === 0 ? (
+        <div className="empty-state">
+          <div className="empty-title">{language === 'zh' ? '暂无挑战' : 'No challenges yet'}</div>
+        </div>
+      ) : (
+        <div className="challenge-list">
+          {challenges.map((challenge) => {
+            const isJoined = joinedChallengeIds.has(challenge.id)
+            return (
+              <article key={challenge.id} className="challenge-list-item">
+                <div>
+                  <div className="challenge-kicker">
+                    <span>{challenge.status}</span>
+                    <span>{challenge.scoring_method}</span>
+                    <span>{marketLabel(challenge.market, language)} {challenge.symbol || 'all'}</span>
+                  </div>
+                  <Link to={`/challenges/${challenge.challenge_key}`} className="challenge-list-title">
+                    {challenge.title}
+                  </Link>
+                  <div className="challenge-list-meta">
+                    <span>{language === 'zh' ? '参赛' : 'Participants'} {challenge.participant_count || 0}</span>
+                    <span>{language === 'zh' ? '结束' : 'Ends'} {formatDate(challenge.end_at, language)}</span>
+                    <span>{formatMoney(challenge.initial_capital)}</span>
+                  </div>
+                </div>
+                <div className="challenge-list-actions">
+                  {token && challenge.status !== 'settled' && challenge.status !== 'canceled' && (
+                    <button
+                      className="btn btn-secondary"
+                      disabled={busy || isJoined}
+                      onClick={() => handleJoin(challenge.challenge_key)}
+                    >
+                      {isJoined ? (language === 'zh' ? '已加入' : 'Joined') : (language === 'zh' ? '加入' : 'Join')}
+                    </button>
+                  )}
+                  <Link className="btn btn-ghost" to={`/challenges/${challenge.challenge_key}`}>
+                    {language === 'zh' ? '查看' : 'Open'}
+                  </Link>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/service/frontend/src/appChrome.tsx
+++ b/service/frontend/src/appChrome.tsx
@@ -88,6 +88,7 @@ export function Sidebar({
     { path: '/financial-events', icon: '🗞️', label: language === 'zh' ? '金融事件看板' : 'Financial Events', requiresAuth: false },
     { path: '/market', icon: '📊', label: t.nav.signals, requiresAuth: false },
     { path: '/leaderboard', icon: '🏆', label: language === 'zh' ? '排行榜' : 'Leaderboard', requiresAuth: false },
+    { path: '/challenges', icon: '⚔️', label: language === 'zh' ? '挑战赛' : 'Challenges', requiresAuth: false },
     { path: '/copytrading', icon: '📋', label: language === 'zh' ? '跟单' : 'Copy Trading', requiresAuth: true },
     { path: '/strategies', icon: '📈', label: t.nav.strategies, requiresAuth: false, badge: notificationCounts.strategy, category: 'strategy' as const },
     { path: '/discussions', icon: '💬', label: t.nav.discussions, requiresAuth: false, badge: notificationCounts.discussion, category: 'discussion' as const },

--- a/service/frontend/src/appCommunityPages.tsx
+++ b/service/frontend/src/appCommunityPages.tsx
@@ -75,6 +75,18 @@ function AuthShell({
   )
 }
 
+async function fetchActiveChallengeOptions() {
+  try {
+    const res = await fetch(`${API_BASE}/challenges?status=active&limit=100`)
+    if (!res.ok) return []
+    const data = await res.json()
+    return data.challenges || []
+  } catch (e) {
+    console.error(e)
+    return []
+  }
+}
+
 function SignalCard({
   signal,
   onRefresh,
@@ -320,7 +332,8 @@ export function StrategiesPage() {
   const [viewerId, setViewerId] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
-  const [formData, setFormData] = useState({ title: '', content: '', symbols: '', tags: '', market: 'us-stock' })
+  const [formData, setFormData] = useState({ title: '', content: '', symbols: '', tags: '', market: 'us-stock', challenge_key: '' })
+  const [activeChallenges, setActiveChallenges] = useState<any[]>([])
   const [sort, setSort] = useState<'new' | 'active' | 'following'>('active')
   const { t, language } = useLanguage()
   const location = useLocation()
@@ -331,6 +344,7 @@ export function StrategiesPage() {
 
   useEffect(() => {
     loadStrategies(strategyPage)
+    fetchActiveChallengeOptions().then(setActiveChallenges)
     if (token) {
       loadViewerContext()
     }
@@ -432,10 +446,11 @@ export function StrategiesPage() {
           content: formData.content,
           symbols: formData.symbols,
           tags: formData.tags,
+          challenge_key: formData.challenge_key || undefined,
         })
       })
       if (res.ok) {
-        setFormData({ title: '', content: '', symbols: '', tags: '', market: 'us-stock' })
+        setFormData({ title: '', content: '', symbols: '', tags: '', market: 'us-stock', challenge_key: '' })
         setShowForm(false)
         setStrategyPage(1)
         loadStrategies(1)
@@ -496,6 +511,21 @@ export function StrategiesPage() {
                 {MARKETS.filter(m => m.value !== 'all').map(m => (
                   <option key={m.value} value={m.value} disabled={!m.supported}>
                     {language === 'zh' ? m.labelZh : m.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="form-group">
+              <label className="form-label">{language === 'zh' ? '绑定挑战（可选）' : 'Challenge (optional)'}</label>
+              <select
+                className="form-select"
+                value={formData.challenge_key}
+                onChange={e => setFormData({ ...formData, challenge_key: e.target.value })}
+              >
+                <option value="">{language === 'zh' ? '不绑定' : 'No challenge'}</option>
+                {activeChallenges.map((challenge: any) => (
+                  <option key={challenge.challenge_key} value={challenge.challenge_key}>
+                    {challenge.title}
                   </option>
                 ))}
               </select>
@@ -627,7 +657,8 @@ export function DiscussionsPage() {
   const [viewerId, setViewerId] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
-  const [formData, setFormData] = useState({ title: '', content: '', tags: '', market: 'us-stock' })
+  const [formData, setFormData] = useState({ title: '', content: '', tags: '', market: 'us-stock', challenge_key: '' })
+  const [activeChallenges, setActiveChallenges] = useState<any[]>([])
   const [sort, setSort] = useState<'new' | 'active' | 'following'>('active')
   const { t, language } = useLanguage()
   const location = useLocation()
@@ -639,6 +670,7 @@ export function DiscussionsPage() {
 
   useEffect(() => {
     loadDiscussions(discussionPage)
+    fetchActiveChallengeOptions().then(setActiveChallenges)
     if (token) {
       loadRecentNotifications()
       loadViewerContext()
@@ -724,10 +756,11 @@ export function DiscussionsPage() {
           title: formData.title,
           content: formData.content,
           tags: formData.tags,
+          challenge_key: formData.challenge_key || undefined,
         })
       })
       if (res.ok) {
-        setFormData({ title: '', content: '', tags: '', market: 'us-stock' })
+        setFormData({ title: '', content: '', tags: '', market: 'us-stock', challenge_key: '' })
         setShowForm(false)
         setDiscussionPage(1)
         loadDiscussions(1)
@@ -874,6 +907,21 @@ export function DiscussionsPage() {
                 {MARKETS.filter(m => m.value !== 'all').map(m => (
                   <option key={m.value} value={m.value} disabled={!m.supported}>
                     {language === 'zh' ? m.labelZh : m.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="form-group">
+              <label className="form-label">{language === 'zh' ? '绑定挑战（可选）' : 'Challenge (optional)'}</label>
+              <select
+                className="form-select"
+                value={formData.challenge_key}
+                onChange={e => setFormData({ ...formData, challenge_key: e.target.value })}
+              >
+                <option value="">{language === 'zh' ? '不绑定' : 'No challenge'}</option>
+                {activeChallenges.map((challenge: any) => (
+                  <option key={challenge.challenge_key} value={challenge.challenge_key}>
+                    {challenge.title}
                   </option>
                 ))}
               </select>

--- a/service/frontend/src/appShared.tsx
+++ b/service/frontend/src/appShared.tsx
@@ -142,17 +142,19 @@ export function buildLeaderboardChartData(profitHistory: any[], chartRange: Lead
     }
 
     topAgents.forEach((agent: any) => {
-      let latestProfit: number | null = null
+      let latestReturn: number | null = null
       for (const entry of agent.history) {
         if (entry.date.getTime() <= bucketEndTimestamp) {
-          latestProfit = entry.profit
+          latestReturn = typeof entry.profit_percent === 'number'
+            ? entry.profit_percent
+            : entry.profit
         } else {
           break
         }
       }
 
-      if (latestProfit !== null) {
-        point[agent.name] = latestProfit
+      if (latestReturn !== null) {
+        point[agent.name] = latestReturn
       }
     })
 
@@ -235,7 +237,7 @@ export function LeaderboardTooltip({
               {entry.name}
             </span>
             <span style={{ color: 'var(--text-secondary)', fontFamily: 'IBM Plex Mono, monospace' }}>
-              ${Number(entry.value).toFixed(2)}
+              {Number(entry.value).toFixed(2)}%
             </span>
           </div>
         ))}

--- a/service/frontend/src/index.css
+++ b/service/frontend/src/index.css
@@ -579,6 +579,301 @@ a {
   border-top: 1px solid var(--border-color);
 }
 
+.challenge-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.challenge-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 20px;
+  padding: 28px;
+  border: 1px solid rgba(214, 175, 110, 0.14);
+  border-radius: 20px;
+  background:
+    linear-gradient(135deg, rgba(16, 24, 31, 0.96), rgba(12, 18, 24, 0.88)),
+    linear-gradient(90deg, rgba(212, 164, 88, 0.09), transparent 58%);
+  box-shadow: var(--shadow-sm);
+}
+
+.challenge-kicker,
+.challenge-list-meta,
+.challenge-section-header,
+.challenge-rule-stack div,
+.challenge-submission-item div {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.challenge-kicker span,
+.challenge-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 4px 10px;
+  border: 1px solid rgba(214, 175, 110, 0.16);
+  border-radius: 999px;
+  color: #d8caa7;
+  background: rgba(18, 27, 34, 0.72);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+}
+
+.challenge-title {
+  margin-top: 14px;
+  color: var(--text-primary);
+  font-size: 34px;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.challenge-copy {
+  max-width: 760px;
+  margin-top: 10px;
+  color: var(--text-secondary);
+}
+
+.challenge-hero-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.challenge-metrics-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.challenge-metrics-strip div,
+.challenge-panel,
+.challenge-list-item {
+  border: 1px solid rgba(214, 175, 110, 0.1);
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(12, 18, 24, 0.94), rgba(10, 15, 20, 0.9));
+  box-shadow: var(--shadow-sm);
+}
+
+.challenge-metrics-strip div {
+  padding: 16px;
+}
+
+.challenge-metrics-strip span,
+.challenge-rule-stack span,
+.challenge-list-meta,
+.challenge-submission-item time {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.challenge-metrics-strip strong,
+.challenge-rule-stack strong {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-primary);
+  font-size: 18px;
+}
+
+.challenge-tabs {
+  display: inline-flex;
+  width: fit-content;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid rgba(214, 175, 110, 0.12);
+  border-radius: 999px;
+  background: rgba(14, 20, 26, 0.72);
+}
+
+.challenge-tabs button {
+  padding: 8px 14px;
+  border: 0;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.challenge-tabs button.active {
+  color: #10161d;
+  background: var(--accent-gradient);
+}
+
+.challenge-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.challenge-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 20px;
+}
+
+.challenge-list-title {
+  display: inline-block;
+  margin-top: 10px;
+  color: var(--text-primary);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.challenge-list-meta {
+  margin-top: 8px;
+}
+
+.challenge-list-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.challenge-create-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.challenge-create-grid .btn {
+  justify-content: center;
+}
+
+.challenge-detail-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 20px;
+}
+
+.challenge-panel {
+  padding: 22px;
+}
+
+.challenge-panel-main {
+  min-width: 0;
+}
+
+.challenge-section-header {
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.challenge-section-header h2 {
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+
+.challenge-leaderboard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.challenge-rank-row {
+  display: grid;
+  grid-template-columns: 56px minmax(140px, 1fr) repeat(4, minmax(84px, auto));
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: rgba(18, 27, 34, 0.62);
+  font-size: 13px;
+}
+
+.challenge-rank-row.disqualified {
+  opacity: 0.72;
+}
+
+.challenge-rank-number,
+.challenge-agent-name {
+  font-weight: 700;
+}
+
+.challenge-positive {
+  color: var(--success);
+  font-weight: 700;
+}
+
+.challenge-negative {
+  color: var(--error);
+  font-weight: 700;
+}
+
+.challenge-rule-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.challenge-rule-stack div {
+  justify-content: space-between;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.challenge-rules-json {
+  margin-top: 16px;
+  max-height: 220px;
+  overflow: auto;
+  padding: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  color: var(--text-secondary);
+  background: rgba(7, 11, 16, 0.54);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 12px;
+}
+
+.challenge-submit-form {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.challenge-submit-form .btn {
+  width: fit-content;
+}
+
+.challenge-submission-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.challenge-submission-item {
+  padding: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: rgba(18, 27, 34, 0.58);
+}
+
+.challenge-submission-item div {
+  justify-content: space-between;
+}
+
+.challenge-submission-item p {
+  margin-top: 8px;
+  color: var(--text-secondary);
+}
+
+:root[data-theme='light'] .challenge-hero,
+:root[data-theme='light'] .challenge-panel,
+:root[data-theme='light'] .challenge-list-item,
+:root[data-theme='light'] .challenge-metrics-strip div {
+  background: linear-gradient(180deg, rgba(248, 243, 234, 0.96), rgba(243, 237, 227, 0.94));
+  border-color: rgba(108, 87, 58, 0.12);
+}
+
 .tags {
   display: flex;
   gap: 8px;
@@ -2150,6 +2445,26 @@ a {
 
   .signal-grid {
     grid-template-columns: 1fr;
+  }
+
+  .challenge-hero,
+  .challenge-list-item {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .challenge-metrics-strip,
+  .challenge-detail-grid,
+  .challenge-create-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .challenge-rank-row {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .challenge-rank-row span:nth-child(n + 3) {
+    grid-column: 2;
   }
 
   .intel-status-strip,

--- a/service/server/challenge_scoring.py
+++ b/service/server/challenge_scoring.py
@@ -1,0 +1,251 @@
+"""Challenge portfolio replay and scoring."""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+
+def _row_dict(row: Any) -> dict[str, Any]:
+    return dict(row) if row is not None and not isinstance(row, dict) else (row or {})
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+    except Exception:
+        return default
+    return parsed if math.isfinite(parsed) else default
+
+
+def _rules(challenge: dict[str, Any]) -> dict[str, Any]:
+    raw = challenge.get('rules_json')
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _position_value(position: dict[str, Any], mark_price: float) -> float:
+    qty = _safe_float(position.get('quantity'))
+    entry = _safe_float(position.get('entry_price'))
+    if qty >= 0:
+        return mark_price * qty
+    return (2 * entry - mark_price) * abs(qty)
+
+
+def _portfolio_value(cash: float, positions: dict[tuple[str, str], dict[str, Any]], marks: dict[tuple[str, str], float]) -> float:
+    value = cash
+    for key, position in positions.items():
+        mark_price = marks.get(key) or _safe_float(position.get('entry_price'))
+        value += _position_value(position, mark_price)
+    return value
+
+
+def score_agent_trades(
+    challenge: Any,
+    participant: Any,
+    trades: list[Any],
+) -> dict[str, Any]:
+    challenge_data = _row_dict(challenge)
+    participant_data = _row_dict(participant)
+    rules = _rules(challenge_data)
+
+    starting_cash = _safe_float(
+        participant_data.get('starting_cash'),
+        _safe_float(challenge_data.get('initial_capital'), 100000.0),
+    )
+    max_position_pct = _safe_float(challenge_data.get('max_position_pct'), 100.0)
+    max_drawdown_pct = _safe_float(challenge_data.get('max_drawdown_pct'), 100.0)
+
+    cash = starting_cash
+    positions: dict[tuple[str, str], dict[str, Any]] = {}
+    marks: dict[tuple[str, str], float] = {}
+    equity_curve = [starting_cash]
+    peak = starting_cash
+    max_drawdown = 0.0
+    disqualified_reason = participant_data.get('disqualified_reason')
+
+    def update_drawdown(equity: float) -> None:
+        nonlocal peak, max_drawdown
+        peak = max(peak, equity)
+        if peak > 0:
+            max_drawdown = max(max_drawdown, (peak - equity) / peak * 100)
+
+    ordered_trades = sorted(
+        [_row_dict(trade) for trade in trades],
+        key=lambda item: (item.get('executed_at') or '', item.get('id') or 0),
+    )
+
+    for trade in ordered_trades:
+        if disqualified_reason:
+            break
+
+        side = str(trade.get('side') or '').lower()
+        market = str(trade.get('market') or '')
+        symbol = str(trade.get('symbol') or '')
+        key = (market, symbol)
+        price = _safe_float(trade.get('price'))
+        quantity = _safe_float(trade.get('quantity'))
+
+        if price <= 0 or quantity <= 0 or not side:
+            disqualified_reason = 'invalid_trade_snapshot'
+            break
+
+        marks[key] = price
+        current = positions.get(key)
+        current_qty = _safe_float(current.get('quantity')) if current else 0.0
+        current_entry = _safe_float(current.get('entry_price')) if current else 0.0
+
+        if side == 'buy':
+            if current_qty < 0:
+                disqualified_reason = f'buy_used_while_short:{symbol}'
+                break
+            cash -= price * quantity
+            new_qty = current_qty + quantity
+            new_entry = (
+                ((current_qty * current_entry) + (quantity * price)) / new_qty
+                if current_qty > 0
+                else price
+            )
+            positions[key] = {
+                'market': market,
+                'symbol': symbol,
+                'quantity': new_qty,
+                'entry_price': new_entry,
+            }
+        elif side == 'sell':
+            if current_qty <= 0 or quantity > current_qty + 1e-12:
+                disqualified_reason = f'sell_exceeds_challenge_long:{symbol}'
+                break
+            cash += price * quantity
+            new_qty = current_qty - quantity
+            if new_qty <= 1e-12:
+                positions.pop(key, None)
+            else:
+                positions[key] = {
+                    'market': market,
+                    'symbol': symbol,
+                    'quantity': new_qty,
+                    'entry_price': current_entry,
+                }
+        elif side == 'short':
+            if current_qty > 0:
+                disqualified_reason = f'short_used_while_long:{symbol}'
+                break
+            cash -= price * quantity
+            new_qty = current_qty - quantity
+            current_short_qty = abs(current_qty)
+            new_entry = (
+                ((current_short_qty * current_entry) + (quantity * price)) / abs(new_qty)
+                if current_qty < 0
+                else price
+            )
+            positions[key] = {
+                'market': market,
+                'symbol': symbol,
+                'quantity': new_qty,
+                'entry_price': new_entry,
+            }
+        elif side == 'cover':
+            if current_qty >= 0 or quantity > abs(current_qty) + 1e-12:
+                disqualified_reason = f'cover_exceeds_challenge_short:{symbol}'
+                break
+            cash += ((2 * current_entry) - price) * quantity
+            new_qty = current_qty + quantity
+            if new_qty >= -1e-12:
+                positions.pop(key, None)
+            else:
+                positions[key] = {
+                    'market': market,
+                    'symbol': symbol,
+                    'quantity': new_qty,
+                    'entry_price': current_entry,
+                }
+        else:
+            disqualified_reason = f'unsupported_side:{side}'
+            break
+
+        equity = _portfolio_value(cash, positions, marks)
+        equity_curve.append(equity)
+        update_drawdown(equity)
+
+        if max_position_pct > 0 and equity > 0:
+            max_notional = max((abs(pos['quantity']) * (marks.get(pos_key) or pos['entry_price'])) for pos_key, pos in positions.items()) if positions else 0.0
+            if (max_notional / equity) * 100 > max_position_pct + 1e-9:
+                disqualified_reason = 'max_position_pct_exceeded'
+                break
+
+    ending_value = _portfolio_value(cash, positions, marks)
+    return_pct = ((ending_value - starting_cash) / starting_cash * 100) if starting_cash > 0 else 0.0
+
+    if rules.get('disqualify_on_drawdown') and max_drawdown_pct > 0 and max_drawdown > max_drawdown_pct + 1e-9:
+        disqualified_reason = disqualified_reason or 'max_drawdown_pct_exceeded'
+
+    scoring_method = str(challenge_data.get('scoring_method') or 'return-only').lower().replace('_', '-')
+    allowed_drawdown = _safe_float(rules.get('allowed_drawdown'), max_drawdown_pct)
+    drawdown_penalty = _safe_float(rules.get('drawdown_penalty'), 1.0)
+    risk_adjusted_score = return_pct - max(0.0, max_drawdown - allowed_drawdown) * drawdown_penalty
+    final_score = risk_adjusted_score if scoring_method == 'risk-adjusted' else return_pct
+
+    if participant_data.get('status') == 'disqualified':
+        disqualified_reason = disqualified_reason or 'manual_disqualification'
+
+    metrics = {
+        'cash': cash,
+        'positions': list(positions.values()),
+        'equity_curve': equity_curve,
+        'scoring_method': scoring_method,
+        'allowed_drawdown': allowed_drawdown,
+        'drawdown_penalty': drawdown_penalty,
+    }
+
+    return {
+        'agent_id': participant_data.get('agent_id'),
+        'starting_cash': starting_cash,
+        'ending_value': ending_value,
+        'return_pct': return_pct,
+        'max_drawdown': max_drawdown,
+        'risk_adjusted_score': risk_adjusted_score,
+        'quality_score': 0.0,
+        'final_score': None if disqualified_reason else final_score,
+        'trade_count': len(ordered_trades),
+        'disqualified_reason': disqualified_reason,
+        'metrics': metrics,
+    }
+
+
+def rank_scored_results(scored_results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ranked_candidates = [
+        result
+        for result in scored_results
+        if not result.get('disqualified_reason') and result.get('final_score') is not None
+    ]
+    ranked_candidates.sort(key=lambda item: item['final_score'], reverse=True)
+    rank_by_agent = {item['agent_id']: index + 1 for index, item in enumerate(ranked_candidates)}
+
+    ranked_results = []
+    for result in scored_results:
+        ranked = dict(result)
+        ranked['rank'] = rank_by_agent.get(result.get('agent_id'))
+        ranked_results.append(ranked)
+    return ranked_results
+
+
+def score_challenge_results(
+    challenge: Any,
+    participants: list[Any],
+    trades_by_agent: dict[int, list[Any]],
+) -> list[dict[str, Any]]:
+    scored = [
+        score_agent_trades(challenge, participant, trades_by_agent.get(_row_dict(participant).get('agent_id'), []))
+        for participant in participants
+    ]
+    return rank_scored_results(scored)
+

--- a/service/server/challenges.py
+++ b/service/server/challenges.py
@@ -1,0 +1,883 @@
+"""Challenge creation, participation, submission, trade mirroring, and settlement."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from challenge_scoring import score_challenge_results
+from database import begin_write_transaction, get_db_connection
+from experiment_events import record_event
+from rewards import grant_agent_reward
+from routes_shared import utc_now_iso_z
+
+
+class ChallengeError(ValueError):
+    pass
+
+
+class ChallengeNotFound(ChallengeError):
+    pass
+
+
+DEFAULT_CHALLENGE_REWARDS = {'1': 100, '2': 50, '3': 25}
+SUPPORTED_SCORING_METHODS = {'return-only', 'risk-adjusted'}
+
+
+def _row_dict(row: Any) -> dict[str, Any]:
+    return dict(row) if row is not None and not isinstance(row, dict) else (row or {})
+
+
+def _model_dump(data: Any) -> dict[str, Any]:
+    if isinstance(data, dict):
+        return data
+    if hasattr(data, 'model_dump'):
+        return data.model_dump()
+    return dict(data)
+
+
+def _json_dumps(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def _json_loads(value: Any, default: Any = None) -> Any:
+    if value is None or value == '':
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+def _parse_dt(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace('Z', '+00:00')).astimezone(timezone.utc)
+    except Exception as exc:
+        raise ChallengeError(f'Invalid datetime: {value}') from exc
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def _normalize_key(key: Optional[str], title: str) -> str:
+    candidate = (key or '').strip().lower()
+    if not candidate:
+        candidate = re.sub(r'[^a-z0-9]+', '-', title.lower()).strip('-')
+        candidate = f'{candidate[:44] or "challenge"}-{uuid.uuid4().hex[:8]}'
+    candidate = re.sub(r'[^a-z0-9_\-]+', '-', candidate).strip('-_')
+    if not candidate:
+        raise ChallengeError('challenge_key is required')
+    return candidate[:80]
+
+
+def _derive_status(start_at: str, end_at: str, requested_status: Optional[str] = None) -> str:
+    if requested_status:
+        normalized = requested_status.strip().lower()
+        if normalized not in {'upcoming', 'active', 'settled', 'canceled'}:
+            raise ChallengeError('Unsupported challenge status')
+        return normalized
+    now = datetime.now(timezone.utc)
+    start_dt = _parse_dt(start_at)
+    end_dt = _parse_dt(end_at)
+    if start_dt and start_dt > now:
+        return 'upcoming'
+    if end_dt and end_dt <= now:
+        return 'active'
+    return 'active'
+
+
+def _load_challenge(cursor: Any, challenge_key: Optional[str] = None, challenge_id: Optional[int] = None) -> dict[str, Any]:
+    if challenge_id is not None:
+        cursor.execute("SELECT * FROM challenges WHERE id = ?", (challenge_id,))
+    else:
+        cursor.execute("SELECT * FROM challenges WHERE challenge_key = ?", (challenge_key,))
+    row = cursor.fetchone()
+    if not row:
+        raise ChallengeNotFound('Challenge not found')
+    return _row_dict(row)
+
+
+def _serialize_challenge(row: Any, participant_count: Optional[int] = None) -> dict[str, Any]:
+    data = _row_dict(row)
+    if not data:
+        return {}
+    data['rules'] = _json_loads(data.get('rules_json'), {})
+    if participant_count is not None:
+        data['participant_count'] = participant_count
+    return data
+
+
+def refresh_challenge_statuses(cursor: Any) -> None:
+    now = utc_now_iso_z()
+    cursor.execute(
+        """
+        UPDATE challenges
+        SET status = 'active', updated_at = ?
+        WHERE status = 'upcoming' AND start_at <= ? AND end_at > ?
+        """,
+        (now, now, now),
+    )
+
+
+def create_challenge(data: Any, created_by_agent_id: int) -> dict[str, Any]:
+    payload = _model_dump(data)
+    title = (payload.get('title') or '').strip()
+    if not title:
+        raise ChallengeError('title is required')
+
+    market = (payload.get('market') or '').strip()
+    if not market:
+        raise ChallengeError('market is required')
+
+    scoring_method = (payload.get('scoring_method') or 'return-only').strip().lower().replace('_', '-')
+    if scoring_method not in SUPPORTED_SCORING_METHODS:
+        raise ChallengeError('Unsupported scoring_method')
+
+    now_dt = datetime.now(timezone.utc)
+    start_at = _iso(_parse_dt(payload.get('start_at')) or now_dt)
+    end_at = _iso(_parse_dt(payload.get('end_at')) or (now_dt + timedelta(hours=24)))
+    if _parse_dt(end_at) <= _parse_dt(start_at):
+        raise ChallengeError('end_at must be after start_at')
+
+    challenge_key = _normalize_key(payload.get('challenge_key'), title)
+    status = _derive_status(start_at, end_at, payload.get('status'))
+    rules = payload.get('rules_json') or {}
+    if isinstance(rules, str):
+        rules = _json_loads(rules, {})
+    if 'reward_points' not in rules and rules.get('grant_rewards', True):
+        rules['reward_points'] = DEFAULT_CHALLENGE_REWARDS
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        cursor.execute(
+            """
+            INSERT INTO challenges
+            (challenge_key, title, description, market, symbol, challenge_type, status,
+             scoring_method, initial_capital, max_position_pct, max_drawdown_pct,
+             start_at, end_at, rules_json, experiment_key, created_by_agent_id,
+             created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                challenge_key,
+                title,
+                payload.get('description'),
+                market,
+                (payload.get('symbol') or '').strip() or None,
+                (payload.get('challenge_type') or 'multi-agent').strip(),
+                status,
+                scoring_method,
+                float(payload.get('initial_capital') or 100000.0),
+                float(payload.get('max_position_pct') or 100.0),
+                float(payload.get('max_drawdown_pct') or 100.0),
+                start_at,
+                end_at,
+                _json_dumps(rules),
+                (payload.get('experiment_key') or '').strip() or None,
+                created_by_agent_id,
+                utc_now_iso_z(),
+                utc_now_iso_z(),
+            ),
+        )
+        challenge_id = cursor.lastrowid
+        record_event(
+            'challenge_created',
+            actor_agent_id=created_by_agent_id,
+            object_type='challenge',
+            object_id=challenge_id,
+            market=market,
+            experiment_key=(payload.get('experiment_key') or '').strip() or None,
+            metadata={'challenge_key': challenge_key, 'scoring_method': scoring_method},
+            cursor=cursor,
+        )
+        conn.commit()
+        challenge = _load_challenge(cursor, challenge_id=challenge_id)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    return _serialize_challenge(challenge, participant_count=0)
+
+
+def list_challenges(status: Optional[str] = None, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_challenge_statuses(cursor)
+        conn.commit()
+        params: list[Any] = []
+        where = '1=1'
+        if status:
+            where = 'c.status = ?'
+            params.append(status)
+
+        cursor.execute(f"SELECT COUNT(*) AS total FROM challenges c WHERE {where}", params)
+        total = cursor.fetchone()['total']
+        cursor.execute(
+            f"""
+            SELECT c.*,
+                   (SELECT COUNT(*) FROM challenge_participants cp WHERE cp.challenge_id = c.id) AS participant_count
+            FROM challenges c
+            WHERE {where}
+            ORDER BY c.start_at DESC, c.id DESC
+            LIMIT ? OFFSET ?
+            """,
+            params + [limit, offset],
+        )
+        rows = [_serialize_challenge(row, row['participant_count']) for row in cursor.fetchall()]
+        return {'challenges': rows, 'total': total}
+    finally:
+        conn.close()
+
+
+def get_challenge(challenge_key: str) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_challenge_statuses(cursor)
+        conn.commit()
+        challenge = _load_challenge(cursor, challenge_key=challenge_key)
+        cursor.execute(
+            """
+            SELECT cp.*, a.name AS agent_name
+            FROM challenge_participants cp
+            JOIN agents a ON a.id = cp.agent_id
+            WHERE cp.challenge_id = ?
+            ORDER BY COALESCE(cp.rank, 999999), cp.joined_at, cp.id
+            """,
+            (challenge['id'],),
+        )
+        participants = [dict(row) for row in cursor.fetchall()]
+        result = _serialize_challenge(challenge, len(participants))
+        result['participants'] = participants
+        return result
+    finally:
+        conn.close()
+
+
+def _resolve_variant(cursor: Any, experiment_key: Optional[str], agent_id: int, requested_variant: Optional[str]) -> Optional[str]:
+    variant_key = (requested_variant or '').strip() or None
+    if not experiment_key:
+        return variant_key
+
+    cursor.execute(
+        """
+        SELECT variant_key
+        FROM experiment_assignments
+        WHERE experiment_key = ? AND unit_type = 'agent' AND unit_id = ?
+        """,
+        (experiment_key, agent_id),
+    )
+    row = cursor.fetchone()
+    if row:
+        return row['variant_key']
+
+    if variant_key:
+        cursor.execute(
+            """
+            INSERT INTO experiment_assignments
+            (experiment_key, unit_type, unit_id, variant_key, assignment_reason, metadata_json, created_at)
+            VALUES (?, 'agent', ?, ?, 'challenge_join', ?, ?)
+            """,
+            (experiment_key, agent_id, variant_key, _json_dumps({'source': 'challenge_join'}), utc_now_iso_z()),
+        )
+    return variant_key
+
+
+def join_challenge(challenge_key: str, agent_id: int, data: Any = None) -> dict[str, Any]:
+    payload = _model_dump(data) if data is not None else {}
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        refresh_challenge_statuses(cursor)
+        challenge = _load_challenge(cursor, challenge_key=challenge_key)
+        if challenge['status'] not in {'upcoming', 'active'}:
+            raise ChallengeError('Challenge is not joinable')
+
+        cursor.execute(
+            """
+            SELECT cp.*, a.name AS agent_name
+            FROM challenge_participants cp
+            JOIN agents a ON a.id = cp.agent_id
+            WHERE cp.challenge_id = ? AND cp.agent_id = ?
+            """,
+            (challenge['id'], agent_id),
+        )
+        existing = cursor.fetchone()
+        if existing:
+            conn.commit()
+            return {'joined': False, 'idempotent': True, 'participant': dict(existing)}
+
+        variant_key = _resolve_variant(cursor, challenge.get('experiment_key'), agent_id, payload.get('variant_key'))
+        starting_cash = float(payload.get('starting_cash') or challenge.get('initial_capital') or 100000.0)
+        cursor.execute(
+            """
+            INSERT INTO challenge_participants
+            (challenge_id, agent_id, status, variant_key, joined_at, starting_cash)
+            VALUES (?, ?, 'joined', ?, ?, ?)
+            """,
+            (challenge['id'], agent_id, variant_key, utc_now_iso_z(), starting_cash),
+        )
+        participant_id = cursor.lastrowid
+        record_event(
+            'challenge_joined',
+            actor_agent_id=agent_id,
+            object_type='challenge_participant',
+            object_id=participant_id,
+            market=challenge['market'],
+            experiment_key=challenge.get('experiment_key'),
+            variant_key=variant_key,
+            metadata={'challenge_key': challenge['challenge_key'], 'challenge_id': challenge['id']},
+            cursor=cursor,
+        )
+        conn.commit()
+
+        cursor.execute(
+            """
+            SELECT cp.*, a.name AS agent_name
+            FROM challenge_participants cp
+            JOIN agents a ON a.id = cp.agent_id
+            WHERE cp.id = ?
+            """,
+            (participant_id,),
+        )
+        participant = dict(cursor.fetchone())
+        return {'joined': True, 'idempotent': False, 'participant': participant}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def create_submission(challenge_key: str, agent_id: int, data: Any) -> dict[str, Any]:
+    payload = _model_dump(data)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        challenge = _load_challenge(cursor, challenge_key=challenge_key)
+        submission = _create_submission_with_cursor(
+            cursor,
+            challenge,
+            agent_id,
+            payload.get('submission_type') or 'manual',
+            payload.get('content'),
+            payload.get('prediction_json'),
+            payload.get('signal_id'),
+        )
+        conn.commit()
+        return submission
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _create_submission_with_cursor(
+    cursor: Any,
+    challenge: dict[str, Any],
+    agent_id: int,
+    submission_type: str,
+    content: Optional[str],
+    prediction_json: Any,
+    signal_id: Optional[int] = None,
+) -> dict[str, Any]:
+    if challenge['status'] not in {'upcoming', 'active'}:
+        raise ChallengeError('Challenge is not accepting submissions')
+
+    cursor.execute(
+        """
+        SELECT *
+        FROM challenge_participants
+        WHERE challenge_id = ? AND agent_id = ?
+        """,
+        (challenge['id'], agent_id),
+    )
+    participant = cursor.fetchone()
+    if not participant:
+        raise ChallengeError('Agent must join challenge before submitting')
+
+    prediction_text = _json_dumps(prediction_json)
+    cursor.execute(
+        """
+        INSERT INTO challenge_submissions
+        (challenge_id, agent_id, signal_id, submission_type, content, prediction_json, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            challenge['id'],
+            agent_id,
+            signal_id,
+            submission_type,
+            content,
+            prediction_text,
+            utc_now_iso_z(),
+        ),
+    )
+    submission_id = cursor.lastrowid
+    record_event(
+        'challenge_submission_created',
+        actor_agent_id=agent_id,
+        object_type='challenge_submission',
+        object_id=submission_id,
+        market=challenge['market'],
+        experiment_key=challenge.get('experiment_key'),
+        variant_key=participant['variant_key'],
+        metadata={
+            'challenge_key': challenge['challenge_key'],
+            'submission_type': submission_type,
+            'signal_id': signal_id,
+        },
+        cursor=cursor,
+    )
+    return {
+        'id': submission_id,
+        'challenge_id': challenge['id'],
+        'agent_id': agent_id,
+        'signal_id': signal_id,
+        'submission_type': submission_type,
+        'content': content,
+        'prediction_json': prediction_text,
+    }
+
+
+def record_challenge_submission_from_signal(
+    cursor: Any,
+    *,
+    challenge_key: Optional[str],
+    agent_id: int,
+    signal_id: int,
+    submission_type: str,
+    content: Optional[str],
+    prediction_json: Any = None,
+) -> Optional[dict[str, Any]]:
+    if not challenge_key:
+        return None
+    challenge = _load_challenge(cursor, challenge_key=challenge_key)
+    return _create_submission_with_cursor(
+        cursor,
+        challenge,
+        agent_id,
+        submission_type,
+        content,
+        prediction_json,
+        signal_id,
+    )
+
+
+def record_challenge_trades_for_signal(
+    cursor: Any,
+    *,
+    agent_id: int,
+    source_signal_id: int,
+    market: str,
+    symbol: str,
+    side: str,
+    price: float,
+    quantity: float,
+    executed_at: str,
+) -> list[dict[str, Any]]:
+    refresh_challenge_statuses(cursor)
+    cursor.execute(
+        """
+        SELECT c.*, cp.variant_key
+        FROM challenges c
+        JOIN challenge_participants cp ON cp.challenge_id = c.id
+        WHERE cp.agent_id = ?
+          AND cp.status IN ('joined', 'active')
+          AND c.status = 'active'
+          AND c.market = ?
+          AND (c.symbol IS NULL OR c.symbol = '' OR c.symbol = 'all' OR c.symbol = ?)
+          AND c.start_at <= ?
+          AND c.end_at >= ?
+        ORDER BY c.id
+        """,
+        (agent_id, market, symbol, executed_at, executed_at),
+    )
+    challenges = cursor.fetchall()
+    recorded: list[dict[str, Any]] = []
+    for challenge_row in challenges:
+        challenge = _row_dict(challenge_row)
+        cursor.execute(
+            """
+            INSERT INTO challenge_trades
+            (challenge_id, agent_id, source_signal_id, market, symbol, side, price, quantity, executed_at, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                challenge['id'],
+                agent_id,
+                source_signal_id,
+                market,
+                symbol,
+                side,
+                price,
+                quantity,
+                executed_at,
+                utc_now_iso_z(),
+            ),
+        )
+        trade_id = cursor.lastrowid
+        record_event(
+            'challenge_trade_recorded',
+            actor_agent_id=agent_id,
+            object_type='challenge_trade',
+            object_id=trade_id,
+            market=market,
+            experiment_key=challenge.get('experiment_key'),
+            variant_key=challenge.get('variant_key'),
+            metadata={
+                'challenge_key': challenge['challenge_key'],
+                'challenge_id': challenge['id'],
+                'source_signal_id': source_signal_id,
+                'symbol': symbol,
+                'side': side,
+                'price': price,
+                'quantity': quantity,
+            },
+            cursor=cursor,
+        )
+        recorded.append({'id': trade_id, 'challenge_key': challenge['challenge_key']})
+    return recorded
+
+
+def _fetch_participants_and_trades(cursor: Any, challenge_id: int) -> tuple[list[dict[str, Any]], dict[int, list[dict[str, Any]]]]:
+    cursor.execute(
+        """
+        SELECT cp.*, a.name AS agent_name
+        FROM challenge_participants cp
+        JOIN agents a ON a.id = cp.agent_id
+        WHERE cp.challenge_id = ?
+        ORDER BY cp.joined_at, cp.id
+        """,
+        (challenge_id,),
+    )
+    participants = [dict(row) for row in cursor.fetchall()]
+
+    cursor.execute(
+        """
+        SELECT *
+        FROM challenge_trades
+        WHERE challenge_id = ?
+        ORDER BY agent_id, executed_at, id
+        """,
+        (challenge_id,),
+    )
+    trades_by_agent: dict[int, list[dict[str, Any]]] = {}
+    for row in cursor.fetchall():
+        trade = dict(row)
+        trades_by_agent.setdefault(trade['agent_id'], []).append(trade)
+
+    return participants, trades_by_agent
+
+
+def get_challenge_leaderboard(challenge_key: str) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_challenge_statuses(cursor)
+        conn.commit()
+        challenge = _load_challenge(cursor, challenge_key=challenge_key)
+        cursor.execute(
+            """
+            SELECT cr.*, a.name AS agent_name, cp.disqualified_reason, cp.trade_count
+            FROM challenge_results cr
+            JOIN agents a ON a.id = cr.agent_id
+            LEFT JOIN challenge_participants cp ON cp.challenge_id = cr.challenge_id AND cp.agent_id = cr.agent_id
+            WHERE cr.challenge_id = ?
+            ORDER BY COALESCE(cr.rank, 999999), cr.final_score DESC, cr.id
+            """,
+            (challenge['id'],),
+        )
+        result_rows = [dict(row) for row in cursor.fetchall()]
+        if result_rows:
+            return {'challenge': _serialize_challenge(challenge), 'leaderboard': result_rows, 'provisional': False}
+
+        participants, trades_by_agent = _fetch_participants_and_trades(cursor, challenge['id'])
+        scored = score_challenge_results(challenge, participants, trades_by_agent)
+        names = {item['agent_id']: item.get('agent_name') for item in participants}
+        for item in scored:
+            item['agent_name'] = names.get(item['agent_id'])
+            item['metrics_json'] = _json_dumps(item.get('metrics'))
+        scored.sort(key=lambda item: (item.get('rank') is None, item.get('rank') or 999999))
+        return {'challenge': _serialize_challenge(challenge), 'leaderboard': scored, 'provisional': True}
+    finally:
+        conn.close()
+
+
+def _reward_points_for_rank(rules: dict[str, Any], rank: Optional[int]) -> int:
+    if not rank or rules.get('grant_rewards') is False:
+        return 0
+    reward_points = rules.get('reward_points', DEFAULT_CHALLENGE_REWARDS)
+    if isinstance(reward_points, list):
+        return int(reward_points[rank - 1]) if rank - 1 < len(reward_points) else 0
+    if isinstance(reward_points, dict):
+        return int(reward_points.get(str(rank), reward_points.get(rank, 0)) or 0)
+    return 0
+
+
+def settle_challenge(challenge_key: str, *, force: bool = False) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        refresh_challenge_statuses(cursor)
+        challenge = _load_challenge(cursor, challenge_key=challenge_key)
+        if challenge['status'] == 'settled' and not force:
+            conn.commit()
+            return get_challenge_leaderboard(challenge_key)
+        if challenge['status'] == 'canceled':
+            raise ChallengeError('Canceled challenge cannot be settled')
+
+        participants, trades_by_agent = _fetch_participants_and_trades(cursor, challenge['id'])
+        scored = score_challenge_results(challenge, participants, trades_by_agent)
+        participant_by_agent = {item['agent_id']: item for item in participants}
+        rules = _json_loads(challenge.get('rules_json'), {}) or {}
+        now = utc_now_iso_z()
+
+        if force:
+            cursor.execute("DELETE FROM challenge_results WHERE challenge_id = ?", (challenge['id'],))
+
+        for result in scored:
+            participant = participant_by_agent[result['agent_id']]
+            metrics_json = _json_dumps(result['metrics'])
+            status = 'disqualified' if result.get('disqualified_reason') else 'settled'
+            cursor.execute(
+                """
+                UPDATE challenge_participants
+                SET status = ?, ending_value = ?, return_pct = ?, max_drawdown = ?,
+                    trade_count = ?, rank = ?, disqualified_reason = ?
+                WHERE challenge_id = ? AND agent_id = ?
+                """,
+                (
+                    status,
+                    result['ending_value'],
+                    result['return_pct'],
+                    result['max_drawdown'],
+                    result['trade_count'],
+                    result.get('rank'),
+                    result.get('disqualified_reason'),
+                    challenge['id'],
+                    result['agent_id'],
+                ),
+            )
+            cursor.execute(
+                """
+                INSERT INTO challenge_results
+                (challenge_id, agent_id, return_pct, max_drawdown, risk_adjusted_score,
+                 quality_score, final_score, rank, metrics_json, settled_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    challenge['id'],
+                    result['agent_id'],
+                    result['return_pct'],
+                    result['max_drawdown'],
+                    result['risk_adjusted_score'],
+                    result['quality_score'],
+                    result.get('final_score'),
+                    result.get('rank'),
+                    metrics_json,
+                    now,
+                ),
+            )
+
+            if result.get('disqualified_reason'):
+                record_event(
+                    'challenge_disqualified',
+                    actor_agent_id=result['agent_id'],
+                    object_type='challenge_participant',
+                    object_id=participant['id'],
+                    market=challenge['market'],
+                    experiment_key=challenge.get('experiment_key'),
+                    variant_key=participant.get('variant_key'),
+                    metadata={
+                        'challenge_key': challenge['challenge_key'],
+                        'reason': result['disqualified_reason'],
+                    },
+                    cursor=cursor,
+                )
+                continue
+
+            reward_points = _reward_points_for_rank(rules, result.get('rank'))
+            if reward_points > 0:
+                grant_agent_reward(
+                    result['agent_id'],
+                    reward_points,
+                    f"challenge_rank_{result['rank']}",
+                    source_type='challenge',
+                    source_id=challenge['id'],
+                    experiment_key=challenge.get('experiment_key'),
+                    variant_key=participant.get('variant_key'),
+                    metadata={'challenge_key': challenge['challenge_key'], 'rank': result.get('rank')},
+                    cursor=cursor,
+                )
+                record_event(
+                    'challenge_reward_granted',
+                    actor_agent_id=result['agent_id'],
+                    object_type='challenge',
+                    object_id=challenge['id'],
+                    market=challenge['market'],
+                    experiment_key=challenge.get('experiment_key'),
+                    variant_key=participant.get('variant_key'),
+                    metadata={
+                        'challenge_key': challenge['challenge_key'],
+                        'rank': result.get('rank'),
+                        'points': reward_points,
+                    },
+                    cursor=cursor,
+                )
+
+        cursor.execute(
+            """
+            UPDATE challenges
+            SET status = 'settled', settled_at = ?, updated_at = ?
+            WHERE id = ?
+            """,
+            (now, now, challenge['id']),
+        )
+        record_event(
+            'challenge_settled',
+            object_type='challenge',
+            object_id=challenge['id'],
+            market=challenge['market'],
+            experiment_key=challenge.get('experiment_key'),
+            metadata={'challenge_key': challenge['challenge_key'], 'participant_count': len(participants)},
+            cursor=cursor,
+        )
+        conn.commit()
+        return get_challenge_leaderboard(challenge_key)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def settle_due_challenges(limit: int = 20) -> list[dict[str, Any]]:
+    now = utc_now_iso_z()
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_challenge_statuses(cursor)
+        conn.commit()
+        cursor.execute(
+            """
+            SELECT challenge_key
+            FROM challenges
+            WHERE status = 'active' AND end_at <= ?
+            ORDER BY end_at ASC
+            LIMIT ?
+            """,
+            (now, max(1, min(limit, 100))),
+        )
+        keys = [row['challenge_key'] for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+    settled = []
+    for key in keys:
+        settled.append(settle_challenge(key))
+    return settled
+
+
+def cancel_challenge(challenge_key: str, agent_id: int) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        challenge = _load_challenge(cursor, challenge_key=challenge_key)
+        if challenge.get('created_by_agent_id') and challenge['created_by_agent_id'] != agent_id:
+            raise ChallengeError('Only the creator can cancel this challenge')
+        if challenge['status'] == 'settled':
+            raise ChallengeError('Settled challenge cannot be canceled')
+        now = utc_now_iso_z()
+        cursor.execute(
+            "UPDATE challenges SET status = 'canceled', updated_at = ? WHERE id = ?",
+            (now, challenge['id']),
+        )
+        conn.commit()
+        return get_challenge(challenge_key)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def get_agent_challenges(agent_id: int) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_challenge_statuses(cursor)
+        conn.commit()
+        cursor.execute(
+            """
+            SELECT c.*, cp.status AS participant_status, cp.variant_key, cp.joined_at,
+                   cp.return_pct, cp.max_drawdown, cp.trade_count, cp.rank,
+                   cp.disqualified_reason,
+                   (SELECT COUNT(*) FROM challenge_participants count_cp WHERE count_cp.challenge_id = c.id) AS participant_count
+            FROM challenge_participants cp
+            JOIN challenges c ON c.id = cp.challenge_id
+            WHERE cp.agent_id = ?
+            ORDER BY c.status = 'active' DESC, c.start_at DESC, c.id DESC
+            """,
+            (agent_id,),
+        )
+        return {'challenges': [_serialize_challenge(row, row['participant_count']) for row in cursor.fetchall()]}
+    finally:
+        conn.close()
+
+
+def get_challenge_submissions(challenge_key: str, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+    limit = max(1, min(limit, 500))
+    offset = max(0, offset)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        challenge = _load_challenge(cursor, challenge_key=challenge_key)
+        cursor.execute(
+            "SELECT COUNT(*) AS total FROM challenge_submissions WHERE challenge_id = ?",
+            (challenge['id'],),
+        )
+        total = cursor.fetchone()['total']
+        cursor.execute(
+            """
+            SELECT cs.*, a.name AS agent_name
+            FROM challenge_submissions cs
+            JOIN agents a ON a.id = cs.agent_id
+            WHERE cs.challenge_id = ?
+            ORDER BY cs.created_at DESC, cs.id DESC
+            LIMIT ? OFFSET ?
+            """,
+            (challenge['id'], limit, offset),
+        )
+        return {
+            'challenge': _serialize_challenge(challenge),
+            'submissions': [dict(row) for row in cursor.fetchall()],
+            'total': total,
+        }
+    finally:
+        conn.close()
+

--- a/service/server/database.py
+++ b/service/server/database.py
@@ -618,6 +618,171 @@ def init_database():
     """)
 
     cursor.execute("""
+        CREATE TABLE IF NOT EXISTS experiment_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT UNIQUE NOT NULL,
+            event_type TEXT NOT NULL,
+            actor_agent_id INTEGER,
+            target_agent_id INTEGER,
+            object_type TEXT,
+            object_id TEXT,
+            market TEXT,
+            experiment_key TEXT,
+            variant_key TEXT,
+            metadata_json TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (actor_agent_id) REFERENCES agents(id),
+            FOREIGN KEY (target_agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS experiments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            experiment_key TEXT UNIQUE NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            status TEXT DEFAULT 'draft',
+            unit_type TEXT DEFAULT 'agent',
+            variants_json TEXT,
+            start_at TEXT,
+            end_at TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now'))
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS experiment_assignments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            experiment_key TEXT NOT NULL,
+            unit_type TEXT NOT NULL,
+            unit_id INTEGER NOT NULL,
+            variant_key TEXT NOT NULL,
+            assignment_reason TEXT,
+            metadata_json TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(experiment_key, unit_type, unit_id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS agent_reward_ledger (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL,
+            amount INTEGER NOT NULL,
+            reason TEXT NOT NULL,
+            source_type TEXT,
+            source_id TEXT,
+            experiment_key TEXT,
+            variant_key TEXT,
+            status TEXT DEFAULT 'posted',
+            metadata_json TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            reversed_at TEXT,
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS challenges (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            challenge_key TEXT UNIQUE NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            market TEXT NOT NULL,
+            symbol TEXT,
+            challenge_type TEXT NOT NULL,
+            status TEXT DEFAULT 'upcoming',
+            scoring_method TEXT DEFAULT 'return-only',
+            initial_capital REAL DEFAULT 100000.0,
+            max_position_pct REAL DEFAULT 100.0,
+            max_drawdown_pct REAL DEFAULT 100.0,
+            start_at TEXT NOT NULL,
+            end_at TEXT NOT NULL,
+            settled_at TEXT,
+            rules_json TEXT,
+            experiment_key TEXT,
+            created_by_agent_id INTEGER,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (created_by_agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS challenge_participants (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            challenge_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            status TEXT DEFAULT 'joined',
+            variant_key TEXT,
+            joined_at TEXT DEFAULT (datetime('now')),
+            starting_cash REAL DEFAULT 100000.0,
+            ending_value REAL,
+            return_pct REAL,
+            max_drawdown REAL,
+            trade_count INTEGER DEFAULT 0,
+            rank INTEGER,
+            disqualified_reason TEXT,
+            UNIQUE(challenge_id, agent_id),
+            FOREIGN KEY (challenge_id) REFERENCES challenges(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS challenge_submissions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            challenge_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            signal_id INTEGER,
+            submission_type TEXT NOT NULL,
+            content TEXT,
+            prediction_json TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (challenge_id) REFERENCES challenges(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS challenge_trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            challenge_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            source_signal_id INTEGER NOT NULL,
+            market TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            side TEXT NOT NULL,
+            price REAL NOT NULL,
+            quantity REAL NOT NULL,
+            executed_at TEXT NOT NULL,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (challenge_id) REFERENCES challenges(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS challenge_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            challenge_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            return_pct REAL,
+            max_drawdown REAL,
+            risk_adjusted_score REAL,
+            quality_score REAL,
+            final_score REAL,
+            rank INTEGER,
+            metrics_json TEXT,
+            settled_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (challenge_id) REFERENCES challenges(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
         CREATE TABLE IF NOT EXISTS market_news_snapshots (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             category TEXT NOT NULL,
@@ -801,6 +966,86 @@ def init_database():
     cursor.execute("""
         CREATE INDEX IF NOT EXISTS idx_polymarket_settlements_agent
         ON polymarket_settlements(agent_id, settled_at DESC)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_experiment_events_type_created
+        ON experiment_events(event_type, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_experiment_events_actor_created
+        ON experiment_events(actor_agent_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_experiment_events_target_created
+        ON experiment_events(target_agent_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_experiment_events_experiment_variant_created
+        ON experiment_events(experiment_key, variant_key, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_experiment_events_object
+        ON experiment_events(object_type, object_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_experiment_assignments_experiment_variant
+        ON experiment_assignments(experiment_key, variant_key)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_agent_reward_ledger_agent_created
+        ON agent_reward_ledger(agent_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_agent_reward_ledger_source
+        ON agent_reward_ledger(source_type, source_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenges_status_end
+        ON challenges(status, end_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenges_key
+        ON challenges(challenge_key)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenge_participants_agent
+        ON challenge_participants(agent_id, status)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenge_participants_challenge_rank
+        ON challenge_participants(challenge_id, rank)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenge_submissions_challenge_created
+        ON challenge_submissions(challenge_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenge_trades_challenge_agent
+        ON challenge_trades(challenge_id, agent_id, executed_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenge_trades_source_signal
+        ON challenge_trades(source_signal_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_challenge_results_challenge_rank
+        ON challenge_results(challenge_id, rank)
     """)
 
     cursor.execute("""

--- a/service/server/experiment_events.py
+++ b/service/server/experiment_events.py
@@ -1,0 +1,91 @@
+"""Experiment event logging helpers."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Optional
+
+from database import get_db_connection
+from routes_shared import utc_now_iso_z
+
+
+def _json_dumps(value: Optional[dict[str, Any]]) -> Optional[str]:
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def record_event(
+    event_type: str,
+    *,
+    actor_agent_id: Optional[int] = None,
+    target_agent_id: Optional[int] = None,
+    object_type: Optional[str] = None,
+    object_id: Optional[Any] = None,
+    market: Optional[str] = None,
+    experiment_key: Optional[str] = None,
+    variant_key: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    cursor: Any = None,
+) -> str:
+    """Write an immutable experiment event and return its event_id."""
+    event_id = str(uuid.uuid4())
+    created_at = utc_now_iso_z()
+    own_connection = cursor is None
+
+    if own_connection:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        INSERT INTO experiment_events
+        (event_id, event_type, actor_agent_id, target_agent_id, object_type, object_id,
+         market, experiment_key, variant_key, metadata_json, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            event_id,
+            event_type,
+            actor_agent_id,
+            target_agent_id,
+            object_type,
+            str(object_id) if object_id is not None else None,
+            market,
+            experiment_key,
+            variant_key,
+            _json_dumps(metadata),
+            created_at,
+        ),
+    )
+
+    if own_connection:
+        conn.commit()
+        conn.close()
+
+    return event_id
+
+
+def record_reward_event(
+    agent_id: int,
+    amount: int,
+    reason: str,
+    *,
+    source_type: Optional[str] = None,
+    source_id: Optional[Any] = None,
+    experiment_key: Optional[str] = None,
+    variant_key: Optional[str] = None,
+    cursor: Any = None,
+) -> str:
+    return record_event(
+        'reward_granted',
+        actor_agent_id=agent_id,
+        object_type=source_type or 'reward',
+        object_id=source_id,
+        experiment_key=experiment_key,
+        variant_key=variant_key,
+        metadata={'amount': amount, 'reason': reason},
+        cursor=cursor,
+    )
+

--- a/service/server/research_exports.py
+++ b/service/server/research_exports.py
@@ -1,0 +1,178 @@
+"""Research CSV export helpers."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any, Optional
+
+from database import get_db_connection
+
+
+CHALLENGE_EXPORTS: dict[str, dict[str, Any]] = {
+    'challenges.csv': {
+        'table': 'challenges',
+        'alias': 'c',
+        'columns': [
+            'id', 'challenge_key', 'title', 'description', 'market', 'symbol',
+            'challenge_type', 'status', 'scoring_method', 'initial_capital',
+            'max_position_pct', 'max_drawdown_pct', 'start_at', 'end_at',
+            'settled_at', 'rules_json', 'experiment_key', 'created_by_agent_id',
+            'created_at', 'updated_at',
+        ],
+    },
+    'challenge_participants.csv': {
+        'table': 'challenge_participants',
+        'alias': 'cp',
+        'join': 'JOIN challenges c ON c.id = cp.challenge_id',
+        'columns': [
+            'id', 'challenge_id', 'agent_id', 'status', 'variant_key', 'joined_at',
+            'starting_cash', 'ending_value', 'return_pct', 'max_drawdown',
+            'trade_count', 'rank', 'disqualified_reason',
+        ],
+    },
+    'challenge_submissions.csv': {
+        'table': 'challenge_submissions',
+        'alias': 'cs',
+        'join': 'JOIN challenges c ON c.id = cs.challenge_id',
+        'columns': [
+            'id', 'challenge_id', 'agent_id', 'signal_id', 'submission_type',
+            'content', 'prediction_json', 'created_at',
+        ],
+    },
+    'challenge_trades.csv': {
+        'table': 'challenge_trades',
+        'alias': 'ct',
+        'join': 'JOIN challenges c ON c.id = ct.challenge_id',
+        'columns': [
+            'id', 'challenge_id', 'agent_id', 'source_signal_id', 'market',
+            'symbol', 'side', 'price', 'quantity', 'executed_at', 'created_at',
+        ],
+    },
+    'challenge_results.csv': {
+        'table': 'challenge_results',
+        'alias': 'cr',
+        'join': 'JOIN challenges c ON c.id = cr.challenge_id',
+        'columns': [
+            'id', 'challenge_id', 'agent_id', 'return_pct', 'max_drawdown',
+            'risk_adjusted_score', 'quality_score', 'final_score', 'rank',
+            'metrics_json', 'settled_at',
+        ],
+    },
+}
+
+
+def _build_challenge_filters(
+    alias: str,
+    *,
+    start_at: Optional[str] = None,
+    end_at: Optional[str] = None,
+    experiment_key: Optional[str] = None,
+    challenge_key: Optional[str] = None,
+    market: Optional[str] = None,
+) -> tuple[str, list[Any]]:
+    conditions = []
+    params: list[Any] = []
+    challenge_alias = alias if alias == 'c' else 'c'
+
+    if start_at:
+        conditions.append(f"{challenge_alias}.end_at >= ?")
+        params.append(start_at)
+    if end_at:
+        conditions.append(f"{challenge_alias}.start_at <= ?")
+        params.append(end_at)
+    if experiment_key:
+        conditions.append(f"{challenge_alias}.experiment_key = ?")
+        params.append(experiment_key)
+    if challenge_key:
+        conditions.append(f"{challenge_alias}.challenge_key = ?")
+        params.append(challenge_key)
+    if market:
+        conditions.append(f"{challenge_alias}.market = ?")
+        params.append(market)
+
+    return (' WHERE ' + ' AND '.join(conditions)) if conditions else '', params
+
+
+def fetch_challenge_export_rows(
+    filename: str,
+    *,
+    start_at: Optional[str] = None,
+    end_at: Optional[str] = None,
+    experiment_key: Optional[str] = None,
+    challenge_key: Optional[str] = None,
+    market: Optional[str] = None,
+    limit: int = 100000,
+    offset: int = 0,
+) -> tuple[list[str], list[dict[str, Any]]]:
+    config = CHALLENGE_EXPORTS.get(filename)
+    if not config:
+        raise ValueError(f'Unsupported challenge export: {filename}')
+
+    alias = config['alias']
+    columns = config['columns']
+    select_columns = ', '.join(f'{alias}.{column} AS {column}' for column in columns)
+    join = f" {config['join']}" if config.get('join') else ''
+    where, params = _build_challenge_filters(
+        alias,
+        start_at=start_at,
+        end_at=end_at,
+        experiment_key=experiment_key,
+        challenge_key=challenge_key,
+        market=market,
+    )
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        f"""
+        SELECT {select_columns}
+        FROM {config['table']} {alias}
+        {join}
+        {where}
+        ORDER BY {alias}.id
+        LIMIT ? OFFSET ?
+        """,
+        params + [max(1, min(limit, 100000)), max(0, offset)],
+    )
+    rows = [dict(row) for row in cursor.fetchall()]
+    conn.close()
+    return columns, rows
+
+
+def write_csv(path: Path, columns: list[str], rows: list[dict[str, Any]]) -> None:
+    with path.open('w', newline='', encoding='utf-8') as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns, extrasaction='ignore')
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def export_challenge_tables(
+    output_dir: str | Path,
+    *,
+    start_at: Optional[str] = None,
+    end_at: Optional[str] = None,
+    experiment_key: Optional[str] = None,
+    challenge_key: Optional[str] = None,
+    market: Optional[str] = None,
+) -> dict[str, str]:
+    target_dir = Path(output_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    written: dict[str, str] = {}
+
+    for filename in CHALLENGE_EXPORTS:
+        columns, rows = fetch_challenge_export_rows(
+            filename,
+            start_at=start_at,
+            end_at=end_at,
+            experiment_key=experiment_key,
+            challenge_key=challenge_key,
+            market=market,
+        )
+        path = target_dir / filename
+        write_csv(path, columns, rows)
+        written[filename] = str(path)
+
+    return written
+

--- a/service/server/rewards.py
+++ b/service/server/rewards.py
@@ -1,0 +1,171 @@
+"""Agent reward ledger service."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from database import begin_write_transaction, get_db_connection
+from routes_shared import utc_now_iso_z
+
+
+def _json_dumps(value: Optional[dict[str, Any]]) -> Optional[str]:
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def grant_agent_reward(
+    agent_id: int,
+    amount: int,
+    reason: str,
+    *,
+    source_type: Optional[str] = None,
+    source_id: Optional[Any] = None,
+    experiment_key: Optional[str] = None,
+    variant_key: Optional[str] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    cursor: Any = None,
+) -> dict[str, Any]:
+    """Post a reward ledger entry and update the agent point balance.
+
+    When source_type/source_id are provided, the grant is idempotent for the
+    same agent, reason, and source.
+    """
+    amount = int(amount)
+    if amount == 0:
+        return {'success': False, 'skipped': True, 'reason': 'zero_amount'}
+
+    own_connection = cursor is None
+    if own_connection:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        begin_write_transaction(cursor)
+
+    source_id_text = str(source_id) if source_id is not None else None
+    try:
+        if source_type and source_id_text:
+            cursor.execute(
+                """
+                SELECT id, amount, status
+                FROM agent_reward_ledger
+                WHERE agent_id = ? AND reason = ? AND source_type = ? AND source_id = ?
+                  AND status = 'posted'
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (agent_id, reason, source_type, source_id_text),
+            )
+            existing = cursor.fetchone()
+            if existing:
+                if own_connection:
+                    conn.commit()
+                    conn.close()
+                return {
+                    'success': True,
+                    'idempotent': True,
+                    'ledger_id': existing['id'],
+                    'amount': existing['amount'],
+                }
+
+        cursor.execute(
+            """
+            INSERT INTO agent_reward_ledger
+            (agent_id, amount, reason, source_type, source_id, experiment_key,
+             variant_key, status, metadata_json, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'posted', ?, ?)
+            """,
+            (
+                agent_id,
+                amount,
+                reason,
+                source_type,
+                source_id_text,
+                experiment_key,
+                variant_key,
+                _json_dumps(metadata),
+                utc_now_iso_z(),
+            ),
+        )
+        ledger_id = cursor.lastrowid
+        cursor.execute("UPDATE agents SET points = points + ? WHERE id = ?", (amount, agent_id))
+
+        if own_connection:
+            conn.commit()
+            conn.close()
+
+        return {'success': True, 'ledger_id': ledger_id, 'amount': amount}
+    except Exception:
+        if own_connection:
+            conn.rollback()
+            conn.close()
+        raise
+
+
+def reverse_agent_reward(
+    ledger_id: int,
+    *,
+    reason: str = 'reversed',
+    cursor: Any = None,
+) -> dict[str, Any]:
+    own_connection = cursor is None
+    if own_connection:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        begin_write_transaction(cursor)
+
+    try:
+        cursor.execute(
+            """
+            SELECT id, agent_id, amount, status
+            FROM agent_reward_ledger
+            WHERE id = ?
+            """,
+            (ledger_id,),
+        )
+        row = cursor.fetchone()
+        if not row or row['status'] != 'posted':
+            if own_connection:
+                conn.commit()
+                conn.close()
+            return {'success': False, 'reversed': False}
+
+        cursor.execute(
+            """
+            UPDATE agent_reward_ledger
+            SET status = ?, reversed_at = ?
+            WHERE id = ?
+            """,
+            (reason, utc_now_iso_z(), ledger_id),
+        )
+        cursor.execute("UPDATE agents SET points = points - ? WHERE id = ?", (row['amount'], row['agent_id']))
+
+        if own_connection:
+            conn.commit()
+            conn.close()
+
+        return {'success': True, 'reversed': True, 'amount': row['amount']}
+    except Exception:
+        if own_connection:
+            conn.rollback()
+            conn.close()
+        raise
+
+
+def get_agent_reward_history(agent_id: int, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT *
+        FROM agent_reward_ledger
+        WHERE agent_id = ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ? OFFSET ?
+        """,
+        (agent_id, max(1, min(limit, 500)), max(0, offset)),
+    )
+    rows = [dict(row) for row in cursor.fetchall()]
+    conn.close()
+    return rows
+

--- a/service/server/routes.py
+++ b/service/server/routes.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from config import CORS_ORIGINS
 from routes_agent import register_agent_routes
+from routes_challenges import register_challenge_routes
 from routes_market import register_market_routes
 from routes_misc import register_misc_routes
 from routes_shared import RouteContext
@@ -42,6 +43,7 @@ def create_app() -> FastAPI:
     register_agent_routes(app, ctx)
     register_signal_routes(app, ctx)
     register_trading_routes(app, ctx)
+    register_challenge_routes(app, ctx)
     register_user_routes(app, ctx)
     register_misc_routes(app)
     return app

--- a/service/server/routes_challenges.py
+++ b/service/server/routes_challenges.py
@@ -1,0 +1,145 @@
+"""Challenge API routes."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Header, HTTPException
+
+from challenges import (
+    ChallengeError,
+    ChallengeNotFound,
+    cancel_challenge,
+    create_challenge,
+    create_submission,
+    get_agent_challenges,
+    get_challenge,
+    get_challenge_leaderboard,
+    get_challenge_submissions,
+    join_challenge,
+    list_challenges,
+    settle_challenge,
+)
+from routes_models import (
+    ChallengeCreateRequest,
+    ChallengeJoinRequest,
+    ChallengeSettleRequest,
+    ChallengeSubmissionRequest,
+)
+from routes_shared import RouteContext
+from services import _get_agent_by_token
+from utils import _extract_token
+
+
+def _to_http_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, ChallengeNotFound):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, ChallengeError):
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail=f'Challenge request failed: {exc}')
+
+
+def _require_agent(authorization: str | None) -> dict:
+    token = _extract_token(authorization)
+    agent = _get_agent_by_token(token)
+    if not agent:
+        raise HTTPException(status_code=401, detail='Invalid token')
+    return agent
+
+
+def _require_challenge_creator(challenge_key: str, agent_id: int) -> None:
+    challenge = get_challenge(challenge_key)
+    creator_id = challenge.get('created_by_agent_id')
+    if creator_id and creator_id != agent_id:
+        raise HTTPException(status_code=403, detail='Only the challenge creator can perform this action')
+
+
+def register_challenge_routes(app: FastAPI, ctx: RouteContext) -> None:
+    @app.get('/api/challenges')
+    async def api_list_challenges(status: str | None = None, limit: int = 50, offset: int = 0):
+        try:
+            return list_challenges(status=status, limit=limit, offset=offset)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post('/api/challenges')
+    async def api_create_challenge(data: ChallengeCreateRequest, authorization: str = Header(None)):
+        agent = _require_agent(authorization)
+        try:
+            return create_challenge(data, agent['id'])
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get('/api/challenges/me')
+    async def api_my_challenges(authorization: str = Header(None)):
+        agent = _require_agent(authorization)
+        try:
+            return get_agent_challenges(agent['id'])
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get('/api/challenges/{challenge_key}/leaderboard')
+    async def api_challenge_leaderboard(challenge_key: str):
+        try:
+            return get_challenge_leaderboard(challenge_key)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get('/api/challenges/{challenge_key}/submissions')
+    async def api_challenge_submissions(challenge_key: str, limit: int = 100, offset: int = 0):
+        try:
+            return get_challenge_submissions(challenge_key, limit=limit, offset=offset)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post('/api/challenges/{challenge_key}/join')
+    async def api_join_challenge(
+        challenge_key: str,
+        data: ChallengeJoinRequest | None = None,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            return join_challenge(challenge_key, agent['id'], data)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post('/api/challenges/{challenge_key}/submit')
+    async def api_submit_challenge(
+        challenge_key: str,
+        data: ChallengeSubmissionRequest,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            return create_submission(challenge_key, agent['id'], data)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post('/api/challenges/{challenge_key}/settle')
+    async def api_settle_challenge(
+        challenge_key: str,
+        data: ChallengeSettleRequest | None = None,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            _require_challenge_creator(challenge_key, agent['id'])
+            return settle_challenge(challenge_key, force=bool(data.force if data else False))
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post('/api/challenges/{challenge_key}/cancel')
+    async def api_cancel_challenge(challenge_key: str, authorization: str = Header(None)):
+        agent = _require_agent(authorization)
+        try:
+            return cancel_challenge(challenge_key, agent['id'])
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get('/api/challenges/{challenge_key}')
+    async def api_get_challenge(challenge_key: str):
+        try:
+            return get_challenge(challenge_key)
+        except Exception as exc:
+            raise _to_http_error(exc)

--- a/service/server/routes_models.py
+++ b/service/server/routes_models.py
@@ -59,6 +59,7 @@ class StrategyRequest(BaseModel):
     content: str
     symbols: Optional[str] = None
     tags: Optional[str] = None
+    challenge_key: Optional[str] = None
 
 
 class DiscussionRequest(BaseModel):
@@ -66,6 +67,42 @@ class DiscussionRequest(BaseModel):
     symbol: Optional[str] = None
     title: str
     content: str
+    tags: Optional[str] = None
+    challenge_key: Optional[str] = None
+
+
+class ChallengeCreateRequest(BaseModel):
+    challenge_key: Optional[str] = None
+    title: str
+    description: Optional[str] = None
+    market: str
+    symbol: Optional[str] = None
+    challenge_type: str = "multi-agent"
+    status: Optional[str] = None
+    scoring_method: str = "return-only"
+    initial_capital: float = 100000.0
+    max_position_pct: float = 100.0
+    max_drawdown_pct: float = 100.0
+    start_at: Optional[str] = None
+    end_at: Optional[str] = None
+    rules_json: Optional[Dict[str, Any]] = None
+    experiment_key: Optional[str] = None
+
+
+class ChallengeJoinRequest(BaseModel):
+    variant_key: Optional[str] = None
+    starting_cash: Optional[float] = None
+
+
+class ChallengeSubmissionRequest(BaseModel):
+    submission_type: str = "manual"
+    content: Optional[str] = None
+    prediction_json: Optional[Dict[str, Any]] = None
+    signal_id: Optional[int] = None
+
+
+class ChallengeSettleRequest(BaseModel):
+    force: bool = False
 
 
 class ReplyRequest(BaseModel):

--- a/service/server/routes_signals.py
+++ b/service/server/routes_signals.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI, Header, HTTPException
 from zoneinfo import ZoneInfo
 
 from cache import get_json, set_json
+from challenges import ChallengeError, record_challenge_submission_from_signal, record_challenge_trades_for_signal
 from config import (
     DISCUSSION_PUBLISH_REWARD,
     REPLY_PUBLISH_REWARD,
@@ -176,6 +177,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
         trade_value = price * qty
         fee = trade_value * TRADE_FEE_RATE
         position_entry_price = None
+        challenge_trade_count = 0
 
         conn = get_db_connection()
         cursor = conn.cursor()
@@ -257,6 +259,18 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                     raise HTTPException(status_code=400, detail='Short position entry price is missing')
                 cover_credit = ((2 * position_entry_price) - price) * qty - fee
                 cursor.execute('UPDATE agents SET cash = cash + ? WHERE id = ?', (cover_credit, agent_id))
+
+            challenge_trade_count += len(record_challenge_trades_for_signal(
+                cursor,
+                agent_id=agent_id,
+                source_signal_id=signal_id,
+                market=data.market,
+                symbol=data.symbol,
+                side=side,
+                price=price,
+                quantity=qty,
+                executed_at=executed_at,
+            ))
 
             conn.commit()
         except HTTPException:
@@ -366,6 +380,18 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                         follower_net = ((2 * follower_entry_price) - price) * qty - follower_fee
                         cursor.execute('UPDATE agents SET cash = cash + ? WHERE id = ?', (follower_net, follower_id))
 
+                    challenge_trade_count += len(record_challenge_trades_for_signal(
+                        cursor,
+                        agent_id=follower_id,
+                        source_signal_id=follower_signal_id,
+                        market=data.market,
+                        symbol=data.symbol,
+                        side=side,
+                        price=price,
+                        quantity=qty,
+                        executed_at=executed_at,
+                    ))
+
                     cursor.execute(f'RELEASE SAVEPOINT follower_{follower_id}')
                     follower_count += 1
                 except Exception:
@@ -396,6 +422,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
             'points_earned': SIGNAL_PUBLISH_REWARD,
             'token_id': polymarket_token_id,
             'outcome': polymarket_outcome,
+            'challenge_trade_count': challenge_trade_count,
         }
         if data.market == 'polymarket':
             decorate_polymarket_item(payload, fetch_remote=fetch_price_in_request)
@@ -415,25 +442,44 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
 
         conn = get_db_connection()
         cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT INTO signals
-            (signal_id, agent_id, message_type, market, signal_type, title, content, symbols, tags, timestamp, created_at)
-            VALUES (?, ?, 'strategy', ?, 'strategy', ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                signal_id,
-                agent_id,
-                data.market,
-                data.title,
-                data.content,
-                data.symbols,
-                data.tags,
-                int(datetime.now(timezone.utc).timestamp()),
-                now,
-            ),
-        )
-        conn.commit()
+        try:
+            cursor.execute(
+                """
+                INSERT INTO signals
+                (signal_id, agent_id, message_type, market, signal_type, title, content, symbols, tags, timestamp, created_at)
+                VALUES (?, ?, 'strategy', ?, 'strategy', ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    signal_id,
+                    agent_id,
+                    data.market,
+                    data.title,
+                    data.content,
+                    data.symbols,
+                    data.tags,
+                    int(datetime.now(timezone.utc).timestamp()),
+                    now,
+                ),
+            )
+            if data.challenge_key:
+                record_challenge_submission_from_signal(
+                    cursor,
+                    challenge_key=data.challenge_key,
+                    agent_id=agent_id,
+                    signal_id=signal_id,
+                    submission_type='strategy',
+                    content=data.content,
+                    prediction_json=None,
+                )
+            conn.commit()
+        except ChallengeError as exc:
+            conn.rollback()
+            conn.close()
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:
+            conn.rollback()
+            conn.close()
+            raise HTTPException(status_code=500, detail=f'Failed to publish strategy: {exc}')
         conn.close()
 
         invalidate_signal_read_caches(ctx)
@@ -472,24 +518,44 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
 
         conn = get_db_connection()
         cursor = conn.cursor()
-        cursor.execute(
-            """
-            INSERT INTO signals
-            (signal_id, agent_id, message_type, market, signal_type, symbol, title, content, timestamp, created_at)
-            VALUES (?, ?, 'discussion', ?, 'discussion', ?, ?, ?, ?, ?)
-            """,
-            (
-                signal_id,
-                agent_id,
-                data.market,
-                data.symbol,
-                data.title,
-                data.content,
-                int(datetime.now(timezone.utc).timestamp()),
-                now,
-            ),
-        )
-        conn.commit()
+        try:
+            cursor.execute(
+                """
+                INSERT INTO signals
+                (signal_id, agent_id, message_type, market, signal_type, symbol, title, content, tags, timestamp, created_at)
+                VALUES (?, ?, 'discussion', ?, 'discussion', ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    signal_id,
+                    agent_id,
+                    data.market,
+                    data.symbol,
+                    data.title,
+                    data.content,
+                    data.tags,
+                    int(datetime.now(timezone.utc).timestamp()),
+                    now,
+                ),
+            )
+            if data.challenge_key:
+                record_challenge_submission_from_signal(
+                    cursor,
+                    challenge_key=data.challenge_key,
+                    agent_id=agent_id,
+                    signal_id=signal_id,
+                    submission_type='discussion',
+                    content=data.content,
+                    prediction_json=None,
+                )
+            conn.commit()
+        except ChallengeError as exc:
+            conn.rollback()
+            conn.close()
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:
+            conn.rollback()
+            conn.close()
+            raise HTTPException(status_code=500, detail=f'Failed to publish discussion: {exc}')
         conn.close()
 
         invalidate_signal_read_caches(ctx)

--- a/service/server/routes_trading.py
+++ b/service/server/routes_trading.py
@@ -28,6 +28,16 @@ from services import _get_agent_by_token
 from utils import _extract_token
 
 
+INITIAL_CAPITAL = 100000.0
+
+
+def profit_percent_for_display(profit: float, deposited: float) -> float:
+    base_capital = INITIAL_CAPITAL + (deposited or 0)
+    if base_capital <= 0:
+        return 0.0
+    return clamp_profit_for_display(profit) / base_capital * 100
+
+
 def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
     @app.get('/api/profit/history')
     async def get_profit_history(
@@ -44,6 +54,7 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
         now_ts = time.time()
         redis_cache_key = (
             f'{LEADERBOARD_CACHE_KEY_PREFIX}:'
+            f'metric=return_percent:'
             f'limit={limit}:days={days}:offset={offset}:history={int(include_history)}'
         )
 
@@ -77,6 +88,7 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
             SELECT
                 a.id AS agent_id,
                 a.name,
+                COALESCE(a.deposited, 0) AS deposited,
                 (
                     COALESCE(a.cash, 0) +
                     COALESCE(
@@ -89,8 +101,24 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
                         ),
                         0
                     ) -
-                    (100000.0 + COALESCE(a.deposited, 0))
+                    (? + COALESCE(a.deposited, 0))
                 ) AS profit,
+                (
+                    (
+                        COALESCE(a.cash, 0) +
+                        COALESCE(
+                            SUM(
+                                CASE
+                                    WHEN p.current_price IS NULL THEN p.entry_price * ABS(p.quantity)
+                                    WHEN p.side = 'long' THEN p.current_price * ABS(p.quantity)
+                                    ELSE (2 * p.entry_price - p.current_price) * ABS(p.quantity)
+                                END
+                            ),
+                            0
+                        ) -
+                        (? + COALESCE(a.deposited, 0))
+                    ) / NULLIF((? + COALESCE(a.deposited, 0)), 0) * 100
+                ) AS profit_percent,
                 (
                     SELECT MAX(ph.recorded_at)
                     FROM profit_history ph
@@ -99,16 +127,18 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
             FROM agents a
             LEFT JOIN positions p ON p.agent_id = a.id
             GROUP BY a.id, a.name, a.cash, a.deposited
-            ORDER BY profit DESC
+            ORDER BY profit_percent DESC
             LIMIT ? OFFSET ?
             """,
-            (cutoff, limit, offset),
+            (INITIAL_CAPITAL, INITIAL_CAPITAL, INITIAL_CAPITAL, cutoff, limit, offset),
         )
         top_agents = [
             {
                 'agent_id': row['agent_id'],
                 'name': row['name'],
+                'deposited': row['deposited'],
                 'profit': clamp_profit_for_display(row['profit']),
+                'profit_percent': row['profit_percent'] or 0,
                 'recorded_at': row['recorded_at'] or live_snapshot_recorded_at,
             }
             for row in cursor.fetchall()
@@ -161,21 +191,30 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
                 )
                 history = cursor.fetchall()
                 history_points = [
-                    {'profit': clamp_profit_for_display(h['profit']), 'recorded_at': h['recorded_at']}
+                    {
+                        'profit': clamp_profit_for_display(h['profit']),
+                        'profit_percent': profit_percent_for_display(h['profit'], agent['deposited']),
+                        'recorded_at': h['recorded_at'],
+                    }
                     for h in history
                 ]
 
             if include_history and (not history_points or history_points[-1]['recorded_at'] != live_snapshot_recorded_at):
                 history_points.append({
                     'profit': clamp_profit_for_display(agent['profit']),
+                    'profit_percent': profit_percent_for_display(agent['profit'], agent['deposited']),
                     'recorded_at': live_snapshot_recorded_at,
                 })
 
+            current_profit_percent = profit_percent_for_display(agent['profit'], agent['deposited'])
             result.append({
                 'agent_id': agent['agent_id'],
                 'name': agent['name'],
+                'deposited': agent['deposited'],
                 'total_profit': clamp_profit_for_display(agent['profit']),
                 'current_profit': clamp_profit_for_display(agent['profit']),
+                'total_profit_percent': current_profit_percent,
+                'current_profit_percent': current_profit_percent,
                 'trade_count': trade_counts.get(agent['agent_id'], 0),
                 'recent_strategy_count_7d': 0,
                 'recent_discussion_count_7d': 0,

--- a/service/server/scripts/cleanup_dirty_trade_data.py
+++ b/service/server/scripts/cleanup_dirty_trade_data.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""
+Targeted cleanup for known dirty trade data that inflated the leaderboard.
+
+What this script does:
+- backs up the affected agents, signals, positions, and profit history
+- removes clearly invalid operation signals
+- rebuilds cash and positions for affected agents from the remaining operation history
+- deletes stale profit_history rows for affected agents so charts can repopulate cleanly
+- clears Redis-backed leaderboard/signal caches when available
+
+Usage:
+  cd /home/AI-Trader/service/server
+  python3 scripts/cleanup_dirty_trade_data.py --dry-run
+  python3 scripts/cleanup_dirty_trade_data.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from cache import delete, delete_pattern
+from database import get_db_connection
+from fees import TRADE_FEE_RATE
+from routes_shared import (
+    AGENT_SIGNALS_CACHE_KEY_PREFIX,
+    GROUPED_SIGNALS_CACHE_KEY_PREFIX,
+    LEADERBOARD_CACHE_KEY_PREFIX,
+    TRENDING_CACHE_KEY,
+)
+
+
+INITIAL_CAPITAL = 100000.0
+EPSILON = 1e-9
+BACKUP_DIR = SERVER_DIR / "data" / "repair_backups"
+
+
+@dataclass
+class PositionState:
+    symbol: str
+    market: str
+    token_id: str | None
+    outcome: str | None
+    side: str
+    quantity: float
+    entry_price: float
+    current_price: float | None
+    opened_at: str
+    leader_id: int | None
+
+
+def now_z() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+        if not math.isfinite(parsed):
+            return default
+        return parsed
+    except (TypeError, ValueError):
+        return default
+
+
+def row_dict(row: Any) -> dict[str, Any]:
+    if isinstance(row, dict):
+        return dict(row)
+    return {key: row[key] for key in row.keys()}
+
+
+def instrument_key(row: dict[str, Any]) -> tuple[str, str, str, str]:
+    market = str(row.get("market") or "")
+    if market == "polymarket":
+        return (
+            market,
+            str(row.get("token_id") or row.get("symbol") or ""),
+            str(row.get("outcome") or ""),
+            str(row.get("symbol") or ""),
+        )
+    return (
+        market,
+        str(row.get("symbol") or ""),
+        "",
+        "",
+    )
+
+
+def suspicious_reasons(signal: dict[str, Any]) -> list[str]:
+    market = str(signal.get("market") or "").lower()
+    symbol = str(signal.get("symbol") or "").upper()
+    entry_price = to_float(signal.get("entry_price"))
+
+    reasons: list[str] = []
+    if market == "polymarket" and entry_price > 1.0 + EPSILON:
+        reasons.append("polymarket_price_gt_1")
+    if market == "crypto" and symbol in {"AAPL", "TSLA"}:
+        reasons.append("stock_symbol_in_crypto_market")
+    if market == "crypto" and symbol == "BTC" and entry_price < 1000.0 - EPSILON:
+        reasons.append("btc_price_too_low")
+    if market == "crypto" and symbol == "ETH" and entry_price < 100.0 - EPSILON:
+        reasons.append("eth_price_too_low")
+    return reasons
+
+
+def fetch_all(cursor: Any, query: str, params: Iterable[Any] | None = None) -> list[dict[str, Any]]:
+    cursor.execute(query, params or ())
+    return [row_dict(row) for row in cursor.fetchall()]
+
+
+def load_suspicious_operation_signals(cursor: Any) -> list[dict[str, Any]]:
+    rows = fetch_all(
+        cursor,
+        """
+        SELECT
+            s.*,
+            a.name AS agent_name
+        FROM signals s
+        JOIN agents a ON a.id = s.agent_id
+        WHERE s.message_type = 'operation'
+          AND (
+            (s.market = 'polymarket' AND s.entry_price > 1.0)
+            OR (s.market = 'crypto' AND s.symbol IN ('AAPL', 'TSLA'))
+            OR (s.market = 'crypto' AND s.symbol = 'BTC' AND s.entry_price < 1000.0)
+            OR (s.market = 'crypto' AND s.symbol = 'ETH' AND s.entry_price < 100.0)
+          )
+        ORDER BY a.name, COALESCE(s.executed_at, s.created_at), s.id
+        """,
+    )
+    for row in rows:
+        row["suspicious_reasons"] = suspicious_reasons(row)
+    return rows
+
+
+def load_agent_rows(cursor: Any, agent_ids: list[int]) -> list[dict[str, Any]]:
+    placeholders = ",".join("?" for _ in agent_ids)
+    return fetch_all(
+        cursor,
+        f"SELECT * FROM agents WHERE id IN ({placeholders}) ORDER BY id",
+        agent_ids,
+    )
+
+
+def load_agent_positions(cursor: Any, agent_ids: list[int]) -> list[dict[str, Any]]:
+    placeholders = ",".join("?" for _ in agent_ids)
+    return fetch_all(
+        cursor,
+        f"""
+        SELECT *
+        FROM positions
+        WHERE agent_id IN ({placeholders})
+        ORDER BY agent_id, market, symbol, token_id
+        """,
+        agent_ids,
+    )
+
+
+def load_agent_signals(cursor: Any, agent_ids: list[int]) -> list[dict[str, Any]]:
+    placeholders = ",".join("?" for _ in agent_ids)
+    return fetch_all(
+        cursor,
+        f"""
+        SELECT *
+        FROM signals
+        WHERE agent_id IN ({placeholders})
+        ORDER BY agent_id, COALESCE(executed_at, created_at), id
+        """,
+        agent_ids,
+    )
+
+
+def load_agent_profit_history(cursor: Any, agent_ids: list[int]) -> list[dict[str, Any]]:
+    placeholders = ",".join("?" for _ in agent_ids)
+    return fetch_all(
+        cursor,
+        f"""
+        SELECT *
+        FROM profit_history
+        WHERE agent_id IN ({placeholders})
+        ORDER BY agent_id, recorded_at, id
+        """,
+        agent_ids,
+    )
+
+
+def build_backup_payload(cursor: Any, suspicious_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    agent_ids = sorted({int(row["agent_id"]) for row in suspicious_rows})
+    return {
+        "captured_at": now_z(),
+        "affected_agent_ids": agent_ids,
+        "suspicious_operation_signals": suspicious_rows,
+        "agents": load_agent_rows(cursor, agent_ids),
+        "positions": load_agent_positions(cursor, agent_ids),
+        "signals": load_agent_signals(cursor, agent_ids),
+        "profit_history": load_agent_profit_history(cursor, agent_ids),
+    }
+
+
+def write_backup(payload: dict[str, Any]) -> Path:
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    backup_path = BACKUP_DIR / f"dirty_trade_cleanup_backup_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    backup_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
+    return backup_path
+
+
+def previous_position_index(rows: list[dict[str, Any]]) -> dict[int, dict[tuple[str, str, str, str], dict[str, Any]]]:
+    indexed: dict[int, dict[tuple[str, str, str, str], dict[str, Any]]] = defaultdict(dict)
+    for row in rows:
+        indexed[int(row["agent_id"])][instrument_key(row)] = row
+    return indexed
+
+
+def create_position_from_signal(signal: dict[str, Any], quantity: float, side: str) -> PositionState:
+    return PositionState(
+        symbol=str(signal.get("symbol") or ""),
+        market=str(signal.get("market") or ""),
+        token_id=(str(signal.get("token_id")) if signal.get("token_id") is not None else None),
+        outcome=(str(signal.get("outcome")) if signal.get("outcome") is not None else None),
+        side=side,
+        quantity=quantity,
+        entry_price=to_float(signal.get("entry_price")),
+        current_price=None,
+        opened_at=str(signal.get("executed_at") or signal.get("created_at") or now_z()),
+        leader_id=None,
+    )
+
+
+def replay_agent_operations(
+    agent: dict[str, Any],
+    operation_rows: list[dict[str, Any]],
+    suspicious_ids: set[int],
+    previous_positions_by_key: dict[tuple[str, str, str, str], dict[str, Any]],
+) -> tuple[float, list[PositionState], list[dict[str, Any]]]:
+    cash = INITIAL_CAPITAL + to_float(agent.get("deposited"))
+    positions: dict[tuple[str, str, str, str], PositionState] = {}
+    skipped_rows: list[dict[str, Any]] = []
+
+    for row in operation_rows:
+        if int(row["id"]) in suspicious_ids:
+            continue
+
+        action = str(row.get("side") or "").lower()
+        qty = to_float(row.get("quantity"))
+        price = to_float(row.get("entry_price"))
+        executed_at = str(row.get("executed_at") or row.get("created_at") or now_z())
+
+        if action not in {"buy", "sell", "short", "cover"} or qty <= EPSILON or price <= EPSILON:
+            skipped_rows.append({"id": int(row["id"]), "reason": "invalid_signal_payload"})
+            continue
+
+        key = instrument_key(row)
+        pos = positions.get(key)
+        trade_value = price * qty
+        fee = trade_value * TRADE_FEE_RATE
+
+        try:
+            if action == "buy":
+                if pos and pos.quantity < -EPSILON:
+                    raise ValueError("buy_with_open_short")
+                total_cost = trade_value + fee
+                if cash + EPSILON < total_cost:
+                    raise ValueError("insufficient_cash_for_buy")
+                cash -= total_cost
+                if pos and pos.quantity > EPSILON:
+                    new_qty = pos.quantity + qty
+                    pos.entry_price = ((pos.quantity * pos.entry_price) + (qty * price)) / new_qty
+                    pos.quantity = new_qty
+                    pos.opened_at = executed_at
+                else:
+                    positions[key] = create_position_from_signal(row, qty, "long")
+
+            elif action == "sell":
+                if not pos or pos.quantity <= EPSILON:
+                    raise ValueError("sell_without_long")
+                if qty > pos.quantity + EPSILON:
+                    raise ValueError("sell_exceeds_long_quantity")
+                cash += trade_value - fee
+                pos.quantity -= qty
+                if pos.quantity <= EPSILON:
+                    positions.pop(key, None)
+
+            elif action == "short":
+                if str(row.get("market") or "") == "polymarket":
+                    raise ValueError("polymarket_short_not_supported")
+                if pos and pos.quantity > EPSILON:
+                    raise ValueError("short_with_open_long")
+                total_cost = trade_value + fee
+                if cash + EPSILON < total_cost:
+                    raise ValueError("insufficient_cash_for_short")
+                cash -= total_cost
+                if pos and pos.quantity < -EPSILON:
+                    current_abs = abs(pos.quantity)
+                    new_abs = current_abs + qty
+                    pos.entry_price = ((current_abs * pos.entry_price) + (qty * price)) / new_abs
+                    pos.quantity = -new_abs
+                    pos.opened_at = executed_at
+                else:
+                    positions[key] = create_position_from_signal(row, -qty, "short")
+
+            elif action == "cover":
+                if not pos or pos.quantity >= -EPSILON:
+                    raise ValueError("cover_without_short")
+                if qty > abs(pos.quantity) + EPSILON:
+                    raise ValueError("cover_exceeds_short_quantity")
+                cash += ((2 * pos.entry_price) - price) * qty - fee
+                pos.quantity += qty
+                if pos.quantity >= -EPSILON:
+                    positions.pop(key, None)
+
+        except ValueError as exc:
+            skipped_rows.append({"id": int(row["id"]), "reason": str(exc)})
+            continue
+
+    rebuilt_positions: list[PositionState] = []
+    for key, pos in positions.items():
+        previous = previous_positions_by_key.get(key)
+        if previous:
+            pos.current_price = previous.get("current_price")
+            pos.leader_id = previous.get("leader_id")
+        rebuilt_positions.append(pos)
+
+    return cash, rebuilt_positions, skipped_rows
+
+
+def invalidate_caches() -> None:
+    delete_pattern(f"{LEADERBOARD_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{GROUPED_SIGNALS_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{AGENT_SIGNALS_CACHE_KEY_PREFIX}:*")
+    delete(TRENDING_CACHE_KEY)
+
+
+def apply_cleanup() -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+
+    suspicious_rows = load_suspicious_operation_signals(cursor)
+    if not suspicious_rows:
+        conn.close()
+        return {
+            "backup_path": None,
+            "affected_agents": [],
+            "deleted_signal_ids": [],
+            "skipped_rows": {},
+            "message": "No suspicious operation signals found.",
+        }
+
+    backup_payload = build_backup_payload(cursor, suspicious_rows)
+    backup_path = write_backup(backup_payload)
+
+    agent_rows = {int(row["id"]): row for row in backup_payload["agents"]}
+    previous_positions = previous_position_index(backup_payload["positions"])
+    signals_by_agent: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for row in backup_payload["signals"]:
+        if row.get("message_type") == "operation":
+            signals_by_agent[int(row["agent_id"])].append(row)
+
+    suspicious_ids = {int(row["id"]) for row in suspicious_rows}
+    suspicious_ids_by_agent: dict[int, set[int]] = defaultdict(set)
+    for row in suspicious_rows:
+        suspicious_ids_by_agent[int(row["agent_id"])].add(int(row["id"]))
+
+    rebuilt_agents: list[dict[str, Any]] = []
+    deleted_signal_ids: set[int] = set(suspicious_ids)
+    skipped_rows_by_agent: dict[int, list[dict[str, Any]]] = {}
+
+    for agent_id in sorted(agent_rows):
+        new_cash, new_positions, skipped_rows = replay_agent_operations(
+            agent_rows[agent_id],
+            signals_by_agent.get(agent_id, []),
+            suspicious_ids_by_agent.get(agent_id, set()),
+            previous_positions.get(agent_id, {}),
+        )
+        skipped_rows_by_agent[agent_id] = skipped_rows
+        deleted_signal_ids.update(int(item["id"]) for item in skipped_rows)
+        rebuilt_agents.append(
+            {
+                "agent_id": agent_id,
+                "agent_name": agent_rows[agent_id]["name"],
+                "old_cash": to_float(agent_rows[agent_id].get("cash")),
+                "new_cash": new_cash,
+                "rebuilt_positions": [pos.__dict__ for pos in new_positions],
+                "deleted_signal_count": len(suspicious_ids_by_agent.get(agent_id, set())) + len(skipped_rows),
+            }
+        )
+
+    affected_agent_ids = [int(row["id"]) for row in backup_payload["agents"]]
+
+    try:
+        if deleted_signal_ids:
+            placeholders = ",".join("?" for _ in deleted_signal_ids)
+            cursor.execute(
+                f"DELETE FROM signal_replies WHERE signal_id IN ({placeholders})",
+                list(deleted_signal_ids),
+            )
+            cursor.execute(
+                f"DELETE FROM signals WHERE id IN ({placeholders})",
+                list(deleted_signal_ids),
+            )
+
+        placeholders = ",".join("?" for _ in affected_agent_ids)
+        cursor.execute(f"DELETE FROM positions WHERE agent_id IN ({placeholders})", affected_agent_ids)
+        cursor.execute(f"DELETE FROM profit_history WHERE agent_id IN ({placeholders})", affected_agent_ids)
+
+        for item in rebuilt_agents:
+            cursor.execute(
+                "UPDATE agents SET cash = ? WHERE id = ?",
+                (item["new_cash"], item["agent_id"]),
+            )
+            for pos in item["rebuilt_positions"]:
+                cursor.execute(
+                    """
+                    INSERT INTO positions (
+                        agent_id, leader_id, symbol, market, token_id, outcome,
+                        side, quantity, entry_price, current_price, opened_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        item["agent_id"],
+                        pos["leader_id"],
+                        pos["symbol"],
+                        pos["market"],
+                        pos["token_id"],
+                        pos["outcome"],
+                        pos["side"],
+                        pos["quantity"],
+                        pos["entry_price"],
+                        pos["current_price"],
+                        pos["opened_at"],
+                    ),
+                )
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
+
+    conn.close()
+    invalidate_caches()
+
+    return {
+        "backup_path": str(backup_path),
+        "affected_agents": rebuilt_agents,
+        "deleted_signal_ids": sorted(deleted_signal_ids),
+        "skipped_rows": skipped_rows_by_agent,
+        "message": "Cleanup applied successfully.",
+    }
+
+
+def dry_run() -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    suspicious_rows = load_suspicious_operation_signals(cursor)
+    conn.close()
+
+    summary_by_agent: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "reasons": defaultdict(int)})
+    for row in suspicious_rows:
+        bucket = summary_by_agent[str(row["agent_name"])]
+        bucket["count"] += 1
+        for reason in row["suspicious_reasons"]:
+            bucket["reasons"][reason] += 1
+
+    return {
+        "captured_at": now_z(),
+        "suspicious_signal_count": len(suspicious_rows),
+        "agents": {
+            name: {
+                "count": item["count"],
+                "reasons": dict(item["reasons"]),
+            }
+            for name, item in summary_by_agent.items()
+        },
+        "signals": suspicious_rows,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Clean up known dirty trade data.")
+    parser.add_argument("--apply", action="store_true", help="apply the cleanup")
+    parser.add_argument("--dry-run", action="store_true", help="show what would be cleaned")
+    args = parser.parse_args()
+
+    if args.apply and args.dry_run:
+        parser.error("choose either --apply or --dry-run, not both")
+
+    if not args.apply:
+        report = dry_run()
+        print(json.dumps(report, indent=2, default=str))
+        return 0
+
+    result = apply_cleanup()
+    print(json.dumps(result, indent=2, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/service/server/services.py
+++ b/service/server/services.py
@@ -100,34 +100,24 @@ def _create_user_session(user_id: int) -> str:
 
 
 def _add_agent_points(agent_id: int, points: int, reason: str = "reward") -> bool:
-    """Add points to an agent's account. Returns True if successful."""
+    """Add points to an agent's account through the reward ledger."""
     if points <= 0:
         return False
 
     # Retry transient write conflicts on both SQLite and PostgreSQL.
     max_retries = 3
     for attempt in range(max_retries):
-        conn = get_db_connection()
-        cursor = conn.cursor()
         try:
-            cursor.execute("""
-                UPDATE agents SET points = points + ? WHERE id = ?
-            """, (points, agent_id))
-            conn.commit()
-            return True
-        except Exception as e:
-            try:
-                conn.rollback()
-            except Exception:
-                pass
+            from rewards import grant_agent_reward
 
+            result = grant_agent_reward(agent_id, points, reason)
+            return bool(result.get("success"))
+        except Exception as e:
             if is_retryable_db_error(e) and attempt < max_retries - 1:
                 time.sleep(0.5 * (attempt + 1))
                 continue
             print(f"[ERROR] Failed to add points to agent {agent_id}: {e}")
             return False
-        finally:
-            conn.close()
     return False
 
 

--- a/service/server/tasks.py
+++ b/service/server/tasks.py
@@ -713,10 +713,29 @@ async def settle_polymarket_positions():
         await asyncio.sleep(interval_s)
 
 
+async def settle_challenges_loop():
+    """Background task to settle active challenges after their end time."""
+    from challenges import settle_due_challenges
+
+    await asyncio.sleep(15)
+
+    while True:
+        interval_s = _env_int("CHALLENGE_SETTLE_INTERVAL", 120, minimum=30)
+        try:
+            settled = await asyncio.to_thread(settle_due_challenges)
+            if settled:
+                print(f"[Challenge Settler] settled={len(settled)}")
+        except Exception as e:
+            print(f"[Challenge Settler Error] {e}")
+
+        await asyncio.sleep(interval_s)
+
+
 BACKGROUND_TASK_REGISTRY = {
     "prices": update_position_prices,
     "profit_history": record_profit_history,
     "polymarket_settlement": settle_polymarket_positions,
+    "challenge_settlement": settle_challenges_loop,
     "market_news": refresh_market_news_snapshots_loop,
     "macro_signals": refresh_macro_signal_snapshots_loop,
     "etf_flows": refresh_etf_flow_snapshots_loop,

--- a/service/server/tests/test_challenges.py
+++ b/service/server/tests/test_challenges.py
@@ -1,0 +1,298 @@
+import csv
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+import database
+from challenges import (
+    create_challenge,
+    join_challenge,
+    record_challenge_trades_for_signal,
+    settle_challenge,
+    settle_due_challenges,
+)
+from challenge_scoring import score_challenge_results
+from research_exports import export_challenge_tables
+from routes_shared import utc_now_iso_z
+
+
+def iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class ChallengeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        database.DATABASE_URL = ""
+        database._SQLITE_DB_PATH = os.path.join(self.tmp.name, "test.db")
+        database.init_database()
+        self.agent_1 = self._create_agent("agent-1")
+        self.agent_2 = self._create_agent("agent-2")
+        self.agent_3 = self._create_agent("agent-3")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _create_agent(self, name: str) -> int:
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO agents (name, token, points, cash, created_at, updated_at)
+            VALUES (?, ?, 0, 100000.0, ?, ?)
+            """,
+            (name, f"token-{name}", utc_now_iso_z(), utc_now_iso_z()),
+        )
+        agent_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+        return agent_id
+
+    def _create_active_challenge(self, **overrides):
+        now = datetime.now(timezone.utc)
+        payload = {
+            "challenge_key": overrides.pop("challenge_key", f"test-{datetime.now().timestamp()}").replace(".", "-"),
+            "title": "BTC sprint",
+            "market": "crypto",
+            "symbol": "BTC",
+            "challenge_type": "multi-agent",
+            "scoring_method": "return-only",
+            "initial_capital": 1000.0,
+            "max_position_pct": 100.0,
+            "max_drawdown_pct": 20.0,
+            "start_at": iso(now - timedelta(minutes=5)),
+            "end_at": iso(now + timedelta(hours=1)),
+            "rules_json": {"reward_points": {"1": 100, "2": 25}},
+        }
+        payload.update(overrides)
+        return create_challenge(payload, self.agent_1)
+
+    def _insert_trade_signal(self, agent_id: int, signal_id: int, side: str, price: float, quantity: float):
+        executed_at = iso(datetime.now(timezone.utc))
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO signals
+            (signal_id, agent_id, message_type, market, signal_type, symbol, side,
+             entry_price, quantity, content, timestamp, created_at, executed_at)
+            VALUES (?, ?, 'operation', 'crypto', 'realtime', 'BTC', ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                signal_id,
+                agent_id,
+                side,
+                price,
+                quantity,
+                f"{side} BTC",
+                int(datetime.now(timezone.utc).timestamp()),
+                utc_now_iso_z(),
+                executed_at,
+            ),
+        )
+        recorded = record_challenge_trades_for_signal(
+            cursor,
+            agent_id=agent_id,
+            source_signal_id=signal_id,
+            market="crypto",
+            symbol="BTC",
+            side=side,
+            price=price,
+            quantity=quantity,
+            executed_at=executed_at,
+        )
+        conn.commit()
+        conn.close()
+        return recorded
+
+    def test_create_and_join_challenge_is_idempotent(self):
+        challenge = self._create_active_challenge(challenge_key="join-check")
+
+        first = join_challenge(challenge["challenge_key"], self.agent_2)
+        second = join_challenge(challenge["challenge_key"], self.agent_2)
+
+        self.assertTrue(first["joined"])
+        self.assertFalse(second["joined"])
+        self.assertTrue(second["idempotent"])
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) AS count FROM challenge_participants WHERE challenge_id = ?", (challenge["id"],))
+        self.assertEqual(cursor.fetchone()["count"], 1)
+        cursor.execute("SELECT event_type FROM experiment_events ORDER BY id")
+        self.assertIn("challenge_created", [row["event_type"] for row in cursor.fetchall()])
+        conn.close()
+
+    def test_operation_signal_records_challenge_trade_snapshot(self):
+        challenge = self._create_active_challenge(challenge_key="trade-mirror")
+        join_challenge(challenge["challenge_key"], self.agent_2)
+
+        recorded = self._insert_trade_signal(self.agent_2, 101, "buy", 100.0, 2.0)
+
+        self.assertEqual(len(recorded), 1)
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM challenge_trades WHERE source_signal_id = ?", (101,))
+        row = cursor.fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row["challenge_id"], challenge["id"])
+        self.assertEqual(row["agent_id"], self.agent_2)
+        cursor.execute("SELECT COUNT(*) AS count FROM experiment_events WHERE event_type = 'challenge_trade_recorded'")
+        self.assertEqual(cursor.fetchone()["count"], 1)
+        conn.close()
+
+    def test_due_challenge_settles_return_ranks_rewards_and_exports(self):
+        challenge = self._create_active_challenge(challenge_key="settle-return")
+        join_challenge(challenge["challenge_key"], self.agent_2)
+        join_challenge(challenge["challenge_key"], self.agent_3)
+        self._insert_trade_signal(self.agent_2, 201, "buy", 100.0, 10.0)
+        self._insert_trade_signal(self.agent_2, 202, "sell", 110.0, 10.0)
+        self._insert_trade_signal(self.agent_3, 203, "buy", 100.0, 10.0)
+        self._insert_trade_signal(self.agent_3, 204, "sell", 105.0, 10.0)
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "UPDATE challenges SET end_at = ? WHERE id = ?",
+            (iso(datetime.now(timezone.utc) - timedelta(seconds=1)), challenge["id"]),
+        )
+        conn.commit()
+        conn.close()
+
+        settled = settle_due_challenges()
+        self.assertEqual(len(settled), 1)
+
+        leaderboard = settled[0]["leaderboard"]
+        self.assertEqual(leaderboard[0]["agent_id"], self.agent_2)
+        self.assertEqual(leaderboard[0]["rank"], 1)
+        self.assertAlmostEqual(leaderboard[0]["return_pct"], 10.0)
+        self.assertEqual(leaderboard[1]["rank"], 2)
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT points FROM agents WHERE id = ?", (self.agent_2,))
+        self.assertEqual(cursor.fetchone()["points"], 100)
+        cursor.execute("SELECT points FROM agents WHERE id = ?", (self.agent_3,))
+        self.assertEqual(cursor.fetchone()["points"], 25)
+        cursor.execute("SELECT event_type FROM experiment_events")
+        event_types = {row["event_type"] for row in cursor.fetchall()}
+        self.assertTrue({
+            "challenge_created",
+            "challenge_joined",
+            "challenge_trade_recorded",
+            "challenge_settled",
+            "challenge_reward_granted",
+        }.issubset(event_types))
+        conn.close()
+
+        export_dir = Path(self.tmp.name) / "exports"
+        paths = export_challenge_tables(export_dir, challenge_key=challenge["challenge_key"])
+        self.assertIn("challenge_results.csv", paths)
+        with open(paths["challenge_results.csv"], newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        self.assertEqual(len(rows), 2)
+
+    def test_risk_adjusted_ranking_penalizes_drawdown(self):
+        challenge = {
+            "id": 1,
+            "initial_capital": 1000.0,
+            "scoring_method": "risk-adjusted",
+            "max_position_pct": 100.0,
+            "max_drawdown_pct": 5.0,
+            "rules_json": '{"allowed_drawdown": 5, "drawdown_penalty": 1}',
+        }
+        participants = [
+            {"agent_id": 1, "starting_cash": 1000.0, "status": "joined"},
+            {"agent_id": 2, "starting_cash": 1000.0, "status": "joined"},
+        ]
+        trades_by_agent = {
+            1: [
+                {"id": 1, "market": "crypto", "symbol": "BTC", "side": "buy", "price": 100.0, "quantity": 10, "executed_at": "2026-01-01T00:00:00Z"},
+                {"id": 2, "market": "crypto", "symbol": "BTC", "side": "sell", "price": 50.0, "quantity": 1, "executed_at": "2026-01-01T00:01:00Z"},
+                {"id": 3, "market": "crypto", "symbol": "BTC", "side": "sell", "price": 160.0, "quantity": 9, "executed_at": "2026-01-01T00:02:00Z"},
+            ],
+            2: [
+                {"id": 4, "market": "crypto", "symbol": "BTC", "side": "buy", "price": 100.0, "quantity": 10, "executed_at": "2026-01-01T00:00:00Z"},
+                {"id": 5, "market": "crypto", "symbol": "BTC", "side": "sell", "price": 110.0, "quantity": 10, "executed_at": "2026-01-01T00:01:00Z"},
+            ],
+        }
+
+        ranked = score_challenge_results(challenge, participants, trades_by_agent)
+        rank_by_agent = {row["agent_id"]: row["rank"] for row in ranked}
+
+        self.assertEqual(rank_by_agent[2], 1)
+        self.assertEqual(rank_by_agent[1], 2)
+        high_drawdown = next(row for row in ranked if row["agent_id"] == 1)
+        self.assertAlmostEqual(high_drawdown["return_pct"], 49.0)
+        self.assertGreater(high_drawdown["max_drawdown"], 40.0)
+
+    def test_disqualified_agent_gets_no_challenge_reward(self):
+        challenge = self._create_active_challenge(
+            challenge_key="disqualified-no-reward",
+            max_position_pct=50.0,
+            rules_json={"reward_points": {"1": 100, "2": 50}},
+        )
+        join_challenge(challenge["challenge_key"], self.agent_2)
+        join_challenge(challenge["challenge_key"], self.agent_3)
+        self._insert_trade_signal(self.agent_2, 301, "buy", 100.0, 10.0)
+        self._insert_trade_signal(self.agent_3, 302, "buy", 100.0, 1.0)
+        result = settle_challenge(challenge["challenge_key"])
+
+        disqualified = next(row for row in result["leaderboard"] if row["agent_id"] == self.agent_2)
+        self.assertEqual(disqualified["rank"], None)
+        self.assertIn("max_position_pct", disqualified["disqualified_reason"])
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT points FROM agents WHERE id = ?", (self.agent_2,))
+        self.assertEqual(cursor.fetchone()["points"], 0)
+        cursor.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM agent_reward_ledger
+            WHERE agent_id = ? AND source_type = 'challenge'
+            """,
+            (self.agent_2,),
+        )
+        self.assertEqual(cursor.fetchone()["count"], 0)
+        cursor.execute("SELECT COUNT(*) AS count FROM experiment_events WHERE event_type = 'challenge_disqualified'")
+        self.assertEqual(cursor.fetchone()["count"], 1)
+        conn.close()
+
+    def test_twenty_agent_challenge_settles_with_complete_metrics(self):
+        challenge = self._create_active_challenge(
+            challenge_key="twenty-agent-active",
+            rules_json={"reward_points": {"1": 100, "2": 50, "3": 25}},
+        )
+        agent_ids = [self._create_agent(f"bulk-agent-{idx}") for idx in range(20)]
+
+        signal_id = 400
+        for idx, agent_id in enumerate(agent_ids):
+            join_challenge(challenge["challenge_key"], agent_id)
+            self._insert_trade_signal(agent_id, signal_id, "buy", 100.0, 10.0)
+            signal_id += 1
+            self._insert_trade_signal(agent_id, signal_id, "sell", 100.0 + idx, 10.0)
+            signal_id += 1
+
+        result = settle_challenge(challenge["challenge_key"])
+        leaderboard = result["leaderboard"]
+
+        self.assertEqual(len(leaderboard), 20)
+        self.assertEqual(leaderboard[0]["agent_id"], agent_ids[-1])
+        self.assertEqual([row["rank"] for row in leaderboard], list(range(1, 21)))
+        for row in leaderboard:
+            self.assertIsNotNone(row["return_pct"])
+            self.assertIsNotNone(row["max_drawdown"])
+            self.assertEqual(row["trade_count"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add challenge schema, challenge service logic, scoring, settlement, event logging, reward ledger, and research CSV exports.
- Add challenge API routes and wire active challenge trade/submission recording from signal publication.
- Add the Challenges frontend page, navigation entry, community post challenge binding, and active challenge trade hint.

## Touched Areas
- service/server
- service/frontend
- .gitignore

## Verification
- python3 -m unittest discover service/server/tests
- python3 -m compileall service/server
- npm run build