### PR TITLE
Add team mission cooperation system

### DIFF
--- a/service/frontend/src/App.tsx
+++ b/service/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import {
   LeaderboardPage,
 } from './AppPages'
 import { ChallengePage } from './ChallengePage'
+import { TeamMissionsPage } from './TeamMissionsPage'
 import { Language, getT } from './i18n'
 
 
@@ -223,6 +224,9 @@ function AppRouter({
             <Route path="/leaderboard" element={<LeaderboardPage token={token} />} />
             <Route path="/challenges" element={<ChallengePage token={token} />} />
             <Route path="/challenges/:challengeKey" element={<ChallengePage token={token} />} />
+            <Route path="/team-missions" element={<TeamMissionsPage token={token} />} />
+            <Route path="/team-missions/:missionKey" element={<TeamMissionsPage token={token} />} />
+            <Route path="/teams/:teamKey" element={<TeamMissionsPage token={token} />} />
             <Route path="/financial-events" element={<FinancialEventsPage />} />
             <Route path="/copytrading" element={token ? <CopyTradingPage token={token} /> : <Navigate to="/login" replace />} />
             <Route path="/strategies" element={<StrategiesPage />} />

--- a/service/frontend/src/TeamMissionsPage.tsx
+++ b/service/frontend/src/TeamMissionsPage.tsx
@@ -1,0 +1,541 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { Link, useParams } from 'react-router-dom'
+
+import { API_BASE, MARKETS, useLanguage } from './appShared'
+
+type TeamMissionsPageProps = {
+  token?: string | null
+}
+
+const missionStatuses = ['upcoming', 'active', 'settled'] as const
+
+function formatDate(value: string | null | undefined, language: string) {
+  if (!value) return '-'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return value
+  return parsed.toLocaleString(language === 'zh' ? 'zh-CN' : 'en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  })
+}
+
+function formatScore(value: any) {
+  return Number(value || 0).toFixed(2)
+}
+
+function marketLabel(value: string, language: string) {
+  return MARKETS.find((market) => market.value === value)?.[language === 'zh' ? 'labelZh' : 'label'] || value
+}
+
+export function TeamMissionsPage({ token }: TeamMissionsPageProps) {
+  const { missionKey, teamKey } = useParams()
+  const { language } = useLanguage()
+  const [status, setStatus] = useState<'upcoming' | 'active' | 'settled'>('active')
+  const [missions, setMissions] = useState<any[]>([])
+  const [mission, setMission] = useState<any | null>(null)
+  const [team, setTeam] = useState<any | null>(null)
+  const [leaderboard, setLeaderboard] = useState<any[]>([])
+  const [myMissions, setMyMissions] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [createForm, setCreateForm] = useState({
+    title: '',
+    mission_key: '',
+    market: 'crypto',
+    symbol: 'BTC',
+    assignment_mode: 'random',
+    team_size_min: '2',
+    team_size_max: '4',
+    submission_due_at: ''
+  })
+  const [teamForm, setTeamForm] = useState({ name: '', role: 'lead' })
+  const [submissionForm, setSubmissionForm] = useState({ title: '', content: '', confidence: '0.7' })
+  const [signalLinkForm, setSignalLinkForm] = useState({ signal_id: '', message_type: 'discussion' })
+
+  const joinedMissionIds = useMemo(() => new Set(myMissions.map((item) => item.id)), [myMissions])
+
+  const loadMine = async () => {
+    if (!token) {
+      setMyMissions([])
+      return
+    }
+    try {
+      const res = await fetch(`${API_BASE}/team-missions/me`, {
+        headers: { 'Authorization': `Bearer ${token}` }
+      })
+      if (!res.ok) return
+      const data = await res.json()
+      setMyMissions(data.missions || [])
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  const loadList = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch(`${API_BASE}/team-missions?status=${status}&limit=100`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.detail || 'mission_load_failed')
+      setMissions(data.missions || [])
+      setError(null)
+    } catch (err: any) {
+      setError(err?.message || (language === 'zh' ? 'Team mission 加载失败' : 'Failed to load team missions'))
+      setMissions([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const loadMission = async () => {
+    if (!missionKey) return
+    setLoading(true)
+    try {
+      const [missionRes, leaderboardRes] = await Promise.all([
+        fetch(`${API_BASE}/team-missions/${missionKey}`),
+        fetch(`${API_BASE}/team-missions/${missionKey}/leaderboard`)
+      ])
+      const [missionData, leaderboardData] = await Promise.all([missionRes.json(), leaderboardRes.json()])
+      if (!missionRes.ok) throw new Error(missionData.detail || 'mission_detail_failed')
+      setMission(missionData)
+      setLeaderboard(leaderboardData.leaderboard || [])
+      setError(null)
+    } catch (err: any) {
+      setError(err?.message || (language === 'zh' ? 'Mission 详情加载失败' : 'Failed to load mission detail'))
+      setMission(null)
+      setLeaderboard([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const loadTeam = async () => {
+    if (!teamKey) return
+    setLoading(true)
+    try {
+      const res = await fetch(`${API_BASE}/teams/${teamKey}`)
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.detail || 'team_load_failed')
+      setTeam(data)
+      setError(null)
+    } catch (err: any) {
+      setError(err?.message || (language === 'zh' ? 'Team 加载失败' : 'Failed to load team'))
+      setTeam(null)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (teamKey) {
+      loadTeam()
+    } else if (missionKey) {
+      loadMission()
+    } else {
+      loadList()
+    }
+    loadMine()
+  }, [missionKey, teamKey, status, token])
+
+  const authedFetch = async (url: string, body: any = {}) => {
+    if (!token) throw new Error(language === 'zh' ? '请先登录' : 'Login required')
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`
+      },
+      body: JSON.stringify(body)
+    })
+    const data = await res.json()
+    if (!res.ok) throw new Error(data.detail || 'request_failed')
+    return data
+  }
+
+  const handleCreateMission = async (event: FormEvent) => {
+    event.preventDefault()
+    setBusy(true)
+    try {
+      const dueAt = createForm.submission_due_at ? new Date(createForm.submission_due_at).toISOString() : undefined
+      await authedFetch(`${API_BASE}/team-missions`, {
+        ...createForm,
+        mission_key: createForm.mission_key || undefined,
+        symbol: createForm.symbol || undefined,
+        team_size_min: Number(createForm.team_size_min || 2),
+        team_size_max: Number(createForm.team_size_max || 4),
+        submission_due_at: dueAt
+      })
+      setCreateForm({
+        title: '',
+        mission_key: '',
+        market: 'crypto',
+        symbol: 'BTC',
+        assignment_mode: 'random',
+        team_size_min: '2',
+        team_size_max: '4',
+        submission_due_at: ''
+      })
+      setShowCreate(false)
+      await loadList()
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '创建失败' : 'Create failed'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleJoinMission = async (key: string) => {
+    setBusy(true)
+    try {
+      await authedFetch(`${API_BASE}/team-missions/${key}/join`, {})
+      await Promise.all([loadMine(), missionKey ? loadMission() : loadList()])
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '加入失败' : 'Join failed'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleCreateTeam = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!mission) return
+    setBusy(true)
+    try {
+      await authedFetch(`${API_BASE}/team-missions/${mission.mission_key}/teams`, teamForm)
+      setTeamForm({ name: '', role: 'lead' })
+      await Promise.all([loadMission(), loadMine()])
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '创建 team 失败' : 'Failed to create team'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleAutoForm = async () => {
+    if (!mission) return
+    setBusy(true)
+    try {
+      await authedFetch(`${API_BASE}/team-missions/${mission.mission_key}/auto-form-teams`, {
+        assignment_mode: mission.assignment_mode
+      })
+      await loadMission()
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '自动组队失败' : 'Auto-form failed'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleSubmitTeam = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!team) return
+    setBusy(true)
+    try {
+      await authedFetch(`${API_BASE}/teams/${team.team_key}/submit`, {
+        title: submissionForm.title,
+        content: submissionForm.content,
+        confidence: Number(submissionForm.confidence || 0)
+      })
+      setSubmissionForm({ title: '', content: '', confidence: '0.7' })
+      await loadTeam()
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '提交失败' : 'Submit failed'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleLinkSignal = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!team) return
+    setBusy(true)
+    try {
+      await authedFetch(`${API_BASE}/teams/${team.team_key}/messages/link-signal`, {
+        signal_id: Number(signalLinkForm.signal_id),
+        message_type: signalLinkForm.message_type
+      })
+      setSignalLinkForm({ signal_id: '', message_type: 'discussion' })
+      await loadTeam()
+    } catch (err: any) {
+      alert(err?.message || (language === 'zh' ? '绑定失败' : 'Link failed'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) {
+    return <div className="loading"><div className="spinner"></div></div>
+  }
+
+  if (teamKey && team) {
+    return (
+      <div className="team-page">
+        <Link to={`/team-missions/${team.mission.mission_key}`} className="back-button">← {language === 'zh' ? '返回 Mission' : 'Back to mission'}</Link>
+        <section className="team-hero">
+          <div>
+            <div className="team-kicker">
+              <span>{team.mission.assignment_mode}</span>
+              <span>{team.status}</span>
+              <span>{team.formation_method}</span>
+            </div>
+            <h1 className="team-title">{team.name}</h1>
+            <p className="team-copy">{team.mission.title}</p>
+          </div>
+        </section>
+
+        <div className="team-grid">
+          <section className="team-panel">
+            <div className="team-section-header"><h2>{language === 'zh' ? '成员与角色' : 'Members and Roles'}</h2></div>
+            <div className="team-member-list">
+              {(team.members || []).map((member: any) => (
+                <div key={member.id} className="team-member-row">
+                  <strong>{member.agent_name}</strong>
+                  <span>{member.role || '-'}</span>
+                  <span>{formatDate(member.joined_at, language)}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="team-panel">
+            <div className="team-section-header"><h2>{language === 'zh' ? '提交团队结论' : 'Submit Team Conclusion'}</h2></div>
+            {token ? (
+              <form className="team-form" onSubmit={handleSubmitTeam}>
+                <input className="form-input" value={submissionForm.title} onChange={(event) => setSubmissionForm({ ...submissionForm, title: event.target.value })} placeholder={language === 'zh' ? '结论标题' : 'Submission title'} required />
+                <textarea className="form-textarea" value={submissionForm.content} onChange={(event) => setSubmissionForm({ ...submissionForm, content: event.target.value })} placeholder={language === 'zh' ? '团队共识、预测和证据' : 'Consensus, prediction, and evidence'} required />
+                <input className="form-input" type="number" min="0" max="1" step="0.05" value={submissionForm.confidence} onChange={(event) => setSubmissionForm({ ...submissionForm, confidence: event.target.value })} />
+                <button className="btn btn-primary" disabled={busy} type="submit">{language === 'zh' ? '提交' : 'Submit'}</button>
+              </form>
+            ) : (
+              <Link className="btn btn-secondary" to="/login">{language === 'zh' ? '登录后提交' : 'Login to submit'}</Link>
+            )}
+          </section>
+        </div>
+
+        <div className="team-grid">
+          <section className="team-panel">
+            <div className="team-section-header"><h2>{language === 'zh' ? '公开信号绑定' : 'Linked Public Signals'}</h2></div>
+            {token && (
+              <form className="team-link-form" onSubmit={handleLinkSignal}>
+                <input className="form-input" type="number" value={signalLinkForm.signal_id} onChange={(event) => setSignalLinkForm({ ...signalLinkForm, signal_id: event.target.value })} placeholder="signal_id" required />
+                <select className="form-input" value={signalLinkForm.message_type} onChange={(event) => setSignalLinkForm({ ...signalLinkForm, message_type: event.target.value })}>
+                  <option value="discussion">discussion</option>
+                  <option value="strategy">strategy</option>
+                </select>
+                <button className="btn btn-secondary" disabled={busy} type="submit">{language === 'zh' ? '绑定' : 'Link'}</button>
+              </form>
+            )}
+            <div className="team-message-list">
+              {(team.messages || []).map((message: any) => (
+                <div key={message.id} className="team-message-row">
+                  <span className="team-badge">{message.message_type}</span>
+                  <strong>{message.agent_name}</strong>
+                  <span>#{message.signal_id || '-'}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="team-panel">
+            <div className="team-section-header"><h2>{language === 'zh' ? '团队提交' : 'Team Submissions'}</h2></div>
+            <div className="team-submission-list">
+              {(team.submissions || []).map((submission: any) => (
+                <article key={submission.id} className="team-submission-item">
+                  <div><strong>{submission.title}</strong><span>{formatScore(Number(submission.confidence || 0) * 100)}%</span></div>
+                  <p>{submission.content}</p>
+                  <time>{formatDate(submission.created_at, language)}</time>
+                </article>
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    )
+  }
+
+  if (missionKey && mission) {
+    const isJoined = joinedMissionIds.has(mission.id)
+    return (
+      <div className="team-page">
+        <Link to="/team-missions" className="back-button">← {language === 'zh' ? '返回 Mission 列表' : 'Back to missions'}</Link>
+        <section className="team-hero">
+          <div>
+            <div className="team-kicker">
+              <span>{mission.status}</span>
+              <span>{mission.assignment_mode}</span>
+              <span>{marketLabel(mission.market, language)} {mission.symbol || 'all'}</span>
+            </div>
+            <h1 className="team-title">{mission.title}</h1>
+            {mission.description && <p className="team-copy">{mission.description}</p>}
+          </div>
+          <div className="team-actions">
+            {token && mission.status !== 'settled' && (
+              <>
+                <button className="btn btn-primary" disabled={busy || isJoined} onClick={() => handleJoinMission(mission.mission_key)}>
+                  {isJoined ? (language === 'zh' ? '已加入' : 'Joined') : (language === 'zh' ? '加入 Mission' : 'Join mission')}
+                </button>
+                <button className="btn btn-secondary" disabled={busy} onClick={handleAutoForm}>
+                  {language === 'zh' ? '自动组队' : 'Auto-form teams'}
+                </button>
+              </>
+            )}
+          </div>
+        </section>
+
+        <section className="team-metrics">
+          <div><span>{language === 'zh' ? '报名 Agent' : 'Participants'}</span><strong>{mission.participant_count || 0}</strong></div>
+          <div><span>{language === 'zh' ? 'Teams' : 'Teams'}</span><strong>{mission.team_count || 0}</strong></div>
+          <div><span>{language === 'zh' ? '队伍规模' : 'Team size'}</span><strong>{mission.team_size_min}-{mission.team_size_max}</strong></div>
+          <div><span>{language === 'zh' ? '截止' : 'Due'}</span><strong>{formatDate(mission.submission_due_at, language)}</strong></div>
+        </section>
+
+        <div className="team-grid">
+          <section className="team-panel team-panel-main">
+            <div className="team-section-header"><h2>Teams</h2><span className="team-badge">{mission.mission_key}</span></div>
+            <div className="team-list">
+              {(mission.teams || []).map((item: any) => (
+                <article key={item.id} className="team-list-item">
+                  <div>
+                    <Link to={`/teams/${item.team_key}`} className="team-list-title">{item.name}</Link>
+                    <div className="team-list-meta">
+                      <span>{item.member_count || 0} {language === 'zh' ? '成员' : 'members'}</span>
+                      <span>{item.formation_method}</span>
+                      <span>{item.status}</span>
+                    </div>
+                  </div>
+                  {token && mission.status !== 'settled' && (
+                    <button className="btn btn-ghost" disabled={busy} onClick={() => authedFetch(`${API_BASE}/teams/${item.team_key}/join`, {}).then(() => loadMission()).catch((err) => alert(err.message))}>
+                      {language === 'zh' ? '加入 Team' : 'Join team'}
+                    </button>
+                  )}
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <aside className="team-panel">
+            <div className="team-section-header"><h2>{language === 'zh' ? '手动创建 Team' : 'Create Team'}</h2></div>
+            {token ? (
+              <form className="team-form" onSubmit={handleCreateTeam}>
+                <input className="form-input" value={teamForm.name} onChange={(event) => setTeamForm({ ...teamForm, name: event.target.value })} placeholder={language === 'zh' ? 'Team 名称' : 'Team name'} />
+                <select className="form-input" value={teamForm.role} onChange={(event) => setTeamForm({ ...teamForm, role: event.target.value })}>
+                  {(mission.required_roles || ['lead', 'analyst', 'risk', 'scribe']).map((role: string) => (
+                    <option key={role} value={role}>{role}</option>
+                  ))}
+                </select>
+                <button className="btn btn-primary" disabled={busy} type="submit">{language === 'zh' ? '创建' : 'Create'}</button>
+              </form>
+            ) : (
+              <Link className="btn btn-secondary" to="/login">{language === 'zh' ? '登录后创建' : 'Login to create'}</Link>
+            )}
+          </aside>
+        </div>
+
+        <section className="team-panel">
+          <div className="team-section-header"><h2>{language === 'zh' ? 'Team Leaderboard' : 'Team Leaderboard'}</h2></div>
+          <div className="team-leaderboard">
+            {leaderboard.length === 0 ? (
+              <div className="empty-state"><div className="empty-title">{language === 'zh' ? '暂无排名' : 'No leaderboard yet'}</div></div>
+            ) : leaderboard.map((row) => (
+              <div key={row.team_id} className="team-rank-row">
+                <span>#{row.rank}</span>
+                <strong>{row.team_name || row.team_key}</strong>
+                <span>{language === 'zh' ? '最终分' : 'Final'} {formatScore(row.final_score)}</span>
+                <span>{language === 'zh' ? '质量' : 'Quality'} {formatScore(row.quality_score)}</span>
+                <span>{language === 'zh' ? '共识' : 'Consensus'} {formatScore(row.consensus_gain)}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    )
+  }
+
+  return (
+    <div className="team-page">
+      <div className="header">
+        <div>
+          <h1 className="header-title">{language === 'zh' ? 'Team Missions' : 'Team Missions'}</h1>
+          <p className="header-subtitle">
+            {language === 'zh' ? '组队、分工、协作提交和贡献结算的实验工作台' : 'An experiment workspace for teams, roles, submissions, and contribution scoring'}
+          </p>
+        </div>
+        {token && <button className="btn btn-primary" onClick={() => setShowCreate(!showCreate)}>{language === 'zh' ? '创建 Mission' : 'Create mission'}</button>}
+      </div>
+
+      <div className="team-tabs">
+        {missionStatuses.map((value) => (
+          <button key={value} className={status === value ? 'active' : ''} onClick={() => setStatus(value)}>
+            {value}
+          </button>
+        ))}
+      </div>
+
+      {showCreate && (
+        <section className="team-panel">
+          <form className="team-create-grid" onSubmit={handleCreateMission}>
+            <input className="form-input" value={createForm.title} onChange={(event) => setCreateForm({ ...createForm, title: event.target.value })} placeholder={language === 'zh' ? 'Mission 标题' : 'Mission title'} required />
+            <input className="form-input" value={createForm.mission_key} onChange={(event) => setCreateForm({ ...createForm, mission_key: event.target.value })} placeholder="mission-key" />
+            <select className="form-input" value={createForm.market} onChange={(event) => setCreateForm({ ...createForm, market: event.target.value })}>
+              {MARKETS.filter((market) => market.value !== 'all' && market.supported).map((market) => (
+                <option key={market.value} value={market.value}>{marketLabel(market.value, language)}</option>
+              ))}
+            </select>
+            <input className="form-input" value={createForm.symbol} onChange={(event) => setCreateForm({ ...createForm, symbol: event.target.value.toUpperCase() })} placeholder="BTC" />
+            <select className="form-input" value={createForm.assignment_mode} onChange={(event) => setCreateForm({ ...createForm, assignment_mode: event.target.value })}>
+              <option value="random">random</option>
+              <option value="homogeneous">homogeneous</option>
+              <option value="heterogeneous">heterogeneous</option>
+            </select>
+            <input className="form-input" type="number" min="1" value={createForm.team_size_min} onChange={(event) => setCreateForm({ ...createForm, team_size_min: event.target.value })} />
+            <input className="form-input" type="number" min="1" value={createForm.team_size_max} onChange={(event) => setCreateForm({ ...createForm, team_size_max: event.target.value })} />
+            <input className="form-input" type="datetime-local" value={createForm.submission_due_at} onChange={(event) => setCreateForm({ ...createForm, submission_due_at: event.target.value })} />
+            <button className="btn btn-primary" disabled={busy} type="submit">{language === 'zh' ? '保存' : 'Save'}</button>
+          </form>
+        </section>
+      )}
+
+      {error && <div className="card" style={{ color: 'var(--error)' }}>{error}</div>}
+
+      {missions.length === 0 ? (
+        <div className="empty-state"><div className="empty-title">{language === 'zh' ? '暂无 Mission' : 'No missions yet'}</div></div>
+      ) : (
+        <div className="team-list">
+          {missions.map((item) => {
+            const isJoined = joinedMissionIds.has(item.id)
+            return (
+              <article key={item.id} className="team-list-item">
+                <div>
+                  <div className="team-kicker">
+                    <span>{item.status}</span>
+                    <span>{item.assignment_mode}</span>
+                    <span>{marketLabel(item.market, language)} {item.symbol || 'all'}</span>
+                  </div>
+                  <Link to={`/team-missions/${item.mission_key}`} className="team-list-title">{item.title}</Link>
+                  <div className="team-list-meta">
+                    <span>{item.participant_count || 0} {language === 'zh' ? '报名' : 'participants'}</span>
+                    <span>{item.team_count || 0} teams</span>
+                    <span>{formatDate(item.submission_due_at, language)}</span>
+                  </div>
+                </div>
+                <div className="team-actions">
+                  {token && item.status !== 'settled' && (
+                    <button className="btn btn-secondary" disabled={busy || isJoined} onClick={() => handleJoinMission(item.mission_key)}>
+                      {isJoined ? (language === 'zh' ? '已加入' : 'Joined') : (language === 'zh' ? '加入' : 'Join')}
+                    </button>
+                  )}
+                  <Link className="btn btn-ghost" to={`/team-missions/${item.mission_key}`}>{language === 'zh' ? '打开' : 'Open'}</Link>
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+

--- a/service/frontend/src/appChrome.tsx
+++ b/service/frontend/src/appChrome.tsx
@@ -89,6 +89,7 @@ export function Sidebar({
     { path: '/market', icon: '📊', label: t.nav.signals, requiresAuth: false },
     { path: '/leaderboard', icon: '🏆', label: language === 'zh' ? '排行榜' : 'Leaderboard', requiresAuth: false },
     { path: '/challenges', icon: '⚔️', label: language === 'zh' ? '挑战赛' : 'Challenges', requiresAuth: false },
+    { path: '/team-missions', icon: '▦', label: language === 'zh' ? '团队任务' : 'Team Missions', requiresAuth: false },
     { path: '/copytrading', icon: '📋', label: language === 'zh' ? '跟单' : 'Copy Trading', requiresAuth: true },
     { path: '/strategies', icon: '📈', label: t.nav.strategies, requiresAuth: false, badge: notificationCounts.strategy, category: 'strategy' as const },
     { path: '/discussions', icon: '💬', label: t.nav.discussions, requiresAuth: false, badge: notificationCounts.discussion, category: 'discussion' as const },
@@ -117,7 +118,7 @@ export function Sidebar({
           <Link
             key={item.path}
             to={item.path}
-            className={`nav-link ${location.pathname === item.path ? 'active' : ''}`}
+            className={`nav-link ${location.pathname === item.path || location.pathname.startsWith(`${item.path}/`) ? 'active' : ''}`}
             title={!token && item.requiresAuth ? (language === 'zh' ? '登录后可用' : 'Login required') : undefined}
             onClick={() => {
               if (item.category && (item.badge || 0) > 0) {

--- a/service/frontend/src/appCommunityPages.tsx
+++ b/service/frontend/src/appCommunityPages.tsx
@@ -87,6 +87,21 @@ async function fetchActiveChallengeOptions() {
   }
 }
 
+async function fetchMyTeamMissionOptions(token: string | null) {
+  if (!token) return []
+  try {
+    const res = await fetch(`${API_BASE}/team-missions/me`, {
+      headers: { 'Authorization': `Bearer ${token}` }
+    })
+    if (!res.ok) return []
+    const data = await res.json()
+    return data.missions || []
+  } catch (e) {
+    console.error(e)
+    return []
+  }
+}
+
 function SignalCard({
   signal,
   onRefresh,
@@ -113,6 +128,7 @@ function SignalCard({
   const [loadingReplies, setLoadingReplies] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const { language } = useLanguage()
+  const teamBadges = Array.isArray(signal.team_badges) ? signal.team_badges : []
 
   const loadReplies = async () => {
     setLoadingReplies(true)
@@ -224,6 +240,17 @@ function SignalCard({
         </div>
       )}
 
+      {teamBadges.length > 0 && (
+        <div className="team-signal-badges">
+          {teamBadges.map((badge: any) => (
+            <span key={`${badge.mission_key}-${badge.team_key}`} className="team-signal-badge">
+              <Link to={`/team-missions/${badge.mission_key}`}>{badge.mission_title || badge.mission_key}</Link>
+              <Link to={`/teams/${badge.team_key}`}>{badge.team_name || badge.team_key}</Link>
+            </span>
+          ))}
+        </div>
+      )}
+
       <p className="signal-content">{signal.content}</p>
 
       <div style={{ display: 'flex', gap: '12px', flexWrap: 'wrap', fontSize: '12px', color: 'var(--text-muted)', marginTop: '8px' }}>
@@ -332,8 +359,9 @@ export function StrategiesPage() {
   const [viewerId, setViewerId] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
-  const [formData, setFormData] = useState({ title: '', content: '', symbols: '', tags: '', market: 'us-stock', challenge_key: '' })
+  const [formData, setFormData] = useState({ title: '', content: '', symbols: '', tags: '', market: 'us-stock', challenge_key: '', mission_key: '', team_key: '' })
   const [activeChallenges, setActiveChallenges] = useState<any[]>([])
+  const [teamMissionOptions, setTeamMissionOptions] = useState<any[]>([])
   const [sort, setSort] = useState<'new' | 'active' | 'following'>('active')
   const { t, language } = useLanguage()
   const location = useLocation()
@@ -345,6 +373,7 @@ export function StrategiesPage() {
   useEffect(() => {
     loadStrategies(strategyPage)
     fetchActiveChallengeOptions().then(setActiveChallenges)
+    fetchMyTeamMissionOptions(token).then(setTeamMissionOptions)
     if (token) {
       loadViewerContext()
     }
@@ -447,10 +476,12 @@ export function StrategiesPage() {
           symbols: formData.symbols,
           tags: formData.tags,
           challenge_key: formData.challenge_key || undefined,
+          mission_key: formData.mission_key || undefined,
+          team_key: formData.team_key || undefined,
         })
       })
       if (res.ok) {
-        setFormData({ title: '', content: '', symbols: '', tags: '', market: 'us-stock', challenge_key: '' })
+        setFormData({ title: '', content: '', symbols: '', tags: '', market: 'us-stock', challenge_key: '', mission_key: '', team_key: '' })
         setShowForm(false)
         setStrategyPage(1)
         loadStrategies(1)
@@ -529,6 +560,47 @@ export function StrategiesPage() {
                   </option>
                 ))}
               </select>
+            </div>
+            <div className="team-binding-grid">
+              <div className="form-group">
+                <label className="form-label">{language === 'zh' ? 'Team Mission（可选）' : 'Team Mission (optional)'}</label>
+                <select
+                  className="form-select"
+                  value={formData.mission_key}
+                  onChange={e => setFormData({ ...formData, mission_key: e.target.value, team_key: '' })}
+                >
+                  <option value="">{language === 'zh' ? '不绑定' : 'No mission'}</option>
+                  {teamMissionOptions.map((mission: any) => (
+                    <option key={mission.mission_key} value={mission.mission_key}>
+                      {mission.title}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label className="form-label">{language === 'zh' ? 'Team（可选）' : 'Team (optional)'}</label>
+                <select
+                  className="form-select"
+                  value={formData.team_key}
+                  onChange={e => {
+                    const selected = teamMissionOptions.find((mission: any) => mission.team_key === e.target.value)
+                    setFormData({
+                      ...formData,
+                      team_key: e.target.value,
+                      mission_key: selected?.mission_key || formData.mission_key
+                    })
+                  }}
+                >
+                  <option value="">{language === 'zh' ? '自动使用当前 Mission Team' : 'Use mission team automatically'}</option>
+                  {teamMissionOptions
+                    .filter((mission: any) => mission.team_key && (!formData.mission_key || mission.mission_key === formData.mission_key))
+                    .map((mission: any) => (
+                      <option key={mission.team_key} value={mission.team_key}>
+                        {mission.team_name || mission.team_key}
+                      </option>
+                    ))}
+                </select>
+              </div>
             </div>
             <div className="form-group">
               <label className="form-label">{t.strategies.title}</label>
@@ -657,8 +729,9 @@ export function DiscussionsPage() {
   const [viewerId, setViewerId] = useState<number | null>(null)
   const [loading, setLoading] = useState(true)
   const [showForm, setShowForm] = useState(false)
-  const [formData, setFormData] = useState({ title: '', content: '', tags: '', market: 'us-stock', challenge_key: '' })
+  const [formData, setFormData] = useState({ title: '', content: '', tags: '', market: 'us-stock', challenge_key: '', mission_key: '', team_key: '' })
   const [activeChallenges, setActiveChallenges] = useState<any[]>([])
+  const [teamMissionOptions, setTeamMissionOptions] = useState<any[]>([])
   const [sort, setSort] = useState<'new' | 'active' | 'following'>('active')
   const { t, language } = useLanguage()
   const location = useLocation()
@@ -671,6 +744,7 @@ export function DiscussionsPage() {
   useEffect(() => {
     loadDiscussions(discussionPage)
     fetchActiveChallengeOptions().then(setActiveChallenges)
+    fetchMyTeamMissionOptions(token).then(setTeamMissionOptions)
     if (token) {
       loadRecentNotifications()
       loadViewerContext()
@@ -757,10 +831,12 @@ export function DiscussionsPage() {
           content: formData.content,
           tags: formData.tags,
           challenge_key: formData.challenge_key || undefined,
+          mission_key: formData.mission_key || undefined,
+          team_key: formData.team_key || undefined,
         })
       })
       if (res.ok) {
-        setFormData({ title: '', content: '', tags: '', market: 'us-stock', challenge_key: '' })
+        setFormData({ title: '', content: '', tags: '', market: 'us-stock', challenge_key: '', mission_key: '', team_key: '' })
         setShowForm(false)
         setDiscussionPage(1)
         loadDiscussions(1)
@@ -925,6 +1001,47 @@ export function DiscussionsPage() {
                   </option>
                 ))}
               </select>
+            </div>
+            <div className="team-binding-grid">
+              <div className="form-group">
+                <label className="form-label">{language === 'zh' ? 'Team Mission（可选）' : 'Team Mission (optional)'}</label>
+                <select
+                  className="form-select"
+                  value={formData.mission_key}
+                  onChange={e => setFormData({ ...formData, mission_key: e.target.value, team_key: '' })}
+                >
+                  <option value="">{language === 'zh' ? '不绑定' : 'No mission'}</option>
+                  {teamMissionOptions.map((mission: any) => (
+                    <option key={mission.mission_key} value={mission.mission_key}>
+                      {mission.title}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-group">
+                <label className="form-label">{language === 'zh' ? 'Team（可选）' : 'Team (optional)'}</label>
+                <select
+                  className="form-select"
+                  value={formData.team_key}
+                  onChange={e => {
+                    const selected = teamMissionOptions.find((mission: any) => mission.team_key === e.target.value)
+                    setFormData({
+                      ...formData,
+                      team_key: e.target.value,
+                      mission_key: selected?.mission_key || formData.mission_key
+                    })
+                  }}
+                >
+                  <option value="">{language === 'zh' ? '自动使用当前 Mission Team' : 'Use mission team automatically'}</option>
+                  {teamMissionOptions
+                    .filter((mission: any) => mission.team_key && (!formData.mission_key || mission.mission_key === formData.mission_key))
+                    .map((mission: any) => (
+                      <option key={mission.team_key} value={mission.team_key}>
+                        {mission.team_name || mission.team_key}
+                      </option>
+                    ))}
+                </select>
+              </div>
             </div>
             <div className="form-group">
               <label className="form-label">{t.discussions.title}</label>

--- a/service/frontend/src/index.css
+++ b/service/frontend/src/index.css
@@ -2407,6 +2407,299 @@ a {
   padding: 28px;
 }
 
+.team-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.team-hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 22px;
+  padding: 28px;
+  border: 1px solid rgba(214, 175, 110, 0.14);
+  border-radius: 20px;
+  background:
+    linear-gradient(135deg, rgba(15, 23, 29, 0.96), rgba(10, 16, 21, 0.9)),
+    linear-gradient(90deg, rgba(143, 193, 157, 0.08), transparent 44%),
+    linear-gradient(270deg, rgba(212, 164, 88, 0.08), transparent 58%);
+  box-shadow: var(--shadow-sm);
+}
+
+.team-kicker,
+.team-list-meta,
+.team-section-header,
+.team-submission-item div,
+.team-actions,
+.team-signal-badges {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.team-kicker span,
+.team-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 26px;
+  padding: 4px 10px;
+  border: 1px solid rgba(214, 175, 110, 0.16);
+  border-radius: 999px;
+  color: #d8caa7;
+  background: rgba(18, 27, 34, 0.72);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+}
+
+.team-title {
+  margin-top: 14px;
+  color: var(--text-primary);
+  font-size: 34px;
+  line-height: 1.1;
+  letter-spacing: -0.04em;
+}
+
+.team-copy {
+  max-width: 780px;
+  margin-top: 10px;
+  color: var(--text-secondary);
+}
+
+.team-metrics {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.team-metrics div,
+.team-panel,
+.team-list-item {
+  border: 1px solid rgba(214, 175, 110, 0.1);
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(12, 18, 24, 0.94), rgba(10, 15, 20, 0.9));
+  box-shadow: var(--shadow-sm);
+}
+
+.team-metrics div {
+  padding: 16px;
+}
+
+.team-metrics span,
+.team-list-meta,
+.team-submission-item time {
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
+.team-metrics strong {
+  display: block;
+  margin-top: 4px;
+  color: var(--text-primary);
+  font-size: 18px;
+}
+
+.team-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 20px;
+}
+
+.team-panel {
+  padding: 22px;
+}
+
+.team-panel-main {
+  min-width: 0;
+}
+
+.team-section-header {
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.team-section-header h2 {
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+
+.team-tabs {
+  display: inline-flex;
+  width: fit-content;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid rgba(214, 175, 110, 0.12);
+  border-radius: 999px;
+  background: rgba(14, 20, 26, 0.72);
+}
+
+.team-tabs button {
+  padding: 8px 14px;
+  border: 0;
+  border-radius: 999px;
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.team-tabs button.active {
+  color: #10161d;
+  background: var(--accent-gradient);
+}
+
+.team-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.team-list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 20px;
+}
+
+.team-list-title {
+  display: inline-block;
+  margin-top: 10px;
+  color: var(--text-primary);
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.team-list-meta {
+  margin-top: 8px;
+}
+
+.team-create-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.team-create-grid .btn {
+  justify-content: center;
+}
+
+.team-member-list,
+.team-message-list,
+.team-submission-list,
+.team-leaderboard,
+.team-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.team-member-row,
+.team-message-row,
+.team-rank-row {
+  display: grid;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: rgba(18, 27, 34, 0.62);
+  font-size: 13px;
+}
+
+.team-member-row {
+  grid-template-columns: minmax(0, 1fr) 110px 150px;
+}
+
+.team-message-row {
+  grid-template-columns: 100px minmax(0, 1fr) 84px;
+}
+
+.team-rank-row {
+  grid-template-columns: 56px minmax(150px, 1fr) repeat(3, minmax(96px, auto));
+}
+
+.team-submission-item {
+  padding: 14px;
+  border: 1px solid var(--border-color);
+  border-radius: 14px;
+  background: rgba(18, 27, 34, 0.58);
+}
+
+.team-submission-item div {
+  justify-content: space-between;
+}
+
+.team-submission-item p {
+  margin-top: 8px;
+  color: var(--text-secondary);
+}
+
+.team-link-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 150px auto;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.team-binding-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.team-signal-badges {
+  margin-bottom: 12px;
+}
+
+.team-signal-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 100%;
+  padding: 5px 9px;
+  border: 1px solid rgba(143, 193, 157, 0.2);
+  border-radius: 999px;
+  background: rgba(143, 193, 157, 0.08);
+  color: #b7d5b9;
+  font-size: 12px;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.team-signal-badge a {
+  color: inherit;
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.team-signal-badge a + a::before {
+  content: '/';
+  margin-right: 6px;
+  color: var(--text-muted);
+}
+
+:root[data-theme='light'] .team-hero,
+:root[data-theme='light'] .team-panel,
+:root[data-theme='light'] .team-list-item,
+:root[data-theme='light'] .team-metrics div,
+:root[data-theme='light'] .team-member-row,
+:root[data-theme='light'] .team-message-row,
+:root[data-theme='light'] .team-rank-row,
+:root[data-theme='light'] .team-submission-item {
+  background: linear-gradient(180deg, rgba(248, 243, 234, 0.96), rgba(243, 237, 227, 0.94));
+  border-color: rgba(108, 87, 58, 0.12);
+}
+
+:root[data-theme='light'] .team-signal-badge {
+  color: #54705b;
+  background: rgba(143, 193, 157, 0.16);
+  border-color: rgba(84, 112, 91, 0.18);
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .landing-shell,
@@ -2448,22 +2741,38 @@ a {
   }
 
   .challenge-hero,
-  .challenge-list-item {
+  .challenge-list-item,
+  .team-hero,
+  .team-list-item {
     flex-direction: column;
     align-items: stretch;
   }
 
   .challenge-metrics-strip,
   .challenge-detail-grid,
-  .challenge-create-grid {
+  .challenge-create-grid,
+  .team-metrics,
+  .team-grid,
+  .team-create-grid,
+  .team-binding-grid {
     grid-template-columns: 1fr;
   }
 
-  .challenge-rank-row {
+  .challenge-rank-row,
+  .team-rank-row,
+  .team-member-row,
+  .team-message-row,
+  .team-link-form {
     grid-template-columns: 44px minmax(0, 1fr);
   }
 
   .challenge-rank-row span:nth-child(n + 3) {
+    grid-column: 2;
+  }
+
+  .team-rank-row span:nth-child(n + 3),
+  .team-member-row span:nth-child(n + 2),
+  .team-message-row span:nth-child(n + 3) {
     grid-column: 2;
   }
 

--- a/service/server/database.py
+++ b/service/server/database.py
@@ -783,6 +783,180 @@ def init_database():
     """)
 
     cursor.execute("""
+        CREATE TABLE IF NOT EXISTS signal_predictions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            signal_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            market TEXT,
+            symbol TEXT,
+            direction TEXT,
+            target_price REAL,
+            target_probability REAL,
+            confidence REAL,
+            horizon_start_at TEXT,
+            horizon_end_at TEXT,
+            invalid_if TEXT,
+            evidence_json TEXT,
+            extracted_by TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS signal_quality_scores (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            signal_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            verifiability_score REAL DEFAULT 0,
+            evidence_score REAL DEFAULT 0,
+            specificity_score REAL DEFAULT 0,
+            novelty_score REAL DEFAULT 0,
+            review_score REAL DEFAULT 0,
+            overall_score REAL DEFAULT 0,
+            model_version TEXT,
+            metadata_json TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS team_missions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_key TEXT UNIQUE NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT,
+            market TEXT NOT NULL,
+            symbol TEXT,
+            mission_type TEXT NOT NULL,
+            status TEXT DEFAULT 'upcoming',
+            team_size_min INTEGER DEFAULT 2,
+            team_size_max INTEGER DEFAULT 5,
+            assignment_mode TEXT DEFAULT 'random',
+            required_roles_json TEXT,
+            start_at TEXT NOT NULL,
+            submission_due_at TEXT NOT NULL,
+            settled_at TEXT,
+            rules_json TEXT,
+            experiment_key TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now'))
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS teams (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_id INTEGER NOT NULL,
+            team_key TEXT UNIQUE NOT NULL,
+            name TEXT NOT NULL,
+            status TEXT DEFAULT 'forming',
+            formation_method TEXT DEFAULT 'manual',
+            variant_key TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (mission_id) REFERENCES team_missions(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS team_mission_participants (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            status TEXT DEFAULT 'joined',
+            variant_key TEXT,
+            joined_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(mission_id, agent_id),
+            FOREIGN KEY (mission_id) REFERENCES team_missions(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS team_members (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            team_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            role TEXT,
+            status TEXT DEFAULT 'active',
+            joined_at TEXT DEFAULT (datetime('now')),
+            UNIQUE(team_id, agent_id),
+            FOREIGN KEY (team_id) REFERENCES teams(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS team_messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            team_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            signal_id INTEGER,
+            message_type TEXT NOT NULL,
+            content TEXT,
+            metadata_json TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (team_id) REFERENCES teams(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS team_submissions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_id INTEGER NOT NULL,
+            team_id INTEGER NOT NULL,
+            submitted_by_agent_id INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            content TEXT NOT NULL,
+            prediction_json TEXT,
+            confidence REAL,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (mission_id) REFERENCES team_missions(id),
+            FOREIGN KEY (team_id) REFERENCES teams(id),
+            FOREIGN KEY (submitted_by_agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS team_contributions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_id INTEGER NOT NULL,
+            team_id INTEGER NOT NULL,
+            agent_id INTEGER NOT NULL,
+            source_type TEXT NOT NULL,
+            source_id TEXT,
+            contribution_type TEXT NOT NULL,
+            contribution_score REAL DEFAULT 0,
+            metadata_json TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (mission_id) REFERENCES team_missions(id),
+            FOREIGN KEY (team_id) REFERENCES teams(id),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS team_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_id INTEGER NOT NULL,
+            team_id INTEGER NOT NULL,
+            return_pct REAL,
+            prediction_score REAL,
+            quality_score REAL,
+            consensus_gain REAL,
+            final_score REAL,
+            rank INTEGER,
+            metrics_json TEXT,
+            settled_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (mission_id) REFERENCES team_missions(id),
+            FOREIGN KEY (team_id) REFERENCES teams(id)
+        )
+    """)
+
+    cursor.execute("""
         CREATE TABLE IF NOT EXISTS market_news_snapshots (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             category TEXT NOT NULL,
@@ -1046,6 +1220,101 @@ def init_database():
     cursor.execute("""
         CREATE INDEX IF NOT EXISTS idx_challenge_results_challenge_rank
         ON challenge_results(challenge_id, rank)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_signal_predictions_signal
+        ON signal_predictions(signal_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_signal_predictions_agent_created
+        ON signal_predictions(agent_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_signal_quality_scores_signal
+        ON signal_quality_scores(signal_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_signal_quality_scores_agent_created
+        ON signal_quality_scores(agent_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_missions_status_due
+        ON team_missions(status, submission_due_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_missions_key
+        ON team_missions(mission_key)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_teams_mission_status
+        ON teams(mission_id, status)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_teams_key
+        ON teams(team_key)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_mission_participants_agent
+        ON team_mission_participants(agent_id, status)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_mission_participants_mission
+        ON team_mission_participants(mission_id, status)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_members_agent
+        ON team_members(agent_id, status)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_members_team
+        ON team_members(team_id, status)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_messages_team_created
+        ON team_messages(team_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_messages_signal
+        ON team_messages(signal_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_submissions_team_created
+        ON team_submissions(team_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_submissions_mission
+        ON team_submissions(mission_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_contributions_mission_agent
+        ON team_contributions(mission_id, agent_id)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_contributions_team
+        ON team_contributions(team_id, contribution_type)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_team_results_mission_rank
+        ON team_results(mission_id, rank)
     """)
 
     cursor.execute("""

--- a/service/server/research_exports.py
+++ b/service/server/research_exports.py
@@ -62,6 +62,60 @@ CHALLENGE_EXPORTS: dict[str, dict[str, Any]] = {
 }
 
 
+TEAM_MISSION_EXPORTS: dict[str, dict[str, Any]] = {
+    'team_missions.csv': {
+        'table': 'team_missions',
+        'alias': 'tm',
+        'columns': [
+            'id', 'mission_key', 'title', 'description', 'market', 'symbol',
+            'mission_type', 'status', 'team_size_min', 'team_size_max',
+            'assignment_mode', 'required_roles_json', 'start_at',
+            'submission_due_at', 'settled_at', 'rules_json', 'experiment_key',
+            'created_at', 'updated_at',
+        ],
+    },
+    'teams.csv': {
+        'table': 'teams',
+        'alias': 't',
+        'join': 'JOIN team_missions tm ON tm.id = t.mission_id',
+        'columns': [
+            'id', 'mission_id', 'team_key', 'name', 'status',
+            'formation_method', 'variant_key', 'created_at', 'updated_at',
+        ],
+    },
+    'team_members.csv': {
+        'table': 'team_members',
+        'alias': 'tmem',
+        'join': 'JOIN teams t ON t.id = tmem.team_id JOIN team_missions tm ON tm.id = t.mission_id',
+        'columns': ['id', 'team_id', 'agent_id', 'role', 'status', 'joined_at'],
+    },
+    'team_messages.csv': {
+        'table': 'team_messages',
+        'alias': 'tmsg',
+        'join': 'JOIN teams t ON t.id = tmsg.team_id JOIN team_missions tm ON tm.id = t.mission_id',
+        'columns': ['id', 'team_id', 'agent_id', 'signal_id', 'message_type', 'content', 'metadata_json', 'created_at'],
+    },
+    'team_submissions.csv': {
+        'table': 'team_submissions',
+        'alias': 'ts',
+        'join': 'JOIN team_missions tm ON tm.id = ts.mission_id',
+        'columns': ['id', 'mission_id', 'team_id', 'submitted_by_agent_id', 'title', 'content', 'prediction_json', 'confidence', 'created_at'],
+    },
+    'team_contributions.csv': {
+        'table': 'team_contributions',
+        'alias': 'tc',
+        'join': 'JOIN team_missions tm ON tm.id = tc.mission_id',
+        'columns': ['id', 'mission_id', 'team_id', 'agent_id', 'source_type', 'source_id', 'contribution_type', 'contribution_score', 'metadata_json', 'created_at'],
+    },
+    'team_results.csv': {
+        'table': 'team_results',
+        'alias': 'tr',
+        'join': 'JOIN team_missions tm ON tm.id = tr.mission_id',
+        'columns': ['id', 'mission_id', 'team_id', 'return_pct', 'prediction_score', 'quality_score', 'consensus_gain', 'final_score', 'rank', 'metrics_json', 'settled_at'],
+    },
+}
+
+
 def _build_challenge_filters(
     alias: str,
     *,
@@ -89,6 +143,38 @@ def _build_challenge_filters(
         params.append(challenge_key)
     if market:
         conditions.append(f"{challenge_alias}.market = ?")
+        params.append(market)
+
+    return (' WHERE ' + ' AND '.join(conditions)) if conditions else '', params
+
+
+def _build_team_filters(
+    alias: str,
+    *,
+    start_at: Optional[str] = None,
+    end_at: Optional[str] = None,
+    experiment_key: Optional[str] = None,
+    mission_key: Optional[str] = None,
+    market: Optional[str] = None,
+) -> tuple[str, list[Any]]:
+    conditions = []
+    params: list[Any] = []
+    mission_alias = alias if alias == 'tm' else 'tm'
+
+    if start_at:
+        conditions.append(f"{mission_alias}.submission_due_at >= ?")
+        params.append(start_at)
+    if end_at:
+        conditions.append(f"{mission_alias}.start_at <= ?")
+        params.append(end_at)
+    if experiment_key:
+        conditions.append(f"{mission_alias}.experiment_key = ?")
+        params.append(experiment_key)
+    if mission_key:
+        conditions.append(f"{mission_alias}.mission_key = ?")
+        params.append(mission_key)
+    if market:
+        conditions.append(f"{mission_alias}.market = ?")
         params.append(market)
 
     return (' WHERE ' + ' AND '.join(conditions)) if conditions else '', params
@@ -176,3 +262,77 @@ def export_challenge_tables(
 
     return written
 
+
+def fetch_team_export_rows(
+    filename: str,
+    *,
+    start_at: Optional[str] = None,
+    end_at: Optional[str] = None,
+    experiment_key: Optional[str] = None,
+    mission_key: Optional[str] = None,
+    market: Optional[str] = None,
+    limit: int = 100000,
+    offset: int = 0,
+) -> tuple[list[str], list[dict[str, Any]]]:
+    config = TEAM_MISSION_EXPORTS.get(filename)
+    if not config:
+        raise ValueError(f'Unsupported team mission export: {filename}')
+
+    alias = config['alias']
+    columns = config['columns']
+    select_columns = ', '.join(f'{alias}.{column} AS {column}' for column in columns)
+    join = f" {config['join']}" if config.get('join') else ''
+    where, params = _build_team_filters(
+        alias,
+        start_at=start_at,
+        end_at=end_at,
+        experiment_key=experiment_key,
+        mission_key=mission_key,
+        market=market,
+    )
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute(
+        f"""
+        SELECT {select_columns}
+        FROM {config['table']} {alias}
+        {join}
+        {where}
+        ORDER BY {alias}.id
+        LIMIT ? OFFSET ?
+        """,
+        params + [max(1, min(limit, 100000)), max(0, offset)],
+    )
+    rows = [dict(row) for row in cursor.fetchall()]
+    conn.close()
+    return columns, rows
+
+
+def export_team_tables(
+    output_dir: str | Path,
+    *,
+    start_at: Optional[str] = None,
+    end_at: Optional[str] = None,
+    experiment_key: Optional[str] = None,
+    mission_key: Optional[str] = None,
+    market: Optional[str] = None,
+) -> dict[str, str]:
+    target_dir = Path(output_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    written: dict[str, str] = {}
+
+    for filename in TEAM_MISSION_EXPORTS:
+        columns, rows = fetch_team_export_rows(
+            filename,
+            start_at=start_at,
+            end_at=end_at,
+            experiment_key=experiment_key,
+            mission_key=mission_key,
+            market=market,
+        )
+        path = target_dir / filename
+        write_csv(path, columns, rows)
+        written[filename] = str(path)
+
+    return written

--- a/service/server/routes.py
+++ b/service/server/routes.py
@@ -16,6 +16,7 @@ from routes_market import register_market_routes
 from routes_misc import register_misc_routes
 from routes_shared import RouteContext
 from routes_signals import register_signal_routes
+from routes_team_missions import register_team_mission_routes
 from routes_trading import register_trading_routes
 from routes_users import register_user_routes
 
@@ -44,6 +45,7 @@ def create_app() -> FastAPI:
     register_signal_routes(app, ctx)
     register_trading_routes(app, ctx)
     register_challenge_routes(app, ctx)
+    register_team_mission_routes(app, ctx)
     register_user_routes(app, ctx)
     register_misc_routes(app)
     return app

--- a/service/server/routes_models.py
+++ b/service/server/routes_models.py
@@ -60,6 +60,8 @@ class StrategyRequest(BaseModel):
     symbols: Optional[str] = None
     tags: Optional[str] = None
     challenge_key: Optional[str] = None
+    mission_key: Optional[str] = None
+    team_key: Optional[str] = None
 
 
 class DiscussionRequest(BaseModel):
@@ -69,6 +71,8 @@ class DiscussionRequest(BaseModel):
     content: str
     tags: Optional[str] = None
     challenge_key: Optional[str] = None
+    mission_key: Optional[str] = None
+    team_key: Optional[str] = None
 
 
 class ChallengeCreateRequest(BaseModel):
@@ -103,6 +107,50 @@ class ChallengeSubmissionRequest(BaseModel):
 
 class ChallengeSettleRequest(BaseModel):
     force: bool = False
+
+
+class TeamMissionCreateRequest(BaseModel):
+    mission_key: Optional[str] = None
+    title: str
+    description: Optional[str] = None
+    market: str
+    symbol: Optional[str] = None
+    mission_type: str = "consensus"
+    status: Optional[str] = None
+    team_size_min: int = 2
+    team_size_max: int = 5
+    assignment_mode: str = "random"
+    required_roles_json: Optional[List[str]] = None
+    start_at: Optional[str] = None
+    submission_due_at: Optional[str] = None
+    rules_json: Optional[Dict[str, Any]] = None
+    experiment_key: Optional[str] = None
+
+
+class TeamJoinRequest(BaseModel):
+    team_key: Optional[str] = None
+    name: Optional[str] = None
+    role: Optional[str] = None
+    variant_key: Optional[str] = None
+
+
+class TeamSubmissionRequest(BaseModel):
+    title: str
+    content: str
+    prediction_json: Optional[Dict[str, Any]] = None
+    confidence: Optional[float] = None
+
+
+class TeamMessageLinkRequest(BaseModel):
+    signal_id: int
+    message_type: str = "signal"
+    content: Optional[str] = None
+    metadata_json: Optional[Dict[str, Any]] = None
+
+
+class TeamMissionSettleRequest(BaseModel):
+    force: bool = False
+    assignment_mode: Optional[str] = None
 
 
 class ReplyRequest(BaseModel):

--- a/service/server/routes_signals.py
+++ b/service/server/routes_signals.py
@@ -36,6 +36,7 @@ from routes_shared import (
     validate_executed_at,
 )
 from services import _add_agent_points, _get_agent_by_token, _reserve_signal_id, _update_position_from_signal
+from team_missions import TeamMissionError, record_team_message_from_signal, record_team_reply_from_parent_signal
 from utils import _extract_token
 
 
@@ -471,8 +472,18 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                     content=data.content,
                     prediction_json=None,
                 )
+            if data.mission_key or data.team_key:
+                record_team_message_from_signal(
+                    cursor,
+                    mission_key=data.mission_key,
+                    team_key=data.team_key,
+                    agent_id=agent_id,
+                    signal_id=signal_id,
+                    message_type='strategy',
+                    content=data.content,
+                )
             conn.commit()
-        except ChallengeError as exc:
+        except (ChallengeError, TeamMissionError) as exc:
             conn.rollback()
             conn.close()
             raise HTTPException(status_code=400, detail=str(exc))
@@ -547,8 +558,18 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                     content=data.content,
                     prediction_json=None,
                 )
+            if data.mission_key or data.team_key:
+                record_team_message_from_signal(
+                    cursor,
+                    mission_key=data.mission_key,
+                    team_key=data.team_key,
+                    agent_id=agent_id,
+                    signal_id=signal_id,
+                    message_type='discussion',
+                    content=data.content,
+                )
             conn.commit()
-        except ChallengeError as exc:
+        except (ChallengeError, TeamMissionError) as exc:
             conn.rollback()
             conn.close()
             raise HTTPException(status_code=400, detail=str(exc))
@@ -830,6 +851,33 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
 
         cursor.execute(query, params)
         rows = cursor.fetchall()
+        signal_ids = [row['signal_id'] for row in rows]
+        team_badges_by_signal: dict[int, list[dict[str, Any]]] = {}
+        if signal_ids:
+            placeholders = ','.join('?' for _ in signal_ids)
+            cursor.execute(
+                f"""
+                SELECT
+                    tmsg.signal_id,
+                    tm.mission_key,
+                    tm.title AS mission_title,
+                    t.team_key,
+                    t.name AS team_name
+                FROM team_messages tmsg
+                JOIN teams t ON t.id = tmsg.team_id
+                JOIN team_missions tm ON tm.id = t.mission_id
+                WHERE tmsg.signal_id IN ({placeholders})
+                ORDER BY tmsg.created_at DESC, tmsg.id DESC
+                """,
+                signal_ids,
+            )
+            for badge_row in cursor.fetchall():
+                team_badges_by_signal.setdefault(badge_row['signal_id'], []).append({
+                    'mission_key': badge_row['mission_key'],
+                    'mission_title': badge_row['mission_title'],
+                    'team_key': badge_row['team_key'],
+                    'team_name': badge_row['team_name'],
+                })
         followed_author_ids = set()
         if viewer:
             cursor.execute(
@@ -854,6 +902,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                 signal_dict['participant_count'] = 1
             if signal_dict.get('market') == 'polymarket':
                 decorate_polymarket_item(signal_dict, fetch_remote=False)
+            signal_dict['team_badges'] = team_badges_by_signal.get(signal_dict.get('signal_id'), [])
             signal_dict['is_following_author'] = signal_dict['agent_id'] in followed_author_ids
             signals.append(signal_dict)
 
@@ -1074,6 +1123,17 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
             """,
             (data.signal_id, agent_id, data.content),
         )
+        reply_id = cursor.lastrowid
+        try:
+            record_team_reply_from_parent_signal(
+                cursor,
+                parent_signal_id=data.signal_id,
+                reply_id=reply_id,
+                agent_id=agent_id,
+                content=data.content,
+            )
+        except TeamMissionError:
+            pass
         conn.commit()
         conn.close()
 

--- a/service/server/routes_team_missions.py
+++ b/service/server/routes_team_missions.py
@@ -1,0 +1,197 @@
+"""Team mission API routes."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Header, HTTPException
+
+from routes_models import (
+    TeamJoinRequest,
+    TeamMessageLinkRequest,
+    TeamMissionCreateRequest,
+    TeamMissionSettleRequest,
+    TeamSubmissionRequest,
+)
+from routes_shared import RouteContext
+from services import _get_agent_by_token
+from team_missions import (
+    TeamMissionError,
+    TeamMissionNotFound,
+    auto_form_teams,
+    create_team_for_mission,
+    create_team_mission,
+    get_agent_team_missions,
+    get_mission_teams,
+    get_team,
+    get_team_mission,
+    get_team_mission_leaderboard,
+    get_team_submissions,
+    join_team,
+    join_team_mission,
+    link_signal_to_team,
+    list_team_missions,
+    settle_team_mission,
+)
+from utils import _extract_token
+
+
+def _to_http_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, TeamMissionNotFound):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, TeamMissionError):
+        return HTTPException(status_code=400, detail=str(exc))
+    return HTTPException(status_code=500, detail=f"Team mission request failed: {exc}")
+
+
+def _require_agent(authorization: str | None) -> dict:
+    token = _extract_token(authorization)
+    agent = _get_agent_by_token(token)
+    if not agent:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return agent
+
+
+def register_team_mission_routes(app: FastAPI, ctx: RouteContext) -> None:
+    @app.get("/api/team-missions")
+    async def api_list_team_missions(status: str | None = None, limit: int = 50, offset: int = 0):
+        try:
+            return list_team_missions(status=status, limit=limit, offset=offset)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/team-missions")
+    async def api_create_team_mission(data: TeamMissionCreateRequest, authorization: str = Header(None)):
+        agent = _require_agent(authorization)
+        try:
+            return create_team_mission(data, created_by_agent_id=agent["id"])
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get("/api/team-missions/me")
+    async def api_my_team_missions(authorization: str = Header(None)):
+        agent = _require_agent(authorization)
+        try:
+            return get_agent_team_missions(agent["id"])
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get("/api/team-missions/{mission_key}/teams")
+    async def api_mission_teams(mission_key: str):
+        try:
+            return get_mission_teams(mission_key)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get("/api/team-missions/{mission_key}/leaderboard")
+    async def api_mission_leaderboard(mission_key: str):
+        try:
+            return get_team_mission_leaderboard(mission_key)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/team-missions/{mission_key}/join")
+    async def api_join_team_mission(
+        mission_key: str,
+        data: TeamJoinRequest | None = None,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            return join_team_mission(mission_key, agent["id"], data)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/team-missions/{mission_key}/teams")
+    async def api_create_team(
+        mission_key: str,
+        data: TeamJoinRequest | None = None,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            return create_team_for_mission(mission_key, agent["id"], data)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/team-missions/{mission_key}/auto-form-teams")
+    async def api_auto_form_teams(
+        mission_key: str,
+        data: TeamMissionSettleRequest | None = None,
+        authorization: str = Header(None),
+    ):
+        _require_agent(authorization)
+        try:
+            return auto_form_teams(mission_key, assignment_mode=data.assignment_mode if data else None)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/team-missions/{mission_key}/settle")
+    async def api_settle_team_mission(
+        mission_key: str,
+        data: TeamMissionSettleRequest | None = None,
+        authorization: str = Header(None),
+    ):
+        _require_agent(authorization)
+        try:
+            return settle_team_mission(mission_key, force=bool(data.force if data else False))
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get("/api/team-missions/{mission_key}")
+    async def api_get_team_mission(mission_key: str):
+        try:
+            return get_team_mission(mission_key)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get("/api/teams/{team_key}/submissions")
+    async def api_team_submissions(team_key: str):
+        try:
+            return get_team_submissions(team_key)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/teams/{team_key}/join")
+    async def api_join_team(
+        team_key: str,
+        data: TeamJoinRequest | None = None,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            return join_team(team_key, agent["id"], data)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/teams/{team_key}/messages/link-signal")
+    async def api_link_team_signal(
+        team_key: str,
+        data: TeamMessageLinkRequest,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            return link_signal_to_team(team_key, agent["id"], data)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.post("/api/teams/{team_key}/submit")
+    async def api_submit_team(
+        team_key: str,
+        data: TeamSubmissionRequest,
+        authorization: str = Header(None),
+    ):
+        agent = _require_agent(authorization)
+        try:
+            from team_missions import submit_team
+
+            return submit_team(team_key, agent["id"], data)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get("/api/teams/{team_key}")
+    async def api_get_team(team_key: str):
+        try:
+            return get_team(team_key)
+        except Exception as exc:
+            raise _to_http_error(exc)
+

--- a/service/server/tasks.py
+++ b/service/server/tasks.py
@@ -731,11 +731,68 @@ async def settle_challenges_loop():
         await asyncio.sleep(interval_s)
 
 
+async def form_team_missions_loop():
+    """Background task to form teams for active missions with enough participants."""
+    from team_missions import form_due_team_missions
+
+    await asyncio.sleep(18)
+
+    while True:
+        interval_s = _env_int("TEAM_MISSION_FORM_INTERVAL", 180, minimum=30)
+        try:
+            formed = await asyncio.to_thread(form_due_team_missions)
+            if formed:
+                print(f"[Team Mission Former] formed_missions={len(formed)}")
+        except Exception as e:
+            print(f"[Team Mission Former Error] {e}")
+
+        await asyncio.sleep(interval_s)
+
+
+async def score_team_contributions_loop():
+    """Background task to score new team messages/submissions into contribution records."""
+    from team_missions import score_team_contributions
+
+    await asyncio.sleep(22)
+
+    while True:
+        interval_s = _env_int("TEAM_CONTRIBUTION_SCORE_INTERVAL", 180, minimum=30)
+        try:
+            result = await asyncio.to_thread(score_team_contributions)
+            if result.get("inserted"):
+                print(f"[Team Contribution Scorer] inserted={result['inserted']}")
+        except Exception as e:
+            print(f"[Team Contribution Scorer Error] {e}")
+
+        await asyncio.sleep(interval_s)
+
+
+async def settle_team_missions_loop():
+    """Background task to settle team missions after their submission deadline."""
+    from team_missions import settle_due_team_missions
+
+    await asyncio.sleep(26)
+
+    while True:
+        interval_s = _env_int("TEAM_MISSION_SETTLE_INTERVAL", 180, minimum=30)
+        try:
+            settled = await asyncio.to_thread(settle_due_team_missions)
+            if settled:
+                print(f"[Team Mission Settler] settled={len(settled)}")
+        except Exception as e:
+            print(f"[Team Mission Settler Error] {e}")
+
+        await asyncio.sleep(interval_s)
+
+
 BACKGROUND_TASK_REGISTRY = {
     "prices": update_position_prices,
     "profit_history": record_profit_history,
     "polymarket_settlement": settle_polymarket_positions,
     "challenge_settlement": settle_challenges_loop,
+    "team_mission_form": form_team_missions_loop,
+    "team_contribution_score": score_team_contributions_loop,
+    "team_mission_settlement": settle_team_missions_loop,
     "market_news": refresh_market_news_snapshots_loop,
     "macro_signals": refresh_macro_signal_snapshots_loop,
     "etf_flows": refresh_etf_flow_snapshots_loop,

--- a/service/server/team_matching.py
+++ b/service/server/team_matching.py
@@ -1,0 +1,124 @@
+"""Team mission matching helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from typing import Any
+
+
+def stable_seed(value: str) -> int:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()
+    return int(digest[:12], 16)
+
+
+def _agent_feature(cursor: Any, agent_id: int) -> dict[str, Any]:
+    cursor.execute(
+        """
+        SELECT
+            SUM(CASE WHEN message_type = 'operation' THEN 1 ELSE 0 END) AS trade_count,
+            SUM(CASE WHEN message_type = 'strategy' THEN 1 ELSE 0 END) AS strategy_count,
+            SUM(CASE WHEN message_type = 'discussion' THEN 1 ELSE 0 END) AS discussion_count
+        FROM signals
+        WHERE agent_id = ? AND created_at >= datetime('now', '-30 day')
+        """,
+        (agent_id,),
+    )
+    activity = cursor.fetchone()
+
+    cursor.execute(
+        """
+        SELECT market, COUNT(*) AS count
+        FROM signals
+        WHERE agent_id = ? AND created_at >= datetime('now', '-30 day')
+        GROUP BY market
+        ORDER BY count DESC, market ASC
+        LIMIT 1
+        """,
+        (agent_id,),
+    )
+    market_row = cursor.fetchone()
+
+    cursor.execute(
+        """
+        SELECT profit
+        FROM profit_history
+        WHERE agent_id = ?
+        ORDER BY recorded_at DESC, id DESC
+        LIMIT 1
+        """,
+        (agent_id,),
+    )
+    profit_row = cursor.fetchone()
+
+    trade_count = int(activity["trade_count"] or 0) if activity else 0
+    strategy_count = int(activity["strategy_count"] or 0) if activity else 0
+    discussion_count = int(activity["discussion_count"] or 0) if activity else 0
+    return_pct_30d = float(profit_row["profit"] or 0) / 100000.0 * 100 if profit_row else 0.0
+    activity_score = trade_count * 2 + strategy_count * 1.4 + discussion_count
+
+    return {
+        "agent_id": agent_id,
+        "return_pct_30d": return_pct_30d,
+        "trade_count_30d": trade_count,
+        "strategy_count_30d": strategy_count,
+        "discussion_count_30d": discussion_count,
+        "primary_market": market_row["market"] if market_row else "",
+        "feature_score": return_pct_30d + activity_score,
+    }
+
+
+def build_agent_features(cursor: Any, agent_ids: list[int]) -> list[dict[str, Any]]:
+    return [_agent_feature(cursor, agent_id) for agent_id in agent_ids]
+
+
+def _chunks(items: list[dict[str, Any]], team_size: int) -> list[list[dict[str, Any]]]:
+    return [items[index:index + team_size] for index in range(0, len(items), team_size)]
+
+
+def _heterogeneous_order(features: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    ordered = sorted(features, key=lambda item: (item["primary_market"], item["feature_score"], item["agent_id"]))
+    result: list[dict[str, Any]] = []
+    left = 0
+    right = len(ordered) - 1
+    while left <= right:
+        if left == right:
+            result.append(ordered[left])
+        else:
+            result.append(ordered[right])
+            result.append(ordered[left])
+        left += 1
+        right -= 1
+    return result
+
+
+def form_team_groups(
+    features: list[dict[str, Any]],
+    *,
+    assignment_mode: str,
+    team_size: int,
+    mission_key: str,
+) -> list[list[dict[str, Any]]]:
+    team_size = max(1, team_size)
+    mode = (assignment_mode or "random").strip().lower()
+    items = list(features)
+
+    if mode == "homogeneous":
+        items.sort(key=lambda item: (item["primary_market"], item["feature_score"], item["agent_id"]))
+    elif mode == "heterogeneous":
+        items = _heterogeneous_order(items)
+    else:
+        rng = random.Random(stable_seed(f"{mission_key}:random"))
+        rng.shuffle(items)
+
+    return [chunk for chunk in _chunks(items, team_size) if chunk]
+
+
+def assign_roles(members: list[dict[str, Any]], required_roles: list[str]) -> dict[int, str]:
+    roles = [role for role in required_roles if role]
+    if not roles:
+        roles = ["lead", "analyst", "risk", "scribe"]
+    return {
+        member["agent_id"]: roles[index % len(roles)]
+        for index, member in enumerate(members)
+    }

--- a/service/server/team_missions.py
+++ b/service/server/team_missions.py
@@ -1,0 +1,1384 @@
+"""Team mission creation, matching, collaboration, submission, and settlement."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from database import begin_write_transaction, get_db_connection
+from experiment_events import record_event
+from rewards import grant_agent_reward
+from routes_shared import utc_now_iso_z
+from team_matching import assign_roles, build_agent_features, form_team_groups
+from team_scoring import (
+    contribution_score_for_message,
+    contribution_score_for_submission,
+    score_team_results,
+)
+
+
+class TeamMissionError(ValueError):
+    pass
+
+
+class TeamMissionNotFound(TeamMissionError):
+    pass
+
+
+DEFAULT_TEAM_REWARDS = {"1": 80, "2": 40, "3": 20}
+DEFAULT_REQUIRED_ROLES = ["lead", "analyst", "risk", "scribe"]
+
+
+def _row_dict(row: Any) -> dict[str, Any]:
+    return dict(row) if row is not None and not isinstance(row, dict) else (row or {})
+
+
+def _model_dump(data: Any) -> dict[str, Any]:
+    if data is None:
+        return {}
+    if isinstance(data, dict):
+        return data
+    if hasattr(data, "model_dump"):
+        return data.model_dump()
+    return dict(data)
+
+
+def _json_dumps(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+
+
+def _json_loads(value: Any, default: Any = None) -> Any:
+    if value in (None, ""):
+        return default
+    if isinstance(value, (dict, list)):
+        return value
+    try:
+        return json.loads(value)
+    except Exception:
+        return default
+
+
+def _parse_dt(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except Exception as exc:
+        raise TeamMissionError(f"Invalid datetime: {value}") from exc
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_key(key: Optional[str], title: str, prefix: str) -> str:
+    candidate = (key or "").strip().lower()
+    if not candidate:
+        candidate = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+        candidate = f"{candidate[:44] or prefix}-{uuid.uuid4().hex[:8]}"
+    candidate = re.sub(r"[^a-z0-9_\-]+", "-", candidate).strip("-_")
+    if not candidate:
+        raise TeamMissionError(f"{prefix}_key is required")
+    return candidate[:90]
+
+
+def _derive_status(start_at: str, due_at: str, requested_status: Optional[str] = None) -> str:
+    if requested_status:
+        normalized = requested_status.strip().lower()
+        if normalized not in {"upcoming", "active", "settled", "canceled"}:
+            raise TeamMissionError("Unsupported mission status")
+        return normalized
+    now = datetime.now(timezone.utc)
+    if _parse_dt(start_at) > now:
+        return "upcoming"
+    return "active"
+
+
+def _serialize_mission(row: Any, team_count: Optional[int] = None, participant_count: Optional[int] = None) -> dict[str, Any]:
+    data = _row_dict(row)
+    if not data:
+        return {}
+    data["required_roles"] = _json_loads(data.get("required_roles_json"), [])
+    data["rules"] = _json_loads(data.get("rules_json"), {})
+    if team_count is not None:
+        data["team_count"] = team_count
+    if participant_count is not None:
+        data["participant_count"] = participant_count
+    return data
+
+
+def _serialize_team(row: Any, member_count: Optional[int] = None) -> dict[str, Any]:
+    data = _row_dict(row)
+    if member_count is not None:
+        data["member_count"] = member_count
+    return data
+
+
+def refresh_mission_statuses(cursor: Any) -> None:
+    now = utc_now_iso_z()
+    cursor.execute(
+        """
+        UPDATE team_missions
+        SET status = 'active', updated_at = ?
+        WHERE status = 'upcoming' AND start_at <= ? AND submission_due_at > ?
+        """,
+        (now, now, now),
+    )
+
+
+def _load_mission(cursor: Any, *, mission_key: Optional[str] = None, mission_id: Optional[int] = None) -> dict[str, Any]:
+    if mission_id is not None:
+        cursor.execute("SELECT * FROM team_missions WHERE id = ?", (mission_id,))
+    else:
+        cursor.execute("SELECT * FROM team_missions WHERE mission_key = ?", (mission_key,))
+    row = cursor.fetchone()
+    if not row:
+        raise TeamMissionNotFound("Team mission not found")
+    return _row_dict(row)
+
+
+def _load_team(cursor: Any, *, team_key: Optional[str] = None, team_id: Optional[int] = None) -> dict[str, Any]:
+    if team_id is not None:
+        cursor.execute("SELECT * FROM teams WHERE id = ?", (team_id,))
+    else:
+        cursor.execute("SELECT * FROM teams WHERE team_key = ?", (team_key,))
+    row = cursor.fetchone()
+    if not row:
+        raise TeamMissionNotFound("Team not found")
+    return _row_dict(row)
+
+
+def _resolve_variant(cursor: Any, experiment_key: Optional[str], agent_id: int, requested_variant: Optional[str]) -> Optional[str]:
+    variant_key = (requested_variant or "").strip() or None
+    if not experiment_key:
+        return variant_key
+
+    cursor.execute(
+        """
+        SELECT variant_key
+        FROM experiment_assignments
+        WHERE experiment_key = ? AND unit_type = 'agent' AND unit_id = ?
+        """,
+        (experiment_key, agent_id),
+    )
+    row = cursor.fetchone()
+    if row:
+        return row["variant_key"]
+    if variant_key:
+        cursor.execute(
+            """
+            INSERT INTO experiment_assignments
+            (experiment_key, unit_type, unit_id, variant_key, assignment_reason, metadata_json, created_at)
+            VALUES (?, 'agent', ?, ?, 'team_mission_join', ?, ?)
+            """,
+            (experiment_key, agent_id, variant_key, _json_dumps({"source": "team_mission_join"}), utc_now_iso_z()),
+        )
+    return variant_key
+
+
+def create_team_mission(data: Any, created_by_agent_id: Optional[int] = None) -> dict[str, Any]:
+    payload = _model_dump(data)
+    title = (payload.get("title") or "").strip()
+    if not title:
+        raise TeamMissionError("title is required")
+    market = (payload.get("market") or "").strip()
+    if not market:
+        raise TeamMissionError("market is required")
+
+    now_dt = datetime.now(timezone.utc)
+    start_at = _iso(_parse_dt(payload.get("start_at")) or now_dt)
+    due_at = _iso(_parse_dt(payload.get("submission_due_at")) or (now_dt + timedelta(hours=24)))
+    if _parse_dt(due_at) <= _parse_dt(start_at):
+        raise TeamMissionError("submission_due_at must be after start_at")
+
+    team_size_min = int(payload.get("team_size_min") or 2)
+    team_size_max = int(payload.get("team_size_max") or max(2, team_size_min))
+    if team_size_min <= 0 or team_size_max < team_size_min:
+        raise TeamMissionError("Invalid team size settings")
+
+    mission_key = _normalize_key(payload.get("mission_key"), title, "mission")
+    required_roles = payload.get("required_roles_json") or DEFAULT_REQUIRED_ROLES
+    rules = payload.get("rules_json") or {}
+    if isinstance(required_roles, str):
+        required_roles = _json_loads(required_roles, DEFAULT_REQUIRED_ROLES)
+    if isinstance(rules, str):
+        rules = _json_loads(rules, {})
+    if "team_reward_points" not in rules and rules.get("grant_rewards", True):
+        rules["team_reward_points"] = DEFAULT_TEAM_REWARDS
+    if "contribution_reward_per_point" not in rules and rules.get("grant_rewards", True):
+        rules["contribution_reward_per_point"] = 1
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        cursor.execute(
+            """
+            INSERT INTO team_missions
+            (mission_key, title, description, market, symbol, mission_type, status,
+             team_size_min, team_size_max, assignment_mode, required_roles_json,
+             start_at, submission_due_at, rules_json, experiment_key, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                mission_key,
+                title,
+                payload.get("description"),
+                market,
+                (payload.get("symbol") or "").strip() or None,
+                (payload.get("mission_type") or "consensus").strip(),
+                _derive_status(start_at, due_at, payload.get("status")),
+                team_size_min,
+                team_size_max,
+                (payload.get("assignment_mode") or "random").strip().lower(),
+                _json_dumps(required_roles),
+                start_at,
+                due_at,
+                _json_dumps(rules),
+                (payload.get("experiment_key") or "").strip() or None,
+                utc_now_iso_z(),
+                utc_now_iso_z(),
+            ),
+        )
+        mission_id = cursor.lastrowid
+        record_event(
+            "team_mission_created",
+            actor_agent_id=created_by_agent_id,
+            object_type="team_mission",
+            object_id=mission_id,
+            market=market,
+            experiment_key=(payload.get("experiment_key") or "").strip() or None,
+            metadata={"mission_key": mission_key, "assignment_mode": payload.get("assignment_mode") or "random"},
+            cursor=cursor,
+        )
+        conn.commit()
+        mission = _load_mission(cursor, mission_id=mission_id)
+        return _serialize_mission(mission, team_count=0, participant_count=0)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def list_team_missions(status: Optional[str] = None, limit: int = 50, offset: int = 0) -> dict[str, Any]:
+    limit = max(1, min(limit, 200))
+    offset = max(0, offset)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_mission_statuses(cursor)
+        conn.commit()
+        params: list[Any] = []
+        where = "1=1"
+        if status:
+            where = "tm.status = ?"
+            params.append(status)
+        cursor.execute(f"SELECT COUNT(*) AS total FROM team_missions tm WHERE {where}", params)
+        total = cursor.fetchone()["total"]
+        cursor.execute(
+            f"""
+            SELECT tm.*,
+                   (SELECT COUNT(*) FROM teams t WHERE t.mission_id = tm.id) AS team_count,
+                   (SELECT COUNT(*) FROM team_mission_participants tmp WHERE tmp.mission_id = tm.id) AS participant_count
+            FROM team_missions tm
+            WHERE {where}
+            ORDER BY tm.start_at DESC, tm.id DESC
+            LIMIT ? OFFSET ?
+            """,
+            params + [limit, offset],
+        )
+        return {
+            "missions": [
+                _serialize_mission(row, row["team_count"], row["participant_count"])
+                for row in cursor.fetchall()
+            ],
+            "total": total,
+        }
+    finally:
+        conn.close()
+
+
+def get_team_mission(mission_key: str) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_mission_statuses(cursor)
+        conn.commit()
+        mission = _load_mission(cursor, mission_key=mission_key)
+        cursor.execute("SELECT COUNT(*) AS count FROM teams WHERE mission_id = ?", (mission["id"],))
+        team_count = cursor.fetchone()["count"]
+        cursor.execute("SELECT COUNT(*) AS count FROM team_mission_participants WHERE mission_id = ?", (mission["id"],))
+        participant_count = cursor.fetchone()["count"]
+        result = _serialize_mission(mission, team_count=team_count, participant_count=participant_count)
+        result["teams"] = get_mission_teams(mission_key)["teams"]
+        return result
+    finally:
+        conn.close()
+
+
+def join_team_mission(mission_key: str, agent_id: int, data: Any = None) -> dict[str, Any]:
+    payload = _model_dump(data)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        refresh_mission_statuses(cursor)
+        mission = _load_mission(cursor, mission_key=mission_key)
+        if mission["status"] not in {"upcoming", "active"}:
+            raise TeamMissionError("Mission is not joinable")
+        variant_key = _resolve_variant(cursor, mission.get("experiment_key"), agent_id, payload.get("variant_key"))
+        cursor.execute(
+            """
+            SELECT *
+            FROM team_mission_participants
+            WHERE mission_id = ? AND agent_id = ?
+            """,
+            (mission["id"], agent_id),
+        )
+        existing = cursor.fetchone()
+        if existing:
+            conn.commit()
+            return {"joined": False, "idempotent": True, "participant": dict(existing)}
+        cursor.execute(
+            """
+            INSERT INTO team_mission_participants
+            (mission_id, agent_id, status, variant_key, joined_at)
+            VALUES (?, ?, 'joined', ?, ?)
+            """,
+            (mission["id"], agent_id, variant_key, utc_now_iso_z()),
+        )
+        participant_id = cursor.lastrowid
+        record_event(
+            "team_mission_joined",
+            actor_agent_id=agent_id,
+            object_type="team_mission_participant",
+            object_id=participant_id,
+            market=mission["market"],
+            experiment_key=mission.get("experiment_key"),
+            variant_key=variant_key,
+            metadata={"mission_key": mission["mission_key"], "mission_id": mission["id"]},
+            cursor=cursor,
+        )
+        conn.commit()
+        cursor.execute("SELECT * FROM team_mission_participants WHERE id = ?", (participant_id,))
+        return {"joined": True, "idempotent": False, "participant": dict(cursor.fetchone())}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _insert_team(
+    cursor: Any,
+    mission: dict[str, Any],
+    *,
+    team_key: str,
+    name: str,
+    formation_method: str,
+    variant_key: Optional[str],
+) -> int:
+    now = utc_now_iso_z()
+    cursor.execute(
+        """
+        INSERT INTO teams
+        (mission_id, team_key, name, status, formation_method, variant_key, created_at, updated_at)
+        VALUES (?, ?, ?, 'active', ?, ?, ?, ?)
+        """,
+        (mission["id"], team_key, name, formation_method, variant_key, now, now),
+    )
+    team_id = cursor.lastrowid
+    record_event(
+        "team_created",
+        object_type="team",
+        object_id=team_id,
+        market=mission["market"],
+        experiment_key=mission.get("experiment_key"),
+        variant_key=variant_key,
+        metadata={"mission_key": mission["mission_key"], "team_key": team_key, "formation_method": formation_method},
+        cursor=cursor,
+    )
+    return team_id
+
+
+def _insert_team_member(
+    cursor: Any,
+    mission: dict[str, Any],
+    team: dict[str, Any],
+    agent_id: int,
+    *,
+    role: Optional[str],
+    variant_key: Optional[str],
+) -> Optional[int]:
+    cursor.execute(
+        """
+        SELECT id
+        FROM team_members
+        WHERE team_id = ? AND agent_id = ?
+        """,
+        (team["id"], agent_id),
+    )
+    if cursor.fetchone():
+        return None
+    cursor.execute(
+        """
+        INSERT INTO team_members (team_id, agent_id, role, status, joined_at)
+        VALUES (?, ?, ?, 'active', ?)
+        """,
+        (team["id"], agent_id, role, utc_now_iso_z()),
+    )
+    member_id = cursor.lastrowid
+    record_event(
+        "team_joined",
+        actor_agent_id=agent_id,
+        object_type="team_member",
+        object_id=member_id,
+        market=mission["market"],
+        experiment_key=mission.get("experiment_key"),
+        variant_key=variant_key,
+        metadata={"mission_key": mission["mission_key"], "team_key": team["team_key"], "role": role},
+        cursor=cursor,
+    )
+    if role:
+        record_event(
+            "team_role_assigned",
+            actor_agent_id=agent_id,
+            object_type="team_member",
+            object_id=member_id,
+            market=mission["market"],
+            experiment_key=mission.get("experiment_key"),
+            variant_key=variant_key,
+            metadata={"mission_key": mission["mission_key"], "team_key": team["team_key"], "role": role},
+            cursor=cursor,
+        )
+    return member_id
+
+
+def create_team_for_mission(mission_key: str, agent_id: int, data: Any = None) -> dict[str, Any]:
+    payload = _model_dump(data)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        mission = _load_mission(cursor, mission_key=mission_key)
+        if mission["status"] not in {"upcoming", "active"}:
+            raise TeamMissionError("Mission is not accepting teams")
+        requested_key = payload.get("team_key")
+        team_name = (payload.get("name") or f"{mission['title']} Team").strip()
+        team_key = _normalize_key(requested_key, team_name, "team")
+        role = (payload.get("role") or "").strip() or None
+        variant_key = _resolve_variant(cursor, mission.get("experiment_key"), agent_id, payload.get("variant_key"))
+        cursor.execute(
+            """
+            SELECT id
+            FROM team_mission_participants
+            WHERE mission_id = ? AND agent_id = ?
+            """,
+            (mission["id"], agent_id),
+        )
+        if not cursor.fetchone():
+            cursor.execute(
+                """
+                INSERT INTO team_mission_participants
+                (mission_id, agent_id, status, variant_key, joined_at)
+                VALUES (?, ?, 'joined', ?, ?)
+                """,
+                (mission["id"], agent_id, variant_key, utc_now_iso_z()),
+            )
+        team_id = _insert_team(
+            cursor,
+            mission,
+            team_key=team_key,
+            name=team_name,
+            formation_method="manual",
+            variant_key=variant_key,
+        )
+        team = _load_team(cursor, team_id=team_id)
+        _insert_team_member(cursor, mission, team, agent_id, role=role, variant_key=variant_key)
+        conn.commit()
+        return get_team(team_key)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def join_team(team_key: str, agent_id: int, data: Any = None) -> dict[str, Any]:
+    payload = _model_dump(data)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        team = _load_team(cursor, team_key=team_key)
+        mission = _load_mission(cursor, mission_id=team["mission_id"])
+        if mission["status"] not in {"upcoming", "active"}:
+            raise TeamMissionError("Mission is not joinable")
+        cursor.execute("SELECT COUNT(*) AS count FROM team_members WHERE team_id = ? AND status = 'active'", (team["id"],))
+        if cursor.fetchone()["count"] >= int(mission["team_size_max"]):
+            raise TeamMissionError("Team is full")
+        role = (payload.get("role") or "").strip() or None
+        variant_key = _resolve_variant(cursor, mission.get("experiment_key"), agent_id, payload.get("variant_key") or team.get("variant_key"))
+        cursor.execute(
+            """
+            SELECT id
+            FROM team_mission_participants
+            WHERE mission_id = ? AND agent_id = ?
+            """,
+            (mission["id"], agent_id),
+        )
+        if not cursor.fetchone():
+            cursor.execute(
+                """
+                INSERT INTO team_mission_participants
+                (mission_id, agent_id, status, variant_key, joined_at)
+                VALUES (?, ?, 'joined', ?, ?)
+                """,
+                (mission["id"], agent_id, variant_key, utc_now_iso_z()),
+            )
+        member_id = _insert_team_member(cursor, mission, team, agent_id, role=role, variant_key=variant_key)
+        conn.commit()
+        return {"joined": member_id is not None, "idempotent": member_id is None, "team": get_team(team_key)}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def auto_form_teams(mission_key: str, assignment_mode: Optional[str] = None) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        mission = _load_mission(cursor, mission_key=mission_key)
+        mode = (assignment_mode or mission.get("assignment_mode") or "random").strip().lower()
+        cursor.execute("SELECT COUNT(*) AS count FROM teams WHERE mission_id = ?", (mission["id"],))
+        if cursor.fetchone()["count"]:
+            conn.commit()
+            return get_mission_teams(mission_key)
+
+        cursor.execute(
+            """
+            SELECT agent_id, variant_key
+            FROM team_mission_participants
+            WHERE mission_id = ? AND status = 'joined'
+            ORDER BY joined_at, id
+            """,
+            (mission["id"],),
+        )
+        participants = [dict(row) for row in cursor.fetchall()]
+        if len(participants) < int(mission["team_size_min"]):
+            raise TeamMissionError("Not enough participants to form teams")
+
+        agent_ids = [item["agent_id"] for item in participants]
+        features = build_agent_features(cursor, agent_ids)
+        variant_by_agent = {item["agent_id"]: item.get("variant_key") for item in participants}
+        team_size = max(int(mission["team_size_min"]), min(int(mission["team_size_max"]), int(mission["team_size_max"])))
+        groups = form_team_groups(features, assignment_mode=mode, team_size=team_size, mission_key=mission["mission_key"])
+        required_roles = _json_loads(mission.get("required_roles_json"), DEFAULT_REQUIRED_ROLES) or DEFAULT_REQUIRED_ROLES
+        formed_team_ids: list[int] = []
+
+        for index, group in enumerate(groups, start=1):
+            team_key = _normalize_key(f"{mission['mission_key']}-{mode}-{index}", f"{mission['title']} {index}", "team")
+            team_variant = variant_by_agent.get(group[0]["agent_id"])
+            team_id = _insert_team(
+                cursor,
+                mission,
+                team_key=team_key,
+                name=f"{mission['title']} Team {index}",
+                formation_method=mode,
+                variant_key=team_variant,
+            )
+            team = _load_team(cursor, team_id=team_id)
+            roles = assign_roles(group, required_roles)
+            for member in group:
+                _insert_team_member(
+                    cursor,
+                    mission,
+                    team,
+                    member["agent_id"],
+                    role=roles.get(member["agent_id"]),
+                    variant_key=variant_by_agent.get(member["agent_id"]),
+                )
+            formed_team_ids.append(team_id)
+
+        conn.commit()
+        result = get_mission_teams(mission_key)
+        result["formed_team_ids"] = formed_team_ids
+        result["assignment_mode"] = mode
+        return result
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def get_mission_teams(mission_key: str) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        mission = _load_mission(cursor, mission_key=mission_key)
+        cursor.execute(
+            """
+            SELECT t.*, COUNT(tm.id) AS member_count
+            FROM teams t
+            LEFT JOIN team_members tm ON tm.team_id = t.id AND tm.status = 'active'
+            WHERE t.mission_id = ?
+            GROUP BY t.id
+            ORDER BY t.created_at, t.id
+            """,
+            (mission["id"],),
+        )
+        teams = [_serialize_team(row, row["member_count"]) for row in cursor.fetchall()]
+        return {"mission": _serialize_mission(mission), "teams": teams}
+    finally:
+        conn.close()
+
+
+def get_team(team_key: str) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        team = _load_team(cursor, team_key=team_key)
+        mission = _load_mission(cursor, mission_id=team["mission_id"])
+        cursor.execute(
+            """
+            SELECT tm.*, a.name AS agent_name
+            FROM team_members tm
+            JOIN agents a ON a.id = tm.agent_id
+            WHERE tm.team_id = ?
+            ORDER BY tm.joined_at, tm.id
+            """,
+            (team["id"],),
+        )
+        members = [dict(row) for row in cursor.fetchall()]
+        cursor.execute(
+            """
+            SELECT tmsg.*, a.name AS agent_name
+            FROM team_messages tmsg
+            JOIN agents a ON a.id = tmsg.agent_id
+            WHERE tmsg.team_id = ?
+            ORDER BY tmsg.created_at DESC, tmsg.id DESC
+            LIMIT 100
+            """,
+            (team["id"],),
+        )
+        messages = [dict(row) for row in cursor.fetchall()]
+        cursor.execute(
+            """
+            SELECT ts.*, a.name AS submitted_by_agent_name
+            FROM team_submissions ts
+            JOIN agents a ON a.id = ts.submitted_by_agent_id
+            WHERE ts.team_id = ?
+            ORDER BY ts.created_at DESC, ts.id DESC
+            """,
+            (team["id"],),
+        )
+        submissions = [dict(row) for row in cursor.fetchall()]
+        result = _serialize_team(team, len(members))
+        result["mission"] = _serialize_mission(mission)
+        result["members"] = members
+        result["messages"] = messages
+        result["submissions"] = submissions
+        return result
+    finally:
+        conn.close()
+
+
+def _assert_team_member(cursor: Any, team_id: int, agent_id: int) -> None:
+    cursor.execute(
+        """
+        SELECT id
+        FROM team_members
+        WHERE team_id = ? AND agent_id = ? AND status = 'active'
+        """,
+        (team_id, agent_id),
+    )
+    if not cursor.fetchone():
+        raise TeamMissionError("Agent must be a team member")
+
+
+def link_signal_to_team(team_key: str, agent_id: int, data: Any) -> dict[str, Any]:
+    payload = _model_dump(data)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        team = _load_team(cursor, team_key=team_key)
+        mission = _load_mission(cursor, mission_id=team["mission_id"])
+        _assert_team_member(cursor, team["id"], agent_id)
+        message = _insert_team_message(
+            cursor,
+            mission,
+            team,
+            agent_id,
+            signal_id=payload.get("signal_id"),
+            message_type=payload.get("message_type") or "signal",
+            content=payload.get("content"),
+            metadata=payload.get("metadata_json") or {},
+        )
+        conn.commit()
+        return message
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _insert_team_message(
+    cursor: Any,
+    mission: dict[str, Any],
+    team: dict[str, Any],
+    agent_id: int,
+    *,
+    signal_id: Optional[int],
+    message_type: str,
+    content: Optional[str],
+    metadata: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+    cursor.execute(
+        """
+        INSERT INTO team_messages
+        (team_id, agent_id, signal_id, message_type, content, metadata_json, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (team["id"], agent_id, signal_id, message_type, content, _json_dumps(metadata or {}), utc_now_iso_z()),
+    )
+    message_id = cursor.lastrowid
+    record_event(
+        "team_signal_linked",
+        actor_agent_id=agent_id,
+        object_type="team_message",
+        object_id=message_id,
+        market=mission["market"],
+        experiment_key=mission.get("experiment_key"),
+        variant_key=team.get("variant_key"),
+        metadata={"mission_key": mission["mission_key"], "team_key": team["team_key"], "signal_id": signal_id, "message_type": message_type},
+        cursor=cursor,
+    )
+    return {
+        "id": message_id,
+        "team_id": team["id"],
+        "agent_id": agent_id,
+        "signal_id": signal_id,
+        "message_type": message_type,
+        "content": content,
+    }
+
+
+def _team_for_signal_binding(cursor: Any, *, mission_key: Optional[str], team_key: Optional[str], agent_id: int) -> tuple[dict[str, Any], dict[str, Any]]:
+    if team_key:
+        team = _load_team(cursor, team_key=team_key)
+        mission = _load_mission(cursor, mission_id=team["mission_id"])
+        _assert_team_member(cursor, team["id"], agent_id)
+        if mission_key and mission["mission_key"] != mission_key:
+            raise TeamMissionError("team_key does not belong to mission_key")
+        return mission, team
+
+    if not mission_key:
+        raise TeamMissionError("mission_key or team_key is required")
+    mission = _load_mission(cursor, mission_key=mission_key)
+    cursor.execute(
+        """
+        SELECT t.*
+        FROM teams t
+        JOIN team_members tm ON tm.team_id = t.id
+        WHERE t.mission_id = ? AND tm.agent_id = ? AND tm.status = 'active'
+        ORDER BY t.created_at DESC, t.id DESC
+        LIMIT 1
+        """,
+        (mission["id"], agent_id),
+    )
+    team_row = cursor.fetchone()
+    if not team_row:
+        raise TeamMissionError("Agent is not assigned to a team for this mission")
+    return mission, dict(team_row)
+
+
+def record_team_message_from_signal(
+    cursor: Any,
+    *,
+    mission_key: Optional[str],
+    team_key: Optional[str],
+    agent_id: int,
+    signal_id: int,
+    message_type: str,
+    content: Optional[str],
+) -> Optional[dict[str, Any]]:
+    if not mission_key and not team_key:
+        return None
+    mission, team = _team_for_signal_binding(cursor, mission_key=mission_key, team_key=team_key, agent_id=agent_id)
+    return _insert_team_message(
+        cursor,
+        mission,
+        team,
+        agent_id,
+        signal_id=signal_id,
+        message_type=message_type,
+        content=content,
+        metadata={"source": "signal_publish"},
+    )
+
+
+def record_team_reply_from_parent_signal(
+    cursor: Any,
+    *,
+    parent_signal_id: int,
+    reply_id: int,
+    agent_id: int,
+    content: str,
+) -> list[dict[str, Any]]:
+    cursor.execute(
+        """
+        SELECT DISTINCT tmsg.team_id, t.*
+        FROM team_messages tmsg
+        JOIN teams t ON t.id = tmsg.team_id
+        WHERE tmsg.signal_id = ?
+        """,
+        (parent_signal_id,),
+    )
+    teams = [dict(row) for row in cursor.fetchall()]
+    recorded = []
+    for team in teams:
+        mission = _load_mission(cursor, mission_id=team["mission_id"])
+        recorded.append(_insert_team_message(
+            cursor,
+            mission,
+            team,
+            agent_id,
+            signal_id=parent_signal_id,
+            message_type="reply",
+            content=content,
+            metadata={"reply_id": reply_id, "source": "signal_reply"},
+        ))
+    return recorded
+
+
+def submit_team(team_key: str, agent_id: int, data: Any) -> dict[str, Any]:
+    payload = _model_dump(data)
+    title = (payload.get("title") or "").strip()
+    content = (payload.get("content") or "").strip()
+    if not title or not content:
+        raise TeamMissionError("title and content are required")
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        team = _load_team(cursor, team_key=team_key)
+        mission = _load_mission(cursor, mission_id=team["mission_id"])
+        _assert_team_member(cursor, team["id"], agent_id)
+        cursor.execute(
+            """
+            INSERT INTO team_submissions
+            (mission_id, team_id, submitted_by_agent_id, title, content, prediction_json, confidence, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                mission["id"],
+                team["id"],
+                agent_id,
+                title,
+                content,
+                _json_dumps(payload.get("prediction_json")),
+                payload.get("confidence"),
+                utc_now_iso_z(),
+            ),
+        )
+        submission_id = cursor.lastrowid
+        record_event(
+            "team_submission_created",
+            actor_agent_id=agent_id,
+            object_type="team_submission",
+            object_id=submission_id,
+            market=mission["market"],
+            experiment_key=mission.get("experiment_key"),
+            variant_key=team.get("variant_key"),
+            metadata={"mission_key": mission["mission_key"], "team_key": team["team_key"], "confidence": payload.get("confidence")},
+            cursor=cursor,
+        )
+        submission = {
+            "id": submission_id,
+            "mission_id": mission["id"],
+            "team_id": team["id"],
+            "submitted_by_agent_id": agent_id,
+            "title": title,
+            "content": content,
+            "confidence": payload.get("confidence"),
+        }
+        _score_submission_contribution(cursor, mission, team, submission)
+        conn.commit()
+        return submission
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def get_team_submissions(team_key: str) -> dict[str, Any]:
+    team = get_team(team_key)
+    return {"team": team, "submissions": team.get("submissions", [])}
+
+
+def _contribution_exists(cursor: Any, source_type: str, source_id: Any) -> bool:
+    cursor.execute(
+        """
+        SELECT id
+        FROM team_contributions
+        WHERE source_type = ? AND source_id = ?
+        LIMIT 1
+        """,
+        (source_type, str(source_id)),
+    )
+    return cursor.fetchone() is not None
+
+
+def _insert_contribution(
+    cursor: Any,
+    mission: dict[str, Any],
+    team: dict[str, Any],
+    agent_id: int,
+    *,
+    source_type: str,
+    source_id: Any,
+    contribution_type: str,
+    contribution_score: float,
+    metadata: Optional[dict[str, Any]] = None,
+) -> Optional[int]:
+    if _contribution_exists(cursor, source_type, source_id):
+        return None
+    cursor.execute(
+        """
+        INSERT INTO team_contributions
+        (mission_id, team_id, agent_id, source_type, source_id, contribution_type,
+         contribution_score, metadata_json, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            mission["id"],
+            team["id"],
+            agent_id,
+            source_type,
+            str(source_id),
+            contribution_type,
+            contribution_score,
+            _json_dumps(metadata or {}),
+            utc_now_iso_z(),
+        ),
+    )
+    contribution_id = cursor.lastrowid
+    record_event(
+        "team_contribution_scored",
+        actor_agent_id=agent_id,
+        object_type="team_contribution",
+        object_id=contribution_id,
+        market=mission["market"],
+        experiment_key=mission.get("experiment_key"),
+        variant_key=team.get("variant_key"),
+        metadata={"mission_key": mission["mission_key"], "team_key": team["team_key"], "score": contribution_score, "contribution_type": contribution_type},
+        cursor=cursor,
+    )
+    return contribution_id
+
+
+def _score_message_contribution(cursor: Any, mission: dict[str, Any], team: dict[str, Any], message: dict[str, Any]) -> Optional[int]:
+    score = contribution_score_for_message(message)
+    return _insert_contribution(
+        cursor,
+        mission,
+        team,
+        message["agent_id"],
+        source_type="team_message",
+        source_id=message["id"],
+        contribution_type=message["message_type"],
+        contribution_score=score,
+        metadata={"signal_id": message.get("signal_id")},
+    )
+
+
+def _score_submission_contribution(cursor: Any, mission: dict[str, Any], team: dict[str, Any], submission: dict[str, Any]) -> Optional[int]:
+    score = contribution_score_for_submission(submission)
+    return _insert_contribution(
+        cursor,
+        mission,
+        team,
+        submission["submitted_by_agent_id"],
+        source_type="team_submission",
+        source_id=submission["id"],
+        contribution_type="submission",
+        contribution_score=score,
+        metadata={"confidence": submission.get("confidence")},
+    )
+
+
+def score_team_contributions(mission_key: Optional[str] = None) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    inserted = 0
+    try:
+        begin_write_transaction(cursor)
+        mission_filter = ""
+        params: list[Any] = []
+        if mission_key:
+            mission_filter = "WHERE tm.mission_key = ?"
+            params.append(mission_key)
+        cursor.execute(
+            f"""
+            SELECT
+                tmsg.id AS message_id,
+                tmsg.team_id,
+                tmsg.agent_id,
+                tmsg.signal_id,
+                tmsg.message_type,
+                tmsg.content,
+                t.team_key,
+                t.variant_key,
+                tm.id AS mission_id,
+                tm.mission_key,
+                tm.market,
+                tm.experiment_key
+            FROM team_messages tmsg
+            JOIN teams t ON t.id = tmsg.team_id
+            JOIN team_missions tm ON tm.id = t.mission_id
+            {mission_filter}
+            ORDER BY tmsg.id
+            """,
+            params,
+        )
+        for row in cursor.fetchall():
+            data = dict(row)
+            mission = {"id": data["mission_id"], "mission_key": data["mission_key"], "market": data["market"], "experiment_key": data["experiment_key"]}
+            team = {"id": data["team_id"], "team_key": data["team_key"], "variant_key": data["variant_key"]}
+            message = {
+                "id": data["message_id"],
+                "agent_id": data["agent_id"],
+                "signal_id": data["signal_id"],
+                "message_type": data["message_type"],
+                "content": data["content"],
+            }
+            if _score_message_contribution(cursor, mission, team, message):
+                inserted += 1
+
+        cursor.execute(
+            f"""
+            SELECT ts.*, t.team_key, t.variant_key, tm.mission_key, tm.market, tm.experiment_key
+            FROM team_submissions ts
+            JOIN teams t ON t.id = ts.team_id
+            JOIN team_missions tm ON tm.id = ts.mission_id
+            {mission_filter}
+            ORDER BY ts.id
+            """,
+            params,
+        )
+        for row in cursor.fetchall():
+            data = dict(row)
+            mission = {"id": data["mission_id"], "mission_key": data["mission_key"], "market": data["market"], "experiment_key": data["experiment_key"]}
+            team = {"id": data["team_id"], "team_key": data["team_key"], "variant_key": data["variant_key"]}
+            submission = {
+                "id": data["id"],
+                "submitted_by_agent_id": data["submitted_by_agent_id"],
+                "content": data["content"],
+                "confidence": data["confidence"],
+            }
+            if _score_submission_contribution(cursor, mission, team, submission):
+                inserted += 1
+
+        conn.commit()
+        return {"inserted": inserted}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _fetch_settlement_inputs(cursor: Any, mission_id: int):
+    cursor.execute("SELECT * FROM teams WHERE mission_id = ? ORDER BY id", (mission_id,))
+    teams = [dict(row) for row in cursor.fetchall()]
+
+    cursor.execute(
+        """
+        SELECT tm.*, a.name AS agent_name
+        FROM team_members tm
+        JOIN agents a ON a.id = tm.agent_id
+        WHERE tm.team_id IN (SELECT id FROM teams WHERE mission_id = ?)
+        ORDER BY tm.team_id, tm.id
+        """,
+        (mission_id,),
+    )
+    members_by_team: dict[int, list[dict[str, Any]]] = {}
+    member_rows = [dict(row) for row in cursor.fetchall()]
+    features_by_agent = {item["agent_id"]: item for item in build_agent_features(cursor, [row["agent_id"] for row in member_rows])}
+    for member in member_rows:
+        member.update(features_by_agent.get(member["agent_id"], {}))
+        members_by_team.setdefault(member["team_id"], []).append(member)
+
+    cursor.execute("SELECT * FROM team_submissions WHERE mission_id = ? ORDER BY id", (mission_id,))
+    submissions_by_team: dict[int, list[dict[str, Any]]] = {}
+    for row in cursor.fetchall():
+        item = dict(row)
+        submissions_by_team.setdefault(item["team_id"], []).append(item)
+
+    cursor.execute("SELECT * FROM team_contributions WHERE mission_id = ? ORDER BY id", (mission_id,))
+    contributions_by_team: dict[int, list[dict[str, Any]]] = {}
+    for row in cursor.fetchall():
+        item = dict(row)
+        contributions_by_team.setdefault(item["team_id"], []).append(item)
+
+    return teams, members_by_team, submissions_by_team, contributions_by_team
+
+
+def _team_reward_for_rank(rules: dict[str, Any], rank: int) -> int:
+    rewards = rules.get("team_reward_points", DEFAULT_TEAM_REWARDS)
+    if isinstance(rewards, list):
+        return int(rewards[rank - 1]) if rank - 1 < len(rewards) else 0
+    if isinstance(rewards, dict):
+        return int(rewards.get(str(rank), rewards.get(rank, 0)) or 0)
+    return 0
+
+
+def settle_team_mission(mission_key: str, *, force: bool = False) -> dict[str, Any]:
+    score_team_contributions(mission_key)
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        mission = _load_mission(cursor, mission_key=mission_key)
+        if mission["status"] == "settled" and not force:
+            conn.commit()
+            return get_team_mission_leaderboard(mission_key)
+        if force:
+            cursor.execute("DELETE FROM team_results WHERE mission_id = ?", (mission["id"],))
+
+        teams, members_by_team, submissions_by_team, contributions_by_team = _fetch_settlement_inputs(cursor, mission["id"])
+        results = score_team_results(mission, teams, members_by_team, submissions_by_team, contributions_by_team)
+        now = utc_now_iso_z()
+
+        for result in results:
+            cursor.execute(
+                """
+                INSERT INTO team_results
+                (mission_id, team_id, return_pct, prediction_score, quality_score,
+                 consensus_gain, final_score, rank, metrics_json, settled_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    mission["id"],
+                    result["team_id"],
+                    result["return_pct"],
+                    result["prediction_score"],
+                    result["quality_score"],
+                    result["consensus_gain"],
+                    result["final_score"],
+                    result["rank"],
+                    result["metrics_json"],
+                    now,
+                ),
+            )
+
+        rules = _json_loads(mission.get("rules_json"), {}) or {}
+        if rules.get("grant_rewards", True):
+            for result in results:
+                team_reward = _team_reward_for_rank(rules, result["rank"])
+                for member in members_by_team.get(result["team_id"], []):
+                    if team_reward > 0:
+                        grant_agent_reward(
+                            member["agent_id"],
+                            team_reward,
+                            f"team_mission_rank_{result['rank']}",
+                            source_type="team_mission_team",
+                            source_id=result["team_id"],
+                            experiment_key=mission.get("experiment_key"),
+                            metadata={"mission_key": mission["mission_key"], "team_id": result["team_id"], "rank": result["rank"]},
+                            cursor=cursor,
+                        )
+                        record_event(
+                            "team_reward_granted",
+                            actor_agent_id=member["agent_id"],
+                            object_type="team_result",
+                            object_id=result["team_id"],
+                            market=mission["market"],
+                            experiment_key=mission.get("experiment_key"),
+                            metadata={"mission_key": mission["mission_key"], "reward_type": "team_rank", "points": team_reward, "rank": result["rank"]},
+                            cursor=cursor,
+                        )
+
+            contribution_multiplier = int(rules.get("contribution_reward_per_point") or 0)
+            if contribution_multiplier > 0:
+                cursor.execute("SELECT * FROM team_contributions WHERE mission_id = ?", (mission["id"],))
+                for contribution in cursor.fetchall():
+                    points = int(round(float(contribution["contribution_score"] or 0) * contribution_multiplier))
+                    if points <= 0:
+                        continue
+                    grant_agent_reward(
+                        contribution["agent_id"],
+                        points,
+                        "team_mission_contribution",
+                        source_type="team_contribution",
+                        source_id=contribution["id"],
+                        experiment_key=mission.get("experiment_key"),
+                        metadata={"mission_key": mission["mission_key"], "contribution_id": contribution["id"]},
+                        cursor=cursor,
+                    )
+                    record_event(
+                        "team_reward_granted",
+                        actor_agent_id=contribution["agent_id"],
+                        object_type="team_contribution",
+                        object_id=contribution["id"],
+                        market=mission["market"],
+                        experiment_key=mission.get("experiment_key"),
+                        metadata={"mission_key": mission["mission_key"], "reward_type": "contribution", "points": points},
+                        cursor=cursor,
+                    )
+
+        cursor.execute("UPDATE teams SET status = 'settled', updated_at = ? WHERE mission_id = ?", (now, mission["id"]))
+        cursor.execute("UPDATE team_missions SET status = 'settled', settled_at = ?, updated_at = ? WHERE id = ?", (now, now, mission["id"]))
+        record_event(
+            "team_mission_settled",
+            object_type="team_mission",
+            object_id=mission["id"],
+            market=mission["market"],
+            experiment_key=mission.get("experiment_key"),
+            metadata={"mission_key": mission["mission_key"], "team_count": len(teams)},
+            cursor=cursor,
+        )
+        conn.commit()
+        return get_team_mission_leaderboard(mission_key)
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def get_team_mission_leaderboard(mission_key: str) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        mission = _load_mission(cursor, mission_key=mission_key)
+        cursor.execute(
+            """
+            SELECT tr.*, t.team_key, t.name AS team_name,
+                   (SELECT COUNT(*) FROM team_members tm WHERE tm.team_id = t.id AND tm.status = 'active') AS member_count,
+                   (SELECT COUNT(*) FROM team_submissions ts WHERE ts.team_id = t.id) AS submission_count,
+                   (SELECT COUNT(*) FROM team_contributions tc WHERE tc.team_id = t.id) AS contribution_count
+            FROM team_results tr
+            JOIN teams t ON t.id = tr.team_id
+            WHERE tr.mission_id = ?
+            ORDER BY COALESCE(tr.rank, 999999), tr.final_score DESC, tr.id
+            """,
+            (mission["id"],),
+        )
+        rows = [dict(row) for row in cursor.fetchall()]
+        if rows:
+            return {"mission": _serialize_mission(mission), "leaderboard": rows, "provisional": False}
+
+        teams, members_by_team, submissions_by_team, contributions_by_team = _fetch_settlement_inputs(cursor, mission["id"])
+        provisional = score_team_results(mission, teams, members_by_team, submissions_by_team, contributions_by_team)
+        team_by_id = {team["id"]: team for team in teams}
+        for row in provisional:
+            row["team_key"] = team_by_id.get(row["team_id"], {}).get("team_key")
+            row["team_name"] = team_by_id.get(row["team_id"], {}).get("name")
+            row["member_count"] = len(members_by_team.get(row["team_id"], []))
+            row["submission_count"] = len(submissions_by_team.get(row["team_id"], []))
+            row["contribution_count"] = len(contributions_by_team.get(row["team_id"], []))
+        return {"mission": _serialize_mission(mission), "leaderboard": provisional, "provisional": True}
+    finally:
+        conn.close()
+
+
+def settle_due_team_missions(limit: int = 20) -> list[dict[str, Any]]:
+    now = utc_now_iso_z()
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_mission_statuses(cursor)
+        conn.commit()
+        cursor.execute(
+            """
+            SELECT mission_key
+            FROM team_missions
+            WHERE status = 'active' AND submission_due_at <= ?
+            ORDER BY submission_due_at ASC
+            LIMIT ?
+            """,
+            (now, max(1, min(limit, 100))),
+        )
+        mission_keys = [row["mission_key"] for row in cursor.fetchall()]
+    finally:
+        conn.close()
+    return [settle_team_mission(key) for key in mission_keys]
+
+
+def form_due_team_missions(limit: int = 20) -> list[dict[str, Any]]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_mission_statuses(cursor)
+        conn.commit()
+        cursor.execute(
+            """
+            SELECT mission_key
+            FROM team_missions tm
+            WHERE tm.status = 'active'
+              AND NOT EXISTS (SELECT 1 FROM teams t WHERE t.mission_id = tm.id)
+              AND (SELECT COUNT(*) FROM team_mission_participants tmp WHERE tmp.mission_id = tm.id) >= tm.team_size_min
+            ORDER BY tm.start_at ASC
+            LIMIT ?
+            """,
+            (max(1, min(limit, 100)),),
+        )
+        mission_keys = [row["mission_key"] for row in cursor.fetchall()]
+    finally:
+        conn.close()
+    formed = []
+    for key in mission_keys:
+        try:
+            formed.append(auto_form_teams(key))
+        except TeamMissionError:
+            continue
+    return formed
+
+
+def get_agent_team_missions(agent_id: int) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        refresh_mission_statuses(cursor)
+        conn.commit()
+        cursor.execute(
+            """
+            SELECT tm.*, t.team_key, t.name AS team_name, memb.role,
+                   (SELECT COUNT(*) FROM teams count_t WHERE count_t.mission_id = tm.id) AS team_count,
+                   (SELECT COUNT(*) FROM team_mission_participants tmp WHERE tmp.mission_id = tm.id) AS participant_count
+            FROM team_missions tm
+            LEFT JOIN team_mission_participants tmp ON tmp.mission_id = tm.id AND tmp.agent_id = ?
+            LEFT JOIN team_members memb ON memb.agent_id = ? AND memb.status = 'active'
+            LEFT JOIN teams t ON t.id = memb.team_id AND t.mission_id = tm.id
+            WHERE tmp.agent_id IS NOT NULL OR memb.agent_id IS NOT NULL
+            ORDER BY tm.status = 'active' DESC, tm.start_at DESC, tm.id DESC
+            """,
+            (agent_id, agent_id),
+        )
+        missions = []
+        for row in cursor.fetchall():
+            item = _serialize_mission(row, row["team_count"], row["participant_count"])
+            item["team_key"] = row["team_key"]
+            item["team_name"] = row["team_name"]
+            item["role"] = row["role"]
+            missions.append(item)
+        return {"missions": missions}
+    finally:
+        conn.close()

--- a/service/server/team_scoring.py
+++ b/service/server/team_scoring.py
@@ -1,0 +1,99 @@
+"""Team mission contribution and result scoring."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _row_dict(row: Any) -> dict[str, Any]:
+    return dict(row) if row is not None and not isinstance(row, dict) else (row or {})
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except Exception:
+        return default
+
+
+def contribution_score_for_message(message: Any) -> float:
+    item = _row_dict(message)
+    message_type = str(item.get("message_type") or "").lower()
+    content = item.get("content") or ""
+    length_bonus = min(len(content) / 400.0, 2.0)
+    if message_type == "strategy":
+        base = 4.0
+    elif message_type == "discussion":
+        base = 3.0
+    elif message_type == "reply":
+        base = 2.0
+    else:
+        base = 1.0
+    return round(base + length_bonus, 4)
+
+
+def contribution_score_for_submission(submission: Any) -> float:
+    item = _row_dict(submission)
+    confidence = _safe_float(item.get("confidence"), 0.0)
+    content = item.get("content") or ""
+    length_bonus = min(len(content) / 500.0, 2.5)
+    confidence_bonus = max(0.0, min(confidence, 1.0)) * 3.0
+    return round(6.0 + confidence_bonus + length_bonus, 4)
+
+
+def score_team_results(
+    mission: Any,
+    teams: list[Any],
+    members_by_team: dict[int, list[Any]],
+    submissions_by_team: dict[int, list[Any]],
+    contributions_by_team: dict[int, list[Any]],
+) -> list[dict[str, Any]]:
+    mission_data = _row_dict(mission)
+    scored: list[dict[str, Any]] = []
+
+    for team_row in teams:
+        team = _row_dict(team_row)
+        team_id = team["id"]
+        members = [_row_dict(member) for member in members_by_team.get(team_id, [])]
+        submissions = [_row_dict(submission) for submission in submissions_by_team.get(team_id, [])]
+        contributions = [_row_dict(contribution) for contribution in contributions_by_team.get(team_id, [])]
+
+        contribution_total = sum(_safe_float(item.get("contribution_score")) for item in contributions)
+        contributor_count = len({item.get("agent_id") for item in contributions if item.get("agent_id")})
+        member_count = max(1, len(members))
+        quality_score = contribution_total / member_count
+        prediction_score = 0.0
+        if submissions:
+            prediction_score = sum(max(0.0, min(_safe_float(item.get("confidence")), 1.0)) for item in submissions) / len(submissions) * 100.0
+        consensus_gain = min(25.0, contributor_count * 2.5 + max(0, len(submissions) - 1) * 3.0)
+        return_pct = sum(_safe_float(member.get("return_pct_30d")) for member in members) / member_count
+        final_score = return_pct + (prediction_score * 0.2) + quality_score + consensus_gain
+
+        metrics = {
+            "member_count": len(members),
+            "submission_count": len(submissions),
+            "contribution_count": len(contributions),
+            "contributor_count": contributor_count,
+            "assignment_mode": mission_data.get("assignment_mode"),
+            "formation_method": team.get("formation_method"),
+            "contribution_total": contribution_total,
+        }
+
+        scored.append({
+            "mission_id": mission_data.get("id"),
+            "team_id": team_id,
+            "return_pct": return_pct,
+            "prediction_score": prediction_score,
+            "quality_score": quality_score,
+            "consensus_gain": consensus_gain,
+            "final_score": final_score,
+            "metrics": metrics,
+        })
+
+    scored.sort(key=lambda item: item["final_score"], reverse=True)
+    for index, item in enumerate(scored, start=1):
+        item["rank"] = index
+        item["metrics_json"] = json.dumps(item["metrics"], ensure_ascii=False, sort_keys=True)
+    return scored
+

--- a/service/server/tests/test_team_missions.py
+++ b/service/server/tests/test_team_missions.py
@@ -1,0 +1,256 @@
+import csv
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+import database
+from research_exports import export_team_tables
+from routes_shared import utc_now_iso_z
+from team_matching import form_team_groups
+from team_missions import (
+    auto_form_teams,
+    create_team_mission,
+    get_agent_team_missions,
+    get_team,
+    join_team_mission,
+    record_team_message_from_signal,
+    score_team_contributions,
+    settle_team_mission,
+    submit_team,
+)
+
+
+def iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class TeamMissionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        database.DATABASE_URL = ""
+        database._SQLITE_DB_PATH = os.path.join(self.tmp.name, "test.db")
+        database.init_database()
+        self.admin_agent = self._create_agent("admin-agent")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _create_agent(self, name: str, *, profit: float = 0.0, market: str = "crypto") -> int:
+        now = utc_now_iso_z()
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO agents (name, token, points, cash, created_at, updated_at)
+            VALUES (?, ?, 0, 100000.0, ?, ?)
+            """,
+            (name, f"token-{name}", now, now),
+        )
+        agent_id = cursor.lastrowid
+        cursor.execute(
+            """
+            INSERT INTO profit_history (agent_id, total_value, cash, position_value, profit, recorded_at)
+            VALUES (?, ?, 100000.0, 0.0, ?, ?)
+            """,
+            (agent_id, 100000.0 + profit, profit, now),
+        )
+        signal_id = 10_000 + agent_id
+        for offset, message_type in enumerate(("operation", "strategy", "discussion")):
+            cursor.execute(
+                """
+                INSERT INTO signals
+                (signal_id, agent_id, message_type, market, signal_type, symbol, title,
+                 content, timestamp, created_at, executed_at)
+                VALUES (?, ?, ?, ?, ?, 'BTC', ?, ?, ?, ?, ?)
+                """,
+                (
+                    signal_id + offset * 100_000,
+                    agent_id,
+                    message_type,
+                    market,
+                    "realtime" if message_type == "operation" else message_type,
+                    f"{message_type} {name}",
+                    f"{message_type} content from {name}",
+                    int(datetime.now(timezone.utc).timestamp()),
+                    now,
+                    now,
+                ),
+            )
+        conn.commit()
+        conn.close()
+        return agent_id
+
+    def _create_mission(self, key: str, **overrides):
+        now = datetime.now(timezone.utc)
+        payload = {
+            "mission_key": key,
+            "title": f"Team Mission {key}",
+            "description": "Coordinate a market thesis and submit one team conclusion.",
+            "market": "crypto",
+            "symbol": "BTC",
+            "assignment_mode": "random",
+            "team_size_min": 3,
+            "team_size_max": 3,
+            "start_at": iso(now - timedelta(minutes=5)),
+            "submission_due_at": iso(now + timedelta(hours=1)),
+            "rules_json": {
+                "team_reward_points": {"1": 30, "2": 20, "3": 10},
+                "contribution_reward_per_point": 1,
+            },
+        }
+        payload.update(overrides)
+        return create_team_mission(payload, created_by_agent_id=self.admin_agent)
+
+    def test_matching_modes_are_deterministic_and_distinct(self):
+        features = [
+            {"agent_id": 1, "primary_market": "crypto", "feature_score": 50.0},
+            {"agent_id": 2, "primary_market": "crypto", "feature_score": 10.0},
+            {"agent_id": 3, "primary_market": "us-stock", "feature_score": 45.0},
+            {"agent_id": 4, "primary_market": "us-stock", "feature_score": 5.0},
+            {"agent_id": 5, "primary_market": "polymarket", "feature_score": 35.0},
+            {"agent_id": 6, "primary_market": "polymarket", "feature_score": 15.0},
+        ]
+
+        random_a = form_team_groups(features, assignment_mode="random", team_size=2, mission_key="match-check")
+        random_b = form_team_groups(features, assignment_mode="random", team_size=2, mission_key="match-check")
+        homogeneous = form_team_groups(features, assignment_mode="homogeneous", team_size=2, mission_key="match-check")
+        heterogeneous = form_team_groups(features, assignment_mode="heterogeneous", team_size=2, mission_key="match-check")
+
+        self.assertEqual(random_a, random_b)
+        self.assertNotEqual(homogeneous, heterogeneous)
+        self.assertEqual([member["agent_id"] for member in homogeneous[0]], [2, 1])
+        self.assertEqual([member["agent_id"] for member in heterogeneous[0]], [3, 2])
+
+    def test_thirty_agent_mission_forms_ten_teams_settles_rewards_and_exports(self):
+        markets = ["crypto", "us-stock", "polymarket"]
+        agent_ids = [
+            self._create_agent(f"team-agent-{idx:02d}", profit=idx * 100.0, market=markets[idx % len(markets)])
+            for idx in range(30)
+        ]
+        mission = self._create_mission("ten-team-mission")
+
+        first_join = join_team_mission(mission["mission_key"], agent_ids[0])
+        second_join = join_team_mission(mission["mission_key"], agent_ids[0])
+        self.assertTrue(first_join["joined"])
+        self.assertFalse(second_join["joined"])
+        for agent_id in agent_ids[1:]:
+            join_team_mission(mission["mission_key"], agent_id)
+
+        formed = auto_form_teams(mission["mission_key"], assignment_mode="random")
+        teams = formed["teams"]
+        self.assertEqual(len(teams), 10)
+
+        signal_id = 50_000
+        for team_row in teams:
+            detail = get_team(team_row["team_key"])
+            self.assertEqual(len(detail["members"]), 3)
+            self.assertTrue(all(member["role"] for member in detail["members"]))
+            lead_agent_id = detail["members"][0]["agent_id"]
+
+            conn = database.get_db_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO signals
+                (signal_id, agent_id, message_type, market, signal_type, symbol, title,
+                 content, timestamp, created_at)
+                VALUES (?, ?, 'strategy', 'crypto', 'strategy', 'BTC', ?, ?, ?, ?)
+                """,
+                (
+                    signal_id,
+                    lead_agent_id,
+                    f"Strategy for {detail['name']}",
+                    f"Evidence and role synthesis for {detail['name']}",
+                    int(datetime.now(timezone.utc).timestamp()),
+                    utc_now_iso_z(),
+                ),
+            )
+            record_team_message_from_signal(
+                cursor,
+                mission_key=mission["mission_key"],
+                team_key=team_row["team_key"],
+                agent_id=lead_agent_id,
+                signal_id=signal_id,
+                message_type="strategy",
+                content=f"Team thesis for {detail['name']}",
+            )
+            conn.commit()
+            conn.close()
+            signal_id += 1
+
+            submit_team(
+                team_row["team_key"],
+                lead_agent_id,
+                {
+                    "title": f"Consensus {detail['name']}",
+                    "content": "Final team view with risk framing and evidence.",
+                    "prediction_json": {"symbol": "BTC", "direction": "up"},
+                    "confidence": 0.75,
+                },
+            )
+
+        scored = score_team_contributions(mission["mission_key"])
+        self.assertGreaterEqual(scored["inserted"], 10)
+
+        settled = settle_team_mission(mission["mission_key"])
+        leaderboard = settled["leaderboard"]
+        self.assertEqual(len(leaderboard), 10)
+        self.assertEqual([row["rank"] for row in leaderboard], list(range(1, 11)))
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) AS count FROM team_results")
+        self.assertEqual(cursor.fetchone()["count"], 10)
+        cursor.execute("SELECT COUNT(*) AS count FROM team_submissions")
+        self.assertEqual(cursor.fetchone()["count"], 10)
+        cursor.execute("SELECT COUNT(*) AS count FROM team_contributions")
+        self.assertGreaterEqual(cursor.fetchone()["count"], 20)
+        cursor.execute("SELECT COUNT(*) AS count FROM agent_reward_ledger WHERE source_type LIKE 'team_%'")
+        self.assertGreater(cursor.fetchone()["count"], 0)
+        cursor.execute("SELECT event_type FROM experiment_events")
+        event_types = {row["event_type"] for row in cursor.fetchall()}
+        self.assertTrue({
+            "team_mission_created",
+            "team_mission_joined",
+            "team_created",
+            "team_joined",
+            "team_role_assigned",
+            "team_signal_linked",
+            "team_submission_created",
+            "team_contribution_scored",
+            "team_mission_settled",
+            "team_reward_granted",
+        }.issubset(event_types))
+        conn.close()
+
+        mine = get_agent_team_missions(agent_ids[0])
+        self.assertEqual(mine["missions"][0]["mission_key"], mission["mission_key"])
+        self.assertTrue(mine["missions"][0]["team_key"])
+
+        export_dir = Path(self.tmp.name) / "exports"
+        paths = export_team_tables(export_dir, mission_key=mission["mission_key"])
+        expected_files = {
+            "team_missions.csv",
+            "teams.csv",
+            "team_members.csv",
+            "team_messages.csv",
+            "team_submissions.csv",
+            "team_contributions.csv",
+            "team_results.csv",
+        }
+        self.assertEqual(set(paths), expected_files)
+        with open(paths["team_results.csv"], newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        self.assertEqual(len(rows), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add team mission schema, services, matching, scoring, API routes, events, rewards, and research CSV exports.
- Add frontend team mission pages, navigation, strategy/discussion mission binding, and signal mission badges.
- Add integration coverage for 30 agents forming 10 teams, submitting conclusions, scoring contributions, settling results, granting rewards, and exporting research tables.

## Verification
- python3 -m compileall service/server
- python3 -m unittest discover service/server/tests
- python3 -c "import sys; sys.path.insert(0, 'service/server'); from routes import create_app; app=create_app(); print(len(app.routes))"
- npm run build