### PR TITLE
fix(market_intel): treat Friday-close intraday quotes as session_close on weekends and pre-market

### DIFF
--- a/service/server/market_intel.py
+++ b/service/server/market_intel.py
@@ -14,7 +14,7 @@ import os
 import threading
 import time
 from collections import Counter
-from datetime import datetime, time as datetime_time, timedelta, timezone
+from datetime import date, datetime, time as datetime_time, timedelta, timezone
 from typing import Any, Optional
 import re
 
@@ -200,6 +200,26 @@ def _is_us_market_open(now_utc: Optional[datetime] = None) -> bool:
     return US_MARKET_OPEN_TIME <= current_time < US_MARKET_CLOSE_TIME
 
 
+def _last_us_session_date(now_et: datetime) -> date:
+    """Return the date of the most-recent US trading session that has closed.
+
+    Walks backward from ``now_et`` (US Eastern time) skipping weekends. If the
+    reference moment is on a weekday and at-or-after the regular-session
+    close (16:00 ET), the same day's session has closed and counts as the
+    most-recent session. Otherwise the most-recent session is the previous
+    weekday. Holidays are not modelled — quotes from a holiday-shortened or
+    closed weekday may still be classified as ``session_close`` rather than
+    ``stale``; that is conservative for the freshness signal.
+    """
+    candidate = now_et
+    if candidate.weekday() < 5 and candidate.time() >= US_MARKET_CLOSE_TIME:
+        return candidate.date()
+    candidate = candidate - timedelta(days=1)
+    while candidate.weekday() >= 5:
+        candidate = candidate - timedelta(days=1)
+    return candidate.date()
+
+
 def _stock_quote_cache_get(symbol: str) -> Optional[dict[str, Any]]:
     now = time.time()
     with _stock_quote_cache_lock:
@@ -310,7 +330,13 @@ def _build_stock_price_metadata(price_as_of: Optional[str], price_source: Option
             stale = age_seconds > STOCK_QUOTE_STALE_AFTER_SECONDS
             status = "realtime" if not stale else "stale"
         else:
-            stale = quote_et.date() != now_et.date()
+            # The market is closed (weekend, pre-market, or post-close). The
+            # most-recent intraday quote is `session_close` only if its date
+            # matches or post-dates the most-recent fully-closed US trading
+            # session. The previous date-equality check incorrectly marked
+            # Friday's close as `stale` on Saturday/Sunday and Monday's close
+            # as `stale` during Tuesday's pre-market.
+            stale = quote_et.date() < _last_us_session_date(now_et)
             status = "session_close" if not stale else "stale"
 
     return {

--- a/service/server/tests/test_market_intel.py
+++ b/service/server/tests/test_market_intel.py
@@ -115,5 +115,129 @@ class MarketIntelLatestPayloadTests(unittest.TestCase):
         self.assertEqual([item["symbol"] for item in payload["items"]], ["AAPL", "MSFT"])
 
 
+class StockPriceMetadataTests(unittest.TestCase):
+    """Coverage for _build_stock_price_metadata staleness classification.
+
+    The intent of `price_status="session_close"` is "the latest US session has
+    closed; this intraday quote is the most-recent available data until the
+    next open". The staleness check must therefore accept Friday's close as
+    `session_close` on Saturday/Sunday, and accept the previous trading day's
+    close as `session_close` during the next day's pre-market hours.
+    """
+
+    def _intraday(self, price_as_of: str) -> dict:
+        return {
+            "price_as_of": price_as_of,
+            "price_source": "alpha_vantage_time_series_intraday",
+        }
+
+    def test_metadata_during_market_open_realtime(self) -> None:
+        # Tuesday 14:35 ET, quote from 14:34 ET (1 min ago) → realtime.
+        with patch(
+            "market_intel._utc_now",
+            return_value=datetime(2026, 4, 21, 18, 35, tzinfo=timezone.utc),
+        ):
+            meta = market_intel._build_stock_price_metadata(
+                "2026-04-21T18:34:00Z",
+                "alpha_vantage_time_series_intraday",
+            )
+        self.assertFalse(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "realtime")
+
+    def test_metadata_post_close_same_day_session_close(self) -> None:
+        # Tuesday 18:00 ET (after 16:00 close), quote from Tuesday 16:00 ET.
+        with patch(
+            "market_intel._utc_now",
+            return_value=datetime(2026, 4, 21, 22, 0, tzinfo=timezone.utc),
+        ):
+            meta = market_intel._build_stock_price_metadata(
+                "2026-04-21T20:00:00Z",
+                "alpha_vantage_time_series_intraday",
+            )
+        self.assertFalse(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "session_close")
+
+    def test_metadata_friday_close_on_saturday_is_session_close(self) -> None:
+        # Saturday 10:00 ET, quote from Friday 16:00 ET.
+        # Friday's close IS the latest available real-time data until Monday's
+        # open — current behavior incorrectly classifies it as `stale`.
+        with patch(
+            "market_intel._utc_now",
+            return_value=datetime(2026, 4, 25, 14, 0, tzinfo=timezone.utc),
+        ):
+            meta = market_intel._build_stock_price_metadata(
+                "2026-04-24T20:00:00Z",
+                "alpha_vantage_time_series_intraday",
+            )
+        self.assertFalse(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "session_close")
+
+    def test_metadata_friday_close_on_sunday_is_session_close(self) -> None:
+        # Sunday 12:00 ET, quote from Friday 16:00 ET.
+        with patch(
+            "market_intel._utc_now",
+            return_value=datetime(2026, 4, 26, 16, 0, tzinfo=timezone.utc),
+        ):
+            meta = market_intel._build_stock_price_metadata(
+                "2026-04-24T20:00:00Z",
+                "alpha_vantage_time_series_intraday",
+            )
+        self.assertFalse(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "session_close")
+
+    def test_metadata_premarket_next_day_is_session_close(self) -> None:
+        # Tuesday 08:00 ET (pre-market), quote from Monday 16:00 ET.
+        with patch(
+            "market_intel._utc_now",
+            return_value=datetime(2026, 4, 21, 12, 0, tzinfo=timezone.utc),
+        ):
+            meta = market_intel._build_stock_price_metadata(
+                "2026-04-20T20:00:00Z",
+                "alpha_vantage_time_series_intraday",
+            )
+        self.assertFalse(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "session_close")
+
+    def test_metadata_premarket_monday_uses_friday_close(self) -> None:
+        # Monday 08:00 ET pre-market, quote from previous Friday 16:00 ET.
+        with patch(
+            "market_intel._utc_now",
+            return_value=datetime(2026, 4, 27, 12, 0, tzinfo=timezone.utc),
+        ):
+            meta = market_intel._build_stock_price_metadata(
+                "2026-04-24T20:00:00Z",
+                "alpha_vantage_time_series_intraday",
+            )
+        self.assertFalse(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "session_close")
+
+    def test_metadata_quote_older_than_last_session_is_stale(self) -> None:
+        # Saturday 10:00 ET, quote from Wednesday 16:00 ET (2 sessions stale).
+        with patch(
+            "market_intel._utc_now",
+            return_value=datetime(2026, 4, 25, 14, 0, tzinfo=timezone.utc),
+        ):
+            meta = market_intel._build_stock_price_metadata(
+                "2026-04-22T20:00:00Z",
+                "alpha_vantage_time_series_intraday",
+            )
+        self.assertTrue(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "stale")
+
+    def test_metadata_daily_fallback_remains_stale(self) -> None:
+        meta = market_intel._build_stock_price_metadata(
+            "2026-04-17T20:00:00Z",
+            "alpha_vantage_time_series_daily_adjusted",
+        )
+        self.assertTrue(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "stale")
+
+    def test_metadata_unparseable_timestamp_is_stale(self) -> None:
+        meta = market_intel._build_stock_price_metadata(None, None)
+        self.assertTrue(meta["price_stale"])
+        self.assertEqual(meta["price_status"], "stale")
+        self.assertIsNone(meta["price_age_seconds"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`_build_stock_price_metadata()` in [`service/server/market_intel.py`](https://github.com/HKUDS/AI-Trader/blob/main/service/server/market_intel.py) classifies an intraday quote's `price_status` as `session_close` only when the quote's date matches today's date in US Eastern time:

```python
else:  # market closed
    stale = quote_et.date() != now_et.date()
    status = "session_close" if not stale else "stale"
```

This is correct for the *same-day after-hours* case (e.g. quote at 16:00 ET, now 18:00 ET on the same weekday) but wrong in two everyday situations:

1. **Weekends.** Friday's 16:00 ET intraday close is the latest available real-time data until Monday's open. On Saturday/Sunday `quote_et.date()` (Friday) ≠ `now_et.date()` (Sat/Sun) → `stale=True`, `status="stale"`.
2. **Pre-market on the next trading day.** At 08:00 ET Tuesday the latest intraday quote is Monday 16:00 ET. Same date mismatch → `stale=True`.

Both quotes are genuinely the most-recent session-close data and should be `session_close`. The intent of the `session_close` status — "the latest session has closed; this is the most-recent available data until next open" — is exactly the case being misclassified.

## Fix

Add a `_last_us_session_date(now_et)` helper that walks back from the current US Eastern moment, skipping weekends, and returns the date of the most-recent fully-closed trading session. Replace the date-equality check with `<` against that helper:

```python
else:
    stale = quote_et.date() < _last_us_session_date(now_et)
    status = "session_close" if not stale else "stale"
```

A quote at-or-after the most-recent session close is `session_close`; older quotes remain `stale`.

Holidays are deliberately not modelled — quotes from a holiday-shortened or closed weekday may still be classified as `session_close` rather than `stale`. That is conservative for the freshness signal and keeps the change dependency-free.

## Tests

`service/server/tests/test_market_intel.py` adds 9 unit tests covering the classifier directly:

| Scenario | Expected `price_status` | Behavior on master |
|---|---|---|
| Tuesday 14:35 ET, quote 14:34 ET | `realtime` | ✓ unchanged |
| Tuesday 18:00 ET, quote 16:00 ET (same day after close) | `session_close` | ✓ unchanged |
| Saturday 10:00 ET, quote Friday 16:00 ET | `session_close` | ✗ regressed to `stale` |
| Sunday 12:00 ET, quote Friday 16:00 ET | `session_close` | ✗ regressed to `stale` |
| Tuesday 08:00 ET pre-market, quote Monday 16:00 ET | `session_close` | ✗ regressed to `stale` |
| Monday 08:00 ET pre-market, quote Friday 16:00 ET | `session_close` | ✗ regressed to `stale` |
| Saturday 10:00 ET, quote Wednesday 16:00 ET (2 sessions stale) | `stale` | ✓ unchanged |
| Daily-fallback source | `stale` | ✓ unchanged |
| Unparseable timestamp | `stale` | ✓ unchanged |

Run with:

```bash
python3 -m unittest service/server/tests/test_market_intel.py -v
python3 -m py_compile service/server/market_intel.py
```

All 25 tests in `service/server/tests/` continue to pass.

## Diff size

- `service/server/market_intel.py`: +28 / -2
- `service/server/tests/test_market_intel.py`: +124 / 0

No new dependencies; uses only stdlib datetime arithmetic.