### PR TITLE
Fix .env.example formatting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,16 @@ ENVIRONMENT=development
 
 # ==================== Database ====================
 # PostgreSQL takes precedence when DATABASE_URL is set.
-DATABASE_URL=postgresql://
-ai_trader:xxxxxx@127.0.0.1:5432/ai_trader
+# Leave empty for local SQLite development.
+DATABASE_URL=
+# Example PostgreSQL URL:
+# DATABASE_URL=postgresql://ai_trader:change-me@127.0.0.1:5432/ai_trader
 
 # SQLite fallback path when DATABASE_URL is empty.
 DB_PATH=service/server/data/clawtrader.db
 
 # ==================== API Keys ====================
 ALPHA_VANTAGE_API_KEY=demo
-
 
 # ==================== Frontend ====================
 # Frontend auto-refresh interval in milliseconds.
@@ -20,8 +21,7 @@ VITE_REFRESH_INTERVAL=300000
 # ==================== Network / CORS ====================
 CLAWTRADER_CORS_ORIGINS=http://localhost:3000,https://ai4trade.ai
 
-# ==================== Market Data Endpoints
-====================
+# ==================== Market Data Endpoints ====================
 ALPHA_VANTAGE_BASE_URL=https://www.alphavantage.co/query
 HYPERLIQUID_API_URL=https://api.hyperliquid.xyz/info
 POLYMARKET_GAMMA_BASE_URL=https://gamma-api.polymarket.com
@@ -36,8 +36,7 @@ MACRO_SIGNAL_REFRESH_INTERVAL=900
 ETF_FLOW_REFRESH_INTERVAL=900
 STOCK_ANALYSIS_REFRESH_INTERVAL=1800
 
-# ==================== Profit History Retention
-====================
+# ==================== Profit History Retention ====================
 # Keep recent history at full resolution.
 PROFIT_HISTORY_FULL_RESOLUTION_HOURS=24
 

--- a/service/server/tests/test_env_example.py
+++ b/service/server/tests/test_env_example.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+
+SERVER_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if SERVER_DIR not in sys.path:
+    sys.path.insert(0, SERVER_DIR)
+
+
+ROOT_DIR = Path(__file__).resolve().parents[3]
+
+
+class EnvExampleTests(unittest.TestCase):
+    def test_env_example_is_parseable_by_dotenv(self) -> None:
+        values = dotenv_values(ROOT_DIR / ".env.example")
+
+        self.assertEqual(values["ENVIRONMENT"], "development")
+        self.assertEqual(values["DATABASE_URL"], "")
+        self.assertEqual(values["DB_PATH"], "service/server/data/clawtrader.db")
+        self.assertEqual(values["ALPHA_VANTAGE_BASE_URL"], "https://www.alphavantage.co/query")
+        self.assertNotIn("ai_trader:change-me", values.values())


### PR DESCRIPTION
## Summary
- make .env.example parseable by dotenv and shell-style loaders
- leave DATABASE_URL empty by default for local SQLite development
- move the PostgreSQL URL into a commented example
- fix section headers that were split across lines
- add a regression test that parses .env.example with python-dotenv

Fixes #205

## Verification
- python3 -m unittest service.server.tests.test_env_example
- python3 -m unittest discover service/server/tests
- python3 -m pytest service/server/tests/test_env_example.py