### PR TITLE
docs: clarify SQLite (local) vs PostgreSQL (Docker/production) defaults in .env.example and service README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,19 @@
 ENVIRONMENT=development
 
 # ==================== Database ====================
-# PostgreSQL takes precedence when DATABASE_URL is set.
-# Leave empty for local SQLite development.
+# AI-Trader supports two database backends:
+#   1. SQLite (default for local development) — used when DATABASE_URL is empty.
+#      The file lives at DB_PATH below.
+#   2. PostgreSQL (recommended for Docker / production) — used when DATABASE_URL
+#      is set. PostgreSQL takes precedence over DB_PATH when both are present.
+#
+# For local development, leave DATABASE_URL empty (the default) and SQLite
+# will be used automatically.
 DATABASE_URL=
-# Example PostgreSQL URL:
+# Example PostgreSQL URL (uncomment and set for Docker / production):
 # DATABASE_URL=postgresql://ai_trader:change-me@127.0.0.1:5432/ai_trader
 
-# SQLite fallback path when DATABASE_URL is empty.
+# SQLite file path. Used only when DATABASE_URL is empty.
 DB_PATH=service/server/data/clawtrader.db
 
 # ==================== API Keys ====================

--- a/service/README.md
+++ b/service/README.md
@@ -6,6 +6,32 @@ This directory contains the proprietary server implementation for AI-Trader.
 
 - `main.py` - Full FastAPI backend implementation
 
+## Database backends
+
+AI-Trader supports two database backends, selected by environment variable:
+
+- **SQLite (default for local development)** — used when `DATABASE_URL` is empty.
+  The database file path comes from `DB_PATH` (default:
+  `service/server/data/clawtrader.db`).
+- **PostgreSQL (recommended for Docker / production)** — used when
+  `DATABASE_URL` is set. When `DATABASE_URL` is set it takes precedence over
+  `DB_PATH`.
+
+Example for local SQLite development (the default, no extra setup required):
+
+```
+# .env
+DATABASE_URL=
+DB_PATH=service/server/data/clawtrader.db
+```
+
+Example for PostgreSQL (Docker / production):
+
+```
+# .env
+DATABASE_URL=postgresql://ai_trader:change-me@127.0.0.1:5432/ai_trader
+```
+
 ## Deployment
 
 See deployment documentation for production setup.


### PR DESCRIPTION
## Summary

A new contributor can now read `.env.example` and `service/README.md` and tell, without scanning code, that SQLite is the local default and PostgreSQL is the Docker/production opt-in path.

## Why this matters

In #206, @JamesVanhecke flagged that `.env.example` ships `DATABASE_URL=` (empty) alongside `DB_PATH=service/server/data/clawtrader.db`, with comments that don't make clear which backend is the recommended local default or whether the `postgresql://` example is the intended path. Maintainer @TianyuFan0504 confirmed (2026-05-12) the intended behavior - SQLite when `DATABASE_URL` is empty, PostgreSQL for Docker/production - and asked to keep the issue open until the docs make that priority unambiguous.

This PR makes that priority explicit in both surfaces a new contributor lands on.

## Testing

- `.env.example` keys are unchanged, only comments updated, so existing local `.env` files keep working.
- The new `service/README.md` "Database backends" section names both `DB_PATH` and `DATABASE_URL` with their roles and gives a one-line example for each.
- `service/server/database.py` already implements the documented behavior (SQLite when `DATABASE_URL` is unset/empty, PostgreSQL otherwise), so no code changes are needed.
- Markdown renders cleanly; no broken links.

Fixes #206
