### PR TITLE
Improve worker and API performance

### DIFF
--- a/service/server/cache.py
+++ b/service/server/cache.py
@@ -7,6 +7,7 @@ Redis-backed cache helpers with graceful fallback when Redis is disabled or unav
 from __future__ import annotations
 
 import json
+import hashlib
 import threading
 import time
 from typing import Any, Optional
@@ -26,11 +27,27 @@ _last_connect_attempt_at = 0.0
 _last_connect_error: Optional[str] = None
 
 
+def _active_database_scope() -> str:
+    try:
+        import database
+
+        backend = database.get_database_backend_name()
+        if backend == "postgresql":
+            raw = database.DATABASE_URL or "postgresql"
+        else:
+            raw = getattr(database, "_SQLITE_DB_PATH", "") or "sqlite"
+    except Exception:
+        raw = "default"
+        backend = "unknown"
+    digest = hashlib.sha1(str(raw).encode("utf-8")).hexdigest()[:12]
+    return f"{backend}:{digest}"
+
+
 def _namespaced(key: str) -> str:
     cleaned = (key or "").strip()
     if not cleaned:
         raise ValueError("Cache key must not be empty")
-    return f"{REDIS_PREFIX}:{cleaned}"
+    return f"{REDIS_PREFIX}:{_active_database_scope()}:{cleaned}"
 
 
 def redis_configured() -> bool:

--- a/service/server/main.py
+++ b/service/server/main.py
@@ -14,6 +14,7 @@ AI-Trader Backend Server
 import secrets
 import logging
 import os
+import sys
 from logging.handlers import RotatingFileHandler
 
 # Setup logging
@@ -28,21 +29,28 @@ logging.basicConfig(
             os.path.join(LOG_DIR, "server.log"),
             maxBytes=10 * 1024 * 1024,  # 10MB
             backupCount=5
-        ),
-        logging.StreamHandler()
+        )
     ]
 )
+
+if os.getenv("API_STDERR_LOG", "false").strip().lower() in {"1", "true", "yes", "on"}:
+    logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
 
 logger = logging.getLogger(__name__)
 
 from cache import get_cache_status
 from database import init_database, get_database_status
 from routes import create_app
+from routes_shared import api_access_log_enabled
 from tasks import (
     _update_trending_cache,
     background_tasks_enabled_for_api,
     start_background_tasks,
 )
+
+if not api_access_log_enabled():
+    logging.getLogger("uvicorn.access").disabled = True
+    logging.getLogger("uvicorn.access").propagate = False
 
 # Initialize database
 init_database()
@@ -90,4 +98,4 @@ async def startup_event():
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=8000, access_log=api_access_log_enabled())

--- a/service/server/price_fetcher.py
+++ b/service/server/price_fetcher.py
@@ -8,6 +8,8 @@ Crypto: 从 Hyperliquid 获取价格（停止使用 Alpha Vantage crypto 端点�
 import os
 import random
 import requests
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import datetime, timezone, timedelta
 from typing import Optional, Dict, Tuple, Any
 import re
@@ -34,6 +36,8 @@ PRICE_FETCH_MAX_RETRIES = max(0, int(os.environ.get("PRICE_FETCH_MAX_RETRIES", "
 PRICE_FETCH_BACKOFF_BASE_SECONDS = max(0.0, float(os.environ.get("PRICE_FETCH_BACKOFF_BASE_SECONDS", "0.35")))
 PRICE_FETCH_ERROR_COOLDOWN_SECONDS = max(0.0, float(os.environ.get("PRICE_FETCH_ERROR_COOLDOWN_SECONDS", "20")))
 PRICE_FETCH_RATE_LIMIT_COOLDOWN_SECONDS = max(0.0, float(os.environ.get("PRICE_FETCH_RATE_LIMIT_COOLDOWN_SECONDS", "60")))
+PRICE_FETCH_VERBOSE = os.environ.get("PRICE_FETCH_VERBOSE", "true").strip().lower() not in {"0", "false", "no", "off"}
+HYPERLIQUID_SYMBOL_CACHE_TTL_SECONDS = max(60.0, float(os.environ.get("HYPERLIQUID_SYMBOL_CACHE_TTL_SECONDS", "300")))
 
 # 时区常量
 UTC = timezone.utc
@@ -47,6 +51,22 @@ _POLYMARKET_CONDITION_ID_RE = re.compile(r"^0x[a-fA-F0-9]{64}$")
 _POLYMARKET_TOKEN_ID_RE = re.compile(r"^\d+$")
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 _provider_cooldowns: Dict[str, float] = {}
+_price_fetch_logging_enabled: ContextVar[bool] = ContextVar("price_fetch_logging_enabled", default=True)
+_hyperliquid_symbol_cache: Tuple[Optional[set[str]], float] = (None, 0.0)
+
+
+def _price_log(message: str) -> None:
+    if PRICE_FETCH_VERBOSE and _price_fetch_logging_enabled.get():
+        print(message)
+
+
+@contextmanager
+def price_fetch_logging(enabled: bool):
+    token = _price_fetch_logging_enabled.set(enabled)
+    try:
+        yield
+    finally:
+        _price_fetch_logging_enabled.reset(token)
 
 # Polymarket outcome prices are probabilities in [0, 1]. Reject values outside to avoid
 # token_id/condition_id or other API noise being interpreted as price (e.g. 1.5e+73).
@@ -61,7 +81,9 @@ def _polymarket_price_valid(price: float) -> bool:
 
 # In-memory cache for Polymarket reference+outcome -> (token_id, expiry_epoch_s)
 _polymarket_token_cache: Dict[str, Tuple[str, float]] = {}
+_polymarket_market_cache: Dict[str, Tuple[Optional[dict], float]] = {}
 _POLYMARKET_TOKEN_CACHE_TTL_S = 300.0
+_POLYMARKET_MARKET_CACHE_TTL_S = 300.0
 
 
 def _provider_cooldown_remaining(provider: str) -> float:
@@ -75,7 +97,7 @@ def _activate_provider_cooldown(provider: str, duration_s: float, reason: str) -
     previous_until = _provider_cooldowns.get(provider, 0.0)
     _provider_cooldowns[provider] = max(previous_until, until)
     remaining = _provider_cooldown_remaining(provider)
-    print(f"[Price API] {provider} cooldown {remaining:.1f}s ({reason})")
+    _price_log(f"[Price API] {provider} cooldown {remaining:.1f}s ({reason})")
 
 
 def _retry_delay(attempt: int) -> float:
@@ -119,7 +141,7 @@ def _request_json_with_retry(
 
             if retryable and attempt < attempts - 1:
                 delay = _retry_delay(attempt)
-                print(
+                _price_log(
                     f"[Price API] {provider} retry {attempt + 1}/{attempts - 1} "
                     f"after HTTP {status_code}; sleeping {delay:.2f}s"
                 )
@@ -144,7 +166,7 @@ def _request_json_with_retry(
             last_exc = exc
             if attempt < attempts - 1:
                 delay = _retry_delay(attempt)
-                print(
+                _price_log(
                     f"[Price API] {provider} retry {attempt + 1}/{attempts - 1} "
                     f"after {exc.__class__.__name__}; sleeping {delay:.2f}s"
                 )
@@ -245,6 +267,14 @@ def _normalize_hyperliquid_symbol(symbol: str) -> str:
             s = s[: -len(sep)]
             break
 
+    for sep in ("-USDT", "/USDT"):
+        if s.endswith(sep):
+            s = s[: -len(sep)]
+            break
+
+    if s.endswith("USDT") and len(s) > len("USDT"):
+        s = s[: -len("USDT")]
+
     return s.strip()
 
 
@@ -257,6 +287,42 @@ def _hyperliquid_post(payload: dict) -> object:
         HYPERLIQUID_API_URL,
         json_payload=payload,
     )
+
+
+def _get_hyperliquid_available_symbols() -> Optional[set[str]]:
+    global _hyperliquid_symbol_cache
+
+    cached_symbols, expires_at = _hyperliquid_symbol_cache
+    now = time.time()
+    if expires_at > now:
+        return cached_symbols
+
+    try:
+        data = _hyperliquid_post({"type": "meta"})
+    except Exception:
+        _hyperliquid_symbol_cache = (None, now + 30.0)
+        return None
+
+    symbols: set[str] = set()
+    if isinstance(data, dict):
+        universe = data.get("universe")
+        if isinstance(universe, list):
+            for asset in universe:
+                if isinstance(asset, dict):
+                    name = str(asset.get("name") or "").strip()
+                    if name:
+                        symbols.add(name)
+
+    _hyperliquid_symbol_cache = (symbols or None, now + HYPERLIQUID_SYMBOL_CACHE_TTL_SECONDS)
+    return symbols or None
+
+
+def _hyperliquid_symbol_available(coin: str) -> bool:
+    symbols = _get_hyperliquid_available_symbols()
+    if symbols is None:
+        return True
+    return coin in symbols
+
 
 def _polymarket_get_json(url: str, params: Optional[dict] = None) -> object:
     return _request_json_with_retry(
@@ -280,17 +346,26 @@ def _parse_string_array(value: Any) -> list[str]:
     return []
 
 
-def _polymarket_fetch_market(reference: str) -> Optional[dict]:
+def _polymarket_fetch_market(reference: str, token_id: Optional[str] = None) -> Optional[dict]:
     if not POLYMARKET_GAMMA_BASE_URL:
         return None
 
     ref = (reference or "").strip()
-    if not ref:
+    requested_token_id = (token_id or "").strip()
+    if not ref and not requested_token_id:
         return None
+
+    cache_key = f"{ref}::{requested_token_id}"
+    now = time.time()
+    cached = _polymarket_market_cache.get(cache_key)
+    if cached and cached[1] > now:
+        return cached[0]
 
     url = f"{POLYMARKET_GAMMA_BASE_URL.rstrip('/')}/markets"
     params = {"limit": "1"}
-    if _POLYMARKET_CONDITION_ID_RE.match(ref):
+    if requested_token_id and _POLYMARKET_TOKEN_ID_RE.match(requested_token_id):
+        params["clob_token_ids"] = requested_token_id
+    elif _POLYMARKET_CONDITION_ID_RE.match(ref):
         params["conditionId"] = ref
     elif _POLYMARKET_TOKEN_ID_RE.match(ref):
         params["clob_token_ids"] = ref
@@ -300,11 +375,15 @@ def _polymarket_fetch_market(reference: str) -> Optional[dict]:
     try:
         raw = _polymarket_get_json(url, params=params)
     except Exception:
+        _polymarket_market_cache[cache_key] = (None, now + 60.0)
         return None
 
     if not isinstance(raw, list) or not raw or not isinstance(raw[0], dict):
+        _polymarket_market_cache[cache_key] = (None, now + _POLYMARKET_MARKET_CACHE_TTL_S)
         return None
-    return raw[0]
+    market = raw[0]
+    _polymarket_market_cache[cache_key] = (market, now + _POLYMARKET_MARKET_CACHE_TTL_S)
+    return market
 
 
 def _polymarket_extract_tokens(market: dict) -> list[dict[str, Optional[str]]]:
@@ -331,6 +410,8 @@ def _polymarket_resolve_reference(reference: str, token_id: Optional[str] = None
     if not ref:
         return None
 
+    requested_token_id = (token_id or "").strip()
+    requested_outcome = (outcome or "").strip().lower()
     cache_key = f"{ref}::{(token_id or '').strip().lower()}::{(outcome or '').strip().lower()}"
     cached = _polymarket_token_cache.get(cache_key)
     now = time.time()
@@ -338,31 +419,31 @@ def _polymarket_resolve_reference(reference: str, token_id: Optional[str] = None
         return {
             "token_id": cached[0],
             "outcome": outcome,
-            "market": _polymarket_fetch_market(ref),
+            "market": _polymarket_fetch_market(ref, token_id=requested_token_id),
         }
 
-    market = _polymarket_fetch_market(ref)
+    market = _polymarket_fetch_market(ref, token_id=requested_token_id)
     if not market:
         return None
 
     tokens = _polymarket_extract_tokens(market)
-    requested_token_id = (token_id or "").strip()
-    requested_outcome = (outcome or "").strip().lower()
 
     selected = None
-    if requested_token_id:
+    if requested_token_id and _POLYMARKET_TOKEN_ID_RE.match(requested_token_id):
         for candidate in tokens:
             if candidate["token_id"] == requested_token_id:
                 selected = candidate
                 break
-    elif _POLYMARKET_TOKEN_ID_RE.match(ref):
+        if selected is None and not tokens:
+            selected = {"token_id": requested_token_id, "outcome": outcome}
+    if selected is None and _POLYMARKET_TOKEN_ID_RE.match(ref):
         selected = {"token_id": ref, "outcome": outcome}
-    elif requested_outcome:
+    if selected is None and requested_outcome:
         for candidate in tokens:
             if (candidate.get("outcome") or "").strip().lower() == requested_outcome:
                 selected = candidate
                 break
-    elif len(tokens) == 1:
+    if selected is None and len(tokens) == 1:
         selected = tokens[0]
 
     if not selected or not selected.get("token_id"):
@@ -496,6 +577,10 @@ def _get_hyperliquid_mid_price(symbol: str) -> Optional[float]:
     This is used for 'now' style queries.
     """
     coin = _normalize_hyperliquid_symbol(symbol)
+    if not _hyperliquid_symbol_available(coin):
+        _price_log(f"[Price API] Hyperliquid symbol not listed: {symbol} -> {coin}")
+        return None
+
     data = _hyperliquid_post({"type": "l2Book", "coin": coin})
     if not isinstance(data, dict) or "levels" not in data:
         return None
@@ -538,6 +623,10 @@ def _get_hyperliquid_candle_close(symbol: str, executed_at: str) -> Optional[flo
     end_ms = target_ms + 10 * 60 * 1000
 
     coin = _normalize_hyperliquid_symbol(symbol)
+    if not _hyperliquid_symbol_available(coin):
+        _price_log(f"[Price API] Hyperliquid symbol not listed: {symbol} -> {coin}")
+        return None
+
     payload = {
         "type": "candleSnapshot",
         "req": {
@@ -595,6 +684,13 @@ def get_price_from_market(
         查询到的价格，如果失败返回 None
     """
     try:
+        try:
+            from routes_shared import normalize_market
+
+            market = normalize_market(market)
+        except Exception:
+            market = (market or "").strip().lower()
+
         if market == "crypto":
             # Crypto pricing now uses Hyperliquid public endpoints.
             # Try historical candle (when executed_at is provided), then fall back to mid price.
@@ -603,20 +699,23 @@ def get_price_from_market(
             # Polymarket pricing uses public Gamma + CLOB endpoints.
             # We use the current orderbook mid price (paper trading).
             price = _get_polymarket_mid_price(symbol, token_id=token_id, outcome=outcome)
-        else:
+        elif market == "us-stock":
             if not ALPHA_VANTAGE_API_KEY or ALPHA_VANTAGE_API_KEY == "demo":
-                print("Warning: ALPHA_VANTAGE_API_KEY not set, using agent-provided price")
+                _price_log("Warning: ALPHA_VANTAGE_API_KEY not set, using agent-provided price")
                 return None
             price = _get_us_stock_price(symbol, executed_at)
+        else:
+            _price_log(f"[Price API] Unsupported market for server price fetch: {market}")
+            return None
 
         if price is None:
-            print(f"[Price API] Failed to fetch {symbol} ({market}) price for time {executed_at}")
+            _price_log(f"[Price API] Failed to fetch {symbol} ({market}) price for time {executed_at}")
         else:
-            print(f"[Price API] Successfully fetched {symbol} ({market}): ${price}")
+            _price_log(f"[Price API] Successfully fetched {symbol} ({market}): ${price}")
 
         return price
     except Exception as e:
-        print(f"[Price API] Error fetching {symbol} ({market}): {e}")
+        _price_log(f"[Price API] Error fetching {symbol} ({market}): {e}")
         return None
 
 
@@ -652,7 +751,7 @@ def _get_us_stock_price(symbol: str, executed_at: str) -> Optional[float]:
         )
 
         if "Error Message" in data:
-            print(f"[Price API] Error: {data.get('Error Message')}")
+            _price_log(f"[Price API] Error: {data.get('Error Message')}")
             return None
         if "Note" in data:
             _activate_provider_cooldown(
@@ -660,12 +759,12 @@ def _get_us_stock_price(symbol: str, executed_at: str) -> Optional[float]:
                 PRICE_FETCH_RATE_LIMIT_COOLDOWN_SECONDS,
                 "body rate limit note"
             )
-            print(f"[Price API] Rate limit: {data.get('Note')}")
+            _price_log(f"[Price API] Rate limit: {data.get('Note')}")
             return None
 
         time_series_key = "Time Series (1min)"
         if time_series_key not in data:
-            print(f"[Price API] No time series data for {symbol}")
+            _price_log(f"[Price API] No time series data for {symbol}")
             return None
 
         time_series = data[time_series_key]
@@ -689,11 +788,11 @@ def _get_us_stock_price(symbol: str, executed_at: str) -> Optional[float]:
                     closest_price = float(values.get("4. close", 0))
 
         if closest_price:
-            print(f"[Price API] Found closest price for {symbol}: ${closest_price} ({int(min_diff)}s earlier)")
+            _price_log(f"[Price API] Found closest price for {symbol}: ${closest_price} ({int(min_diff)}s earlier)")
         return closest_price
 
     except Exception as e:
-        print(f"[Price API] Exception while fetching {symbol}: {e}")
+        _price_log(f"[Price API] Exception while fetching {symbol}: {e}")
         return None
 
 

--- a/service/server/routes.py
+++ b/service/server/routes.py
@@ -42,7 +42,7 @@ def create_app() -> FastAPI:
         return response
 
     ctx = RouteContext()
-    register_market_routes(app)
+    register_market_routes(app, ctx)
     register_agent_routes(app, ctx)
     register_signal_routes(app, ctx)
     register_trading_routes(app, ctx)

--- a/service/server/routes_agent.py
+++ b/service/server/routes_agent.py
@@ -18,7 +18,18 @@ from routes_models import (
     AgentRegister,
     AgentTaskCreate,
 )
-from routes_shared import RouteContext, push_agent_message, utc_now_iso_z
+from routes_shared import (
+    AGENT_MESSAGE_SUMMARY_CACHE_KEY_PREFIX,
+    AGENT_MESSAGE_SUMMARY_CACHE_TTL_SECONDS,
+    PUBLIC_COUNT_CACHE_KEY_PREFIX,
+    PUBLIC_COUNT_CACHE_TTL_SECONDS,
+    RouteContext,
+    get_short_cached_payload,
+    invalidate_agent_message_caches,
+    push_agent_message,
+    set_short_cached_payload,
+    utc_now_iso_z,
+)
 from services import (
     _get_agent_by_id,
     _get_agent_by_name,
@@ -129,6 +140,7 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
         conn.commit()
         message_id = cursor.lastrowid
         conn.close()
+        invalidate_agent_message_caches(ctx, data.agent_id)
 
         if data.agent_id in ctx.ws_connections:
             try:
@@ -149,32 +161,48 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
         if not agent:
             raise HTTPException(status_code=401, detail='Invalid token')
 
-        conn = get_db_connection()
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT type, COUNT(*) as count
-            FROM agent_messages
-            WHERE agent_id = ? AND read = 0
-            GROUP BY type
-            """,
-            (agent['id'],),
+        redis_cache_key = f'{AGENT_MESSAGE_SUMMARY_CACHE_KEY_PREFIX}:agent_id={agent["id"]}'
+        payload = get_short_cached_payload(
+            ctx,
+            ctx.agent_message_summary_cache,
+            redis_cache_key,
+            AGENT_MESSAGE_SUMMARY_CACHE_TTL_SECONDS,
         )
-        rows = cursor.fetchall()
-        conn.close()
+        if not isinstance(payload, dict):
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT type, COUNT(*) as count
+                FROM agent_messages
+                WHERE agent_id = ? AND read = 0
+                GROUP BY type
+                """,
+                (agent['id'],),
+            )
+            rows = cursor.fetchall()
+            conn.close()
 
-        counts = {row['type']: row['count'] for row in rows}
-        discussion_unread = sum(counts.get(message_type, 0) for message_type in DISCUSSION_NOTIFICATION_TYPES)
-        strategy_unread = sum(counts.get(message_type, 0) for message_type in STRATEGY_NOTIFICATION_TYPES)
-        experiment_unread = sum(counts.get(message_type, 0) for message_type in EXPERIMENT_NOTIFICATION_TYPES)
+            counts = {row['type']: row['count'] for row in rows}
+            discussion_unread = sum(counts.get(message_type, 0) for message_type in DISCUSSION_NOTIFICATION_TYPES)
+            strategy_unread = sum(counts.get(message_type, 0) for message_type in STRATEGY_NOTIFICATION_TYPES)
+            experiment_unread = sum(counts.get(message_type, 0) for message_type in EXPERIMENT_NOTIFICATION_TYPES)
 
-        return {
-            'discussion_unread': discussion_unread,
-            'strategy_unread': strategy_unread,
-            'experiment_unread': experiment_unread,
-            'total_unread': discussion_unread + strategy_unread + experiment_unread,
-            'by_type': counts,
-        }
+            payload = {
+                'discussion_unread': discussion_unread,
+                'strategy_unread': strategy_unread,
+                'experiment_unread': experiment_unread,
+                'total_unread': discussion_unread + strategy_unread + experiment_unread,
+                'by_type': counts,
+            }
+            set_short_cached_payload(
+                ctx,
+                ctx.agent_message_summary_cache,
+                redis_cache_key,
+                payload,
+                AGENT_MESSAGE_SUMMARY_CACHE_TTL_SECONDS,
+            )
+        return payload
 
     @app.get('/api/claw/messages/recent')
     async def get_recent_agent_messages(
@@ -264,6 +292,8 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
         updated = cursor.rowcount
         conn.commit()
         conn.close()
+        if updated:
+            invalidate_agent_message_caches(ctx, agent['id'])
 
         return {'success': True, 'updated': updated}
 
@@ -368,6 +398,8 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
 
         conn.commit()
         conn.close()
+        if message_ids:
+            invalidate_agent_message_caches(ctx, agent_id)
 
         parsed_messages = []
         for row in messages:
@@ -467,6 +499,10 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
 
             conn.commit()
             conn.close()
+            from cache import delete
+
+            ctx.public_count_cache.pop(f'{PUBLIC_COUNT_CACHE_KEY_PREFIX}:agents', None)
+            delete(f'{PUBLIC_COUNT_CACHE_KEY_PREFIX}:agents')
 
             try:
                 experiment_assignments = variant_for_agent(agent_id)
@@ -663,9 +699,25 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
 
     @app.get('/api/claw/agents/count')
     async def get_agent_count():
-        conn = get_db_connection()
-        cursor = conn.cursor()
-        cursor.execute('SELECT COUNT(*) as count FROM agents')
-        count = cursor.fetchone()['count']
-        conn.close()
-        return {'count': count}
+        redis_cache_key = f'{PUBLIC_COUNT_CACHE_KEY_PREFIX}:agents'
+        payload = get_short_cached_payload(
+            ctx,
+            ctx.public_count_cache,
+            redis_cache_key,
+            PUBLIC_COUNT_CACHE_TTL_SECONDS,
+        )
+        if not isinstance(payload, dict):
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            cursor.execute('SELECT COUNT(*) as count FROM agents')
+            count = cursor.fetchone()['count']
+            conn.close()
+            payload = {'count': count}
+            set_short_cached_payload(
+                ctx,
+                ctx.public_count_cache,
+                redis_cache_key,
+                payload,
+                PUBLIC_COUNT_CACHE_TTL_SECONDS,
+            )
+        return payload

--- a/service/server/routes_market.py
+++ b/service/server/routes_market.py
@@ -11,39 +11,77 @@ from market_intel import (
     get_stock_analysis_history_payload,
     get_stock_analysis_latest_payload,
 )
-from routes_shared import utc_now_iso_z
+from routes_shared import (
+    MARKET_INTEL_CACHE_KEY_PREFIX,
+    MARKET_INTEL_CACHE_TTL_SECONDS,
+    RouteContext,
+    get_short_cached_payload,
+    set_short_cached_payload,
+    utc_now_iso_z,
+)
 
 
-def register_market_routes(app: FastAPI) -> None:
+def register_market_routes(app: FastAPI, ctx: RouteContext) -> None:
+    def _cached_market_payload(cache_key: str, builder):
+        redis_key = f'{MARKET_INTEL_CACHE_KEY_PREFIX}:{cache_key}'
+        cached = get_short_cached_payload(ctx, ctx.market_intel_cache, redis_key, MARKET_INTEL_CACHE_TTL_SECONDS)
+        if isinstance(cached, dict):
+            return cached
+        payload = builder()
+        return set_short_cached_payload(
+            ctx,
+            ctx.market_intel_cache,
+            redis_key,
+            payload,
+            MARKET_INTEL_CACHE_TTL_SECONDS,
+        )
+
     @app.get('/health')
     async def health_check():
         return {'status': 'ok', 'timestamp': utc_now_iso_z()}
 
     @app.get('/api/market-intel/overview')
     async def market_intel_overview():
-        return get_market_intel_overview()
+        return _cached_market_payload('overview', get_market_intel_overview)
 
     @app.get('/api/market-intel/news')
     async def market_intel_news(category: Optional[str] = None, limit: int = 5):
         safe_limit = max(1, min(limit, 12))
-        return get_market_news_payload(category=category, limit=safe_limit)
+        category_key = (category or 'all').strip() or 'all'
+        return _cached_market_payload(
+            f'news:category={category_key}:limit={safe_limit}',
+            lambda: get_market_news_payload(category=category, limit=safe_limit),
+        )
 
     @app.get('/api/market-intel/macro-signals')
     async def market_intel_macro_signals():
-        return get_macro_signals_payload()
+        return _cached_market_payload('macro_signals', get_macro_signals_payload)
 
     @app.get('/api/market-intel/etf-flows')
     async def market_intel_etf_flows():
-        return get_etf_flows_payload()
+        return _cached_market_payload('etf_flows', get_etf_flows_payload)
 
     @app.get('/api/market-intel/stocks/featured')
     async def market_intel_featured_stocks(limit: int = 6):
-        return get_featured_stock_analysis_payload(limit=max(1, min(limit, 12)))
+        safe_limit = max(1, min(limit, 12))
+        return _cached_market_payload(
+            f'stocks_featured:limit={safe_limit}',
+            lambda: get_featured_stock_analysis_payload(limit=safe_limit),
+        )
 
     @app.get('/api/market-intel/stocks/{symbol}/latest')
     async def market_intel_stock_latest(symbol: str):
-        return get_stock_analysis_latest_payload(symbol)
+        normalized_symbol = (symbol or '').strip().upper()
+        return _cached_market_payload(
+            f'stock_latest:symbol={normalized_symbol}',
+            lambda: get_stock_analysis_latest_payload(normalized_symbol),
+        )
 
     @app.get('/api/market-intel/stocks/{symbol}/history')
     async def market_intel_stock_history(symbol: str, limit: int = 10):
-        return get_stock_analysis_history_payload(symbol, limit=limit)
+        normalized_symbol = (symbol or '').strip().upper()
+        safe_limit = max(1, min(limit, 100))
+        return _cached_market_payload(
+            f'stock_history:symbol={normalized_symbol}:limit={safe_limit}',
+            lambda: get_stock_analysis_history_payload(normalized_symbol, limit=safe_limit),
+        )

--- a/service/server/routes_shared.py
+++ b/service/server/routes_shared.py
@@ -43,16 +43,68 @@ LEADERBOARD_CACHE_KEY_PREFIX = 'leaderboard:profit_history'
 GROUPED_SIGNALS_CACHE_KEY_PREFIX = 'signals:grouped'
 AGENT_SIGNALS_CACHE_KEY_PREFIX = 'signals:agent'
 PRICE_CACHE_KEY_PREFIX = 'price:quote'
+SIGNAL_FEED_CACHE_KEY_PREFIX = 'signals:feed'
+POSITIONS_CACHE_TTL_SECONDS = 10
+SIGNAL_FEED_CACHE_TTL_SECONDS = 10
+AGENT_MESSAGE_SUMMARY_CACHE_KEY_PREFIX = 'agent_messages:unread_summary'
+AGENT_MESSAGE_SUMMARY_CACHE_TTL_SECONDS = 5
+PUBLIC_COUNT_CACHE_KEY_PREFIX = 'public_counts'
+PUBLIC_COUNT_CACHE_TTL_SECONDS = 30
+MARKET_INTEL_CACHE_KEY_PREFIX = 'market_intel'
+MARKET_INTEL_CACHE_TTL_SECONDS = 30
 
 MENTION_PATTERN = re.compile(r'@([A-Za-z0-9_\-]{2,64})')
+SUPPORTED_MARKETS = {'us-stock', 'crypto', 'polymarket'}
+MARKET_ALIASES = {
+    'binance': 'crypto',
+    'binance-spot': 'crypto',
+    'binance_spot': 'crypto',
+    'coinbase': 'crypto',
+    'coinbase-spot': 'crypto',
+    'coinbase_spot': 'crypto',
+    'hyperliquid': 'crypto',
+    'hl': 'crypto',
+    'kraken': 'crypto',
+    'okx': 'crypto',
+    'stock': 'us-stock',
+    'stocks': 'us-stock',
+    'us': 'us-stock',
+    'us stock': 'us-stock',
+    'us stocks': 'us-stock',
+    'us_stock': 'us-stock',
+    'us_stocks': 'us-stock',
+    'usstock': 'us-stock',
+    'nasdaq': 'us-stock',
+    'sp500': 'us-stock',
+    'etf': 'us-stock',
+    'equity': 'us-stock',
+    'equities': 'us-stock',
+}
+
+
+def normalize_market(market: str | None) -> str:
+    normalized = (market or 'us-stock').strip().lower()
+    return MARKET_ALIASES.get(normalized, normalized)
+
+
+def validate_market(market: str | None) -> str:
+    normalized = normalize_market(market)
+    if normalized not in SUPPORTED_MARKETS:
+        allowed = ', '.join(sorted(SUPPORTED_MARKETS))
+        raise HTTPException(status_code=400, detail=f"Unsupported market '{market}'. Supported markets: {allowed}")
+    return normalized
 
 
 def allow_sync_price_fetch_in_api() -> bool:
     return os.getenv('ALLOW_SYNC_PRICE_FETCH_IN_API', 'false').strip().lower() in {'1', 'true', 'yes', 'on'}
 
 
+def api_access_log_enabled() -> bool:
+    return os.getenv('API_ACCESS_LOG', 'false').strip().lower() in {'1', 'true', 'yes', 'on'}
+
+
 def should_fetch_server_trade_price(market: str) -> bool:
-    normalized_market = (market or '').strip().lower()
+    normalized_market = normalize_market(market)
     if normalized_market in {'crypto', 'polymarket'}:
         return True
     return allow_sync_price_fetch_in_api()
@@ -61,10 +113,15 @@ def should_fetch_server_trade_price(market: str) -> bool:
 @dataclass
 class RouteContext:
     grouped_signals_cache: dict[tuple[str, str, int, int], tuple[float, dict[str, Any]]] = field(default_factory=dict)
+    signal_feed_cache: dict[tuple[str, str, str, int, int, str, int], tuple[float, dict[str, Any]]] = field(default_factory=dict)
     agent_signals_cache: dict[tuple[int, str, int], tuple[float, dict[str, Any]]] = field(default_factory=dict)
+    positions_cache: dict[int, tuple[float, dict[str, Any]]] = field(default_factory=dict)
     price_api_last_request: dict[int, float] = field(default_factory=dict)
     price_quote_cache: dict[tuple[str, str, str, str], tuple[float, dict[str, Any]]] = field(default_factory=dict)
     leaderboard_cache: dict[tuple[int, int, int, bool], tuple[float, dict[str, Any]]] = field(default_factory=dict)
+    market_intel_cache: dict[str, tuple[float, dict[str, Any]]] = field(default_factory=dict)
+    public_count_cache: dict[str, tuple[float, dict[str, Any]]] = field(default_factory=dict)
+    agent_message_summary_cache: dict[str, tuple[float, dict[str, Any]]] = field(default_factory=dict)
     content_rate_limit_state: dict[tuple[int, str], dict[str, Any]] = field(default_factory=dict)
     ws_connections: dict[int, WebSocket] = field(default_factory=dict)
     verification_codes: dict[str, dict[str, Any]] = field(default_factory=dict)
@@ -135,6 +192,49 @@ def check_price_api_rate_limit(ctx: RouteContext, agent_id: int) -> bool:
 
 def utc_now_iso_z() -> str:
     return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+
+def get_short_cached_payload(
+    ctx: RouteContext,
+    local_cache: dict[Any, tuple[float, Any]],
+    redis_key: str,
+    ttl_seconds: int,
+) -> Any:
+    from cache import get_json
+
+    now_ts = time.time()
+    cached = local_cache.get(redis_key)
+    if cached and now_ts - cached[0] < ttl_seconds:
+        return cached[1]
+
+    cached_payload = get_json(redis_key)
+    if cached_payload is not None:
+        local_cache[redis_key] = (now_ts, cached_payload)
+        return cached_payload
+
+    return None
+
+
+def set_short_cached_payload(
+    ctx: RouteContext,
+    local_cache: dict[Any, tuple[float, Any]],
+    redis_key: str,
+    payload: Any,
+    ttl_seconds: int,
+) -> Any:
+    from cache import set_json
+
+    local_cache[redis_key] = (time.time(), payload)
+    set_json(redis_key, payload, ttl_seconds=ttl_seconds)
+    return payload
+
+
+def invalidate_agent_message_caches(ctx: RouteContext, agent_id: int) -> None:
+    from cache import delete
+
+    key = f'{AGENT_MESSAGE_SUMMARY_CACHE_KEY_PREFIX}:agent_id={agent_id}'
+    ctx.agent_message_summary_cache.pop(key, None)
+    delete(key)
 
 
 def experiment_unread_notice(agent_id: int, *, limit: int = EXPERIMENT_UNREAD_PREVIEW_LIMIT) -> Optional[dict[str, Any]]:
@@ -374,7 +474,9 @@ def invalidate_signal_list_caches(ctx: RouteContext) -> None:
     from cache import delete_pattern
 
     ctx.grouped_signals_cache.clear()
+    ctx.signal_feed_cache.clear()
     delete_pattern(f'{GROUPED_SIGNALS_CACHE_KEY_PREFIX}:*')
+    delete_pattern(f'{SIGNAL_FEED_CACHE_KEY_PREFIX}:*')
     invalidate_agent_signal_caches(ctx)
 
 
@@ -398,6 +500,13 @@ def invalidate_signal_read_caches(ctx: RouteContext, refresh_trending: bool = Fa
     invalidate_leaderboard_caches(ctx)
     if refresh_trending:
         invalidate_trending_caches()
+
+
+def invalidate_position_cache(ctx: RouteContext, agent_id: int | None = None) -> None:
+    if agent_id is None:
+        ctx.positions_cache.clear()
+        return
+    ctx.positions_cache.pop(agent_id, None)
 
 
 def get_position_snapshot(cursor: Any, agent_id: int, market: str, symbol: str, token_id: Optional[str]):
@@ -440,6 +549,7 @@ async def push_agent_message(
     )
     conn.commit()
     conn.close()
+    invalidate_agent_message_caches(ctx, agent_id)
 
     if agent_id in ctx.ws_connections:
         try:

--- a/service/server/routes_signals.py
+++ b/service/server/routes_signals.py
@@ -24,11 +24,14 @@ from routes_shared import (
     GROUPED_SIGNALS_CACHE_KEY_PREFIX,
     GROUPED_SIGNALS_CACHE_TTL_SECONDS,
     RouteContext,
+    SIGNAL_FEED_CACHE_KEY_PREFIX,
+    SIGNAL_FEED_CACHE_TTL_SECONDS,
     attach_experiment_unread_notice,
     decorate_polymarket_item,
     enforce_content_rate_limit,
     extract_mentions,
     get_position_snapshot,
+    invalidate_position_cache,
     invalidate_agent_signal_caches,
     invalidate_signal_read_caches,
     is_market_open,
@@ -37,6 +40,7 @@ from routes_shared import (
     should_fetch_server_trade_price,
     utc_now_iso_z,
     validate_executed_at,
+    validate_market,
 )
 from services import _add_agent_points, _get_agent_by_token, _reserve_signal_id, _update_position_from_signal
 from signal_quality import score_signal_quality
@@ -104,11 +108,13 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
         now = utc_now_iso_z()
         side = data.action
         action_lower = side.lower()
-        fetch_price_in_request = should_fetch_server_trade_price(data.market)
+        market = validate_market(data.market)
+        symbol = data.symbol.strip() if market == 'polymarket' else data.symbol.strip().upper()
+        fetch_price_in_request = should_fetch_server_trade_price(market)
         polymarket_token_id = None
         polymarket_outcome = None
 
-        if data.market == 'polymarket' and action_lower in ('short', 'cover'):
+        if market == 'polymarket' and action_lower in ('short', 'cover'):
             raise HTTPException(
                 status_code=400,
                 detail='Polymarket paper trading does not support short/cover. Use buy/sell of outcome tokens instead.',
@@ -124,13 +130,13 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
         if qty > 1_000_000:
             raise HTTPException(status_code=400, detail='Quantity too large')
 
-        if data.market == 'polymarket':
+        if market == 'polymarket':
             if data.executed_at.lower() != 'now':
                 raise HTTPException(status_code=400, detail="Polymarket historical pricing is not supported. Use executed_at='now'.")
             if fetch_price_in_request:
                 from price_fetcher import _polymarket_resolve_reference
 
-                contract = _polymarket_resolve_reference(data.symbol, token_id=data.token_id, outcome=data.outcome)
+                contract = _polymarket_resolve_reference(symbol, token_id=data.token_id, outcome=data.outcome)
                 if not contract:
                     raise HTTPException(
                         status_code=400,
@@ -158,8 +164,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
             executed_at = now_utc.strftime('%Y-%m-%dT%H:%M:%SZ')
             now_et = now_utc.astimezone(ZoneInfo('America/New_York'))
 
-            if not is_market_open(data.market):
-                if data.market == 'us-stock':
+            if not is_market_open(market):
+                if market == 'us-stock':
                     raise HTTPException(
                         status_code=400,
                         detail=(
@@ -168,23 +174,23 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                             'Trading hours: Mon-Fri 9:30-16:00 ET'
                         ),
                     )
-                raise HTTPException(status_code=400, detail=f'{data.market} is currently closed')
+                raise HTTPException(status_code=400, detail=f'{market} is currently closed')
 
             if get_price_from_market is not None:
                 actual_price = get_price_from_market(
-                    data.symbol,
+                    symbol,
                     executed_at,
-                    data.market,
+                    market,
                     token_id=polymarket_token_id,
                     outcome=polymarket_outcome,
                 )
                 if not actual_price:
-                    raise HTTPException(status_code=400, detail=f'Unable to fetch current price for {data.symbol}')
+                    raise HTTPException(status_code=400, detail=f'Unable to fetch current price for {symbol}')
                 price = actual_price
             else:
                 price = data.price
         else:
-            is_valid, error_msg = validate_executed_at(data.executed_at, data.market)
+            is_valid, error_msg = validate_executed_at(data.executed_at, market)
             if not is_valid:
                 raise HTTPException(status_code=400, detail=error_msg)
 
@@ -194,16 +200,16 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
 
             if get_price_from_market is not None:
                 actual_price = get_price_from_market(
-                    data.symbol,
+                    symbol,
                     executed_at,
-                    data.market,
+                    market,
                     token_id=polymarket_token_id,
                     outcome=polymarket_outcome,
                 )
                 if not actual_price:
                     raise HTTPException(
                         status_code=400,
-                        detail=f'Unable to fetch historical price for {data.symbol} at {executed_at}',
+                        detail=f'Unable to fetch historical price for {symbol} at {executed_at}',
                     )
                 price = actual_price
             else:
@@ -242,7 +248,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
             signal_id = _reserve_signal_id(cursor)
 
             if action_lower in ('sell', 'cover'):
-                pos = get_position_snapshot(cursor, agent_id, data.market, data.symbol, polymarket_token_id)
+                pos = get_position_snapshot(cursor, agent_id, market, symbol, polymarket_token_id)
                 current_qty = float(pos['quantity']) if pos else 0.0
                 position_entry_price = float(pos['entry_price']) if pos and pos['entry_price'] is not None else None
                 if action_lower == 'sell':
@@ -279,8 +285,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                 (
                     signal_id,
                     agent_id,
-                    data.market,
-                    data.symbol,
+                    market,
+                    symbol,
                     polymarket_token_id,
                     polymarket_outcome,
                     side,
@@ -295,8 +301,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
 
             _update_position_from_signal(
                 agent_id,
-                data.symbol,
-                data.market,
+                symbol,
+                market,
                 side,
                 qty,
                 price,
@@ -320,8 +326,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                 cursor,
                 agent_id=agent_id,
                 source_signal_id=signal_id,
-                market=data.market,
-                symbol=data.symbol,
+                market=market,
+                symbol=symbol,
                 side=side,
                 price=price,
                 quantity=qty,
@@ -332,8 +338,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                     'signal_id': signal_id,
                     'agent_id': agent_id,
                     'message_type': 'operation',
-                    'market': data.market,
-                    'symbol': data.symbol,
+                    'market': market,
+                    'symbol': symbol,
                     'side': side,
                     'content': data.content,
                     'created_at': now,
@@ -352,11 +358,11 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                 agent_id=agent_id,
                 signal_id=signal_id,
                 message_type='operation',
-                market=data.market,
+                market=market,
                 experiment_key=event_experiment_key,
                 variant_key=event_variant_key,
                 metadata={
-                    'symbol': data.symbol,
+                    'symbol': symbol,
                     'side': side,
                     'quality_score': signal_quality.get('overall_score'),
                     **reward_metadata,
@@ -388,6 +394,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
         )
 
         follower_count = 0
+        copied_follower_ids: set[int] = set()
         try:
             conn = get_db_connection()
             cursor = conn.cursor()
@@ -420,8 +427,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                         follower_position = get_position_snapshot(
                             cursor,
                             follower_id,
-                            data.market,
-                            data.symbol,
+                            market,
+                            symbol,
                             polymarket_token_id,
                         )
                         if action_lower == 'cover' and (not follower_position or follower_position['entry_price'] is None):
@@ -430,8 +437,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
 
                     _update_position_from_signal(
                         follower_id,
-                        data.symbol,
-                        data.market,
+                        symbol,
+                        market,
                         side,
                         qty,
                         price,
@@ -454,8 +461,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                         (
                             follower_signal_id,
                             follower_id,
-                            data.market,
-                            data.symbol,
+                            market,
+                            symbol,
                             polymarket_token_id,
                             polymarket_outcome,
                             side,
@@ -486,8 +493,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                         cursor,
                         agent_id=follower_id,
                         source_signal_id=follower_signal_id,
-                        market=data.market,
-                        symbol=data.symbol,
+                        market=market,
+                        symbol=symbol,
                         side=side,
                         price=price,
                         quantity=qty,
@@ -498,8 +505,8 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                             'signal_id': follower_signal_id,
                             'agent_id': follower_id,
                             'message_type': 'operation',
-                            'market': data.market,
-                            'symbol': data.symbol,
+                            'market': market,
+                            'symbol': symbol,
                             'side': side,
                             'content': copy_content,
                             'created_at': now,
@@ -512,13 +519,14 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                         agent_id=follower_id,
                         signal_id=follower_signal_id,
                         message_type='operation',
-                        market=data.market,
-                        metadata={'symbol': data.symbol, 'side': side, 'copied_from_agent_id': agent_id},
+                        market=market,
+                        metadata={'symbol': symbol, 'side': side, 'copied_from_agent_id': agent_id},
                         cursor=cursor,
                     )
 
                     cursor.execute(f'RELEASE SAVEPOINT follower_{follower_id}')
                     follower_count += 1
+                    copied_follower_ids.add(follower_id)
                 except Exception:
                     try:
                         cursor.execute(f'ROLLBACK TO SAVEPOINT follower_{follower_id}')
@@ -535,13 +543,16 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                 pass
 
         invalidate_signal_read_caches(ctx, refresh_trending=True)
+        invalidate_position_cache(ctx, agent_id)
+        for follower_id in copied_follower_ids:
+            invalidate_position_cache(ctx, follower_id)
 
         payload = {
             'success': True,
             'signal_id': signal_id,
             'message_type': 'operation',
-            'market': data.market,
-            'symbol': data.symbol,
+            'market': market,
+            'symbol': symbol,
             'price': price,
             'follower_count': follower_count,
             'points_earned': reward_points,
@@ -549,7 +560,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
             'outcome': polymarket_outcome,
             'challenge_trade_count': challenge_trade_count,
         }
-        if data.market == 'polymarket':
+        if market == 'polymarket':
             decorate_polymarket_item(payload, fetch_remote=fetch_price_in_request)
         return attach_experiment_unread_notice(payload, agent_id)
 
@@ -999,6 +1010,32 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
         if token:
             viewer = _get_agent_by_token(token)
 
+        feed_cache_key = (
+            (message_type or '').strip(),
+            (market or '').strip(),
+            (keyword or '').strip(),
+            limit,
+            offset,
+            (sort or 'new').strip(),
+            int(viewer['id']) if sort == 'following' and viewer else 0,
+        )
+        now_ts = time.time()
+        redis_cache_key = (
+            f'{SIGNAL_FEED_CACHE_KEY_PREFIX}:'
+            f"message_type={feed_cache_key[0] or 'all'}:"
+            f"market={feed_cache_key[1] or 'all'}:"
+            f"keyword={feed_cache_key[2] or 'none'}:"
+            f'limit={limit}:offset={offset}:sort={feed_cache_key[5]}:viewer={feed_cache_key[6]}'
+        )
+        cached_payload = get_json(redis_cache_key)
+        if isinstance(cached_payload, dict):
+            ctx.signal_feed_cache[feed_cache_key] = (now_ts, cached_payload)
+            return cached_payload
+
+        cached = ctx.signal_feed_cache.get(feed_cache_key)
+        if cached and now_ts - cached[0] < SIGNAL_FEED_CACHE_TTL_SECONDS:
+            return cached[1]
+
         conn = get_db_connection()
         cursor = conn.cursor()
 
@@ -1173,13 +1210,16 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
             signal_dict['is_following_author'] = signal_dict['agent_id'] in followed_author_ids
             signals.append(signal_dict)
 
-        return {
+        payload = {
             'signals': signals,
             'total': total,
             'limit': limit,
             'offset': offset,
             'has_more': offset + len(signals) < total,
         }
+        ctx.signal_feed_cache[feed_cache_key] = (now_ts, payload)
+        set_json(redis_cache_key, payload, ttl_seconds=SIGNAL_FEED_CACHE_TTL_SECONDS)
+        return payload
 
     @app.get('/api/signals/following')
     async def get_following(

--- a/service/server/routes_trading.py
+++ b/service/server/routes_trading.py
@@ -12,6 +12,7 @@ from routes_models import FollowRequest
 from routes_shared import (
     LEADERBOARD_CACHE_KEY_PREFIX,
     LEADERBOARD_CACHE_TTL_SECONDS,
+    POSITIONS_CACHE_TTL_SECONDS,
     PRICE_CACHE_KEY_PREFIX,
     PRICE_QUOTE_CACHE_TTL_SECONDS,
     RouteContext,
@@ -24,6 +25,7 @@ from routes_shared import (
     push_agent_message,
     resolve_position_prices,
     utc_now_iso_z,
+    validate_market,
 )
 from services import _get_agent_by_token
 from utils import _extract_token
@@ -464,6 +466,7 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
         if not check_price_api_rate_limit(ctx, agent['id']):
             raise HTTPException(status_code=429, detail='Rate limit exceeded. Please wait 1 second between requests.')
 
+        market = validate_market(market)
         now = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
         normalized_symbol = symbol.upper() if market == 'us-stock' else symbol
         cache_key = (
@@ -532,6 +535,11 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
         if not agent:
             raise HTTPException(status_code=401, detail='Invalid token')
 
+        now_ts = time.time()
+        cached = ctx.positions_cache.get(agent['id'])
+        if cached and now_ts - cached[0] < POSITIONS_CACHE_TTL_SECONDS:
+            return cached[1]
+
         conn = get_db_connection()
         cursor = conn.cursor()
         cursor.execute(
@@ -578,7 +586,9 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
             if positions[-1]['market'] == 'polymarket':
                 decorate_polymarket_item(positions[-1], fetch_remote=False)
 
-        return {'positions': positions, 'cash': agent.get('cash', 100000.0)}
+        payload = {'positions': positions, 'cash': agent.get('cash', 100000.0)}
+        ctx.positions_cache[agent['id']] = (now_ts, payload)
+        return payload
 
     @app.get('/api/agents/{agent_id}/positions')
     async def get_agent_positions(agent_id: int):

--- a/service/server/tasks.py
+++ b/service/server/tasks.py
@@ -5,16 +5,28 @@ Tasks Module
 """
 
 import asyncio
+import hashlib
 import json
 import os
+import re
+import threading
 import time
+from collections import Counter
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any
 
 # Global trending cache (shared with routes)
 trending_cache: list = []
-_last_profit_history_prune_at: float = 0.0
+_last_profit_history_prune_at: float = time.time()
+_profit_history_prune_task: Optional[asyncio.Task] = None
 _TRENDING_CACHE_KEY = "trending:top20"
+_SUPPORTED_PRICE_MARKETS = {"crypto", "polymarket", "us-stock"}
+_PRICE_FAILURES: Dict[tuple[str, str, str, str], dict[str, float]] = {}
+_PRICE_FAILURE_CACHE_KEY_PREFIX = "position_price_failures"
+_POLYMARKET_SETTLEMENT_RECHECK_AFTER: Dict[tuple[str, str, str], float] = {}
+_POLYMARKET_UPDOWN_RE = re.compile(r"^(btc|eth|sol|xrp)-updown-(5m|15m|1h|4h)-(\d+)$", re.IGNORECASE)
+_profit_history_prune_lock = threading.Lock()
+_POLYMARKET_SETTLEMENT_CURSOR = 0
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -32,6 +44,98 @@ def _env_int(name: str, default: int, minimum: Optional[int] = None) -> int:
     if minimum is not None:
         value = max(minimum, value)
     return value
+
+
+def _env_csv_set(name: str, default: str = "") -> set[str]:
+    raw = os.getenv(name, default)
+    return {item.strip().lower() for item in raw.split(",") if item.strip()}
+
+
+def _normalize_task_market(market: str | None) -> str:
+    try:
+        from routes_shared import normalize_market
+
+        return normalize_market(market)
+    except Exception:
+        return (market or "").strip().lower()
+
+
+def _price_failure_retry_after(key: tuple[str, str, str, str], now_ts: float) -> float:
+    state = _PRICE_FAILURES.get(key)
+    if not state:
+        try:
+            from cache import get_json
+
+            cached = get_json(_price_failure_cache_key(key))
+            if isinstance(cached, dict):
+                state = {
+                    "count": float(cached.get("count") or 0),
+                    "retry_after": float(cached.get("retry_after") or 0),
+                    "last_failed_at": float(cached.get("last_failed_at") or 0),
+                }
+                if state["retry_after"] > now_ts:
+                    _PRICE_FAILURES[key] = state
+        except Exception:
+            state = None
+    if not state:
+        return 0.0
+    return max(0.0, float(state.get("retry_after", 0.0)) - now_ts)
+
+
+def _price_failure_cache_key(key: tuple[str, str, str, str]) -> str:
+    payload = json.dumps(list(key), separators=(",", ":"), sort_keys=False)
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()
+    return f"{_PRICE_FAILURE_CACHE_KEY_PREFIX}:{digest}"
+
+
+def _record_price_failure(key: tuple[str, str, str, str], now_ts: float) -> int:
+    base_s = _env_int("POSITION_PRICE_FAILURE_COOLDOWN_SECONDS", 3600, minimum=60)
+    max_s = _env_int("POSITION_PRICE_FAILURE_MAX_COOLDOWN_SECONDS", 21600, minimum=base_s)
+    previous = _PRICE_FAILURES.get(key, {})
+    count = int(previous.get("count", 0)) + 1
+    cooldown_s = min(max_s, base_s * (2 ** min(count - 1, 6)))
+    state = {
+        "count": float(count),
+        "retry_after": now_ts + cooldown_s,
+        "last_failed_at": now_ts,
+    }
+    _PRICE_FAILURES[key] = state
+    try:
+        from cache import set_json
+
+        set_json(_price_failure_cache_key(key), state, ttl_seconds=cooldown_s + 300)
+    except Exception:
+        pass
+    return cooldown_s
+
+
+def _clear_price_failure(key: tuple[str, str, str, str]) -> None:
+    _PRICE_FAILURES.pop(key, None)
+    try:
+        from cache import delete
+
+        delete(_price_failure_cache_key(key))
+    except Exception:
+        pass
+
+
+def _format_price_key(key: tuple[str, str, str, str]) -> str:
+    symbol, market, token_id, outcome = key
+    suffix = f", token={token_id}" if token_id else ""
+    if outcome:
+        suffix = f"{suffix}, outcome={outcome}" if suffix else f", outcome={outcome}"
+    return f"{symbol} ({market}{suffix})"
+
+
+def _polymarket_updown_expired_seconds(symbol: str | None, now_ts: float) -> Optional[float]:
+    match = _POLYMARKET_UPDOWN_RE.match((symbol or "").strip())
+    if not match:
+        return None
+    try:
+        end_ts = int(match.group(3))
+    except Exception:
+        return None
+    return now_ts - float(end_ts)
 
 
 def _backfill_polymarket_position_metadata() -> None:
@@ -123,6 +227,16 @@ def _update_trending_cache():
 
 
 def _prune_profit_history() -> None:
+    if not _profit_history_prune_lock.acquire(blocking=False):
+        print("[Profit History] Prune already running; skipped")
+        return
+    try:
+        _prune_profit_history_unlocked()
+    finally:
+        _profit_history_prune_lock.release()
+
+
+def _prune_profit_history_unlocked() -> None:
     """Tier profit history into high-resolution, 15m, hourly, and daily retention."""
     from database import get_db_connection, using_postgres
 
@@ -315,20 +429,54 @@ def _maybe_prune_profit_history() -> None:
     if now - _last_profit_history_prune_at < prune_interval:
         return
 
-    _prune_profit_history()
     _last_profit_history_prune_at = now
+    _prune_profit_history()
+
+
+def _profit_history_prune_done(task: asyncio.Task) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception as exc:
+        print(f"[Profit History] Async prune failed: {exc}")
+
+
+def _maybe_schedule_profit_history_prune() -> None:
+    global _last_profit_history_prune_at, _profit_history_prune_task
+
+    prune_interval = _env_int("PROFIT_HISTORY_PRUNE_INTERVAL_SECONDS", 3600)
+    if prune_interval <= 0:
+        return
+
+    if _profit_history_prune_task is not None and not _profit_history_prune_task.done():
+        return
+
+    now = time.time()
+    if now - _last_profit_history_prune_at < prune_interval:
+        return
+
+    _last_profit_history_prune_at = now
+    _profit_history_prune_task = asyncio.create_task(
+        asyncio.to_thread(_prune_profit_history),
+        name="ai-trader:profit_history_prune",
+    )
+    _profit_history_prune_task.add_done_callback(_profit_history_prune_done)
+    print("[Profit History] Scheduled async prune")
 
 
 async def update_position_prices():
     """Background task to update position prices every 5 minutes."""
     from database import get_db_connection
-    from price_fetcher import get_price_from_market
+    from price_fetcher import get_price_from_market, price_fetch_logging
 
     # Get max parallel requests from environment variable
     max_parallel = _env_int("MAX_PARALLEL_PRICE_FETCH", 2, minimum=1)
+    verbose_fetch = _env_bool("POSITION_PRICE_VERBOSE_FETCH_LOGS", False)
+    refresh_priced_markets = _env_csv_set("POSITION_PRICE_REFRESH_PRICED_MARKETS", "crypto")
 
     # Wait a bit on startup before first update
-    await asyncio.sleep(5)
+    await asyncio.sleep(_env_int("POSITION_PRICE_STARTUP_DELAY_SECONDS", 15, minimum=0))
 
     while True:
         try:
@@ -337,54 +485,136 @@ async def update_position_prices():
             try:
                 cursor = conn.cursor()
 
-                # Get all unique positions with symbol and market
                 cursor.execute("""
-                    SELECT DISTINCT symbol, market, token_id, outcome
+                    SELECT
+                        symbol,
+                        market,
+                        token_id,
+                        outcome,
+                        COUNT(*) AS position_count,
+                        SUM(CASE WHEN current_price IS NULL THEN 1 ELSE 0 END) AS null_price_count
                     FROM positions
+                    GROUP BY symbol, market, token_id, outcome
                 """)
                 unique_positions = cursor.fetchall()
             finally:
                 conn.close()
 
-            print(f"[Price Update] Found {len(unique_positions)} positions to update")
+            now_ts = time.time()
+            candidates = []
+            skipped_unsupported = 0
+            skipped_cooldown = 0
+            skipped_expired_polymarket = 0
+            skipped_priced = 0
+            skipped_cooldown_by_market: Counter[str] = Counter()
+            skipped_priced_by_market: Counter[str] = Counter()
+            skipped_unsupported_by_market: Counter[str] = Counter()
+
+            for row in unique_positions:
+                symbol = row["symbol"]
+                original_market = row["market"]
+                market = _normalize_task_market(original_market)
+                token_id = row["token_id"] or ""
+                outcome = row["outcome"] or ""
+                null_price_count = int(row["null_price_count"] or 0)
+
+                if market not in _SUPPORTED_PRICE_MARKETS:
+                    skipped_unsupported += 1
+                    skipped_unsupported_by_market[str(original_market or "-")] += 1
+                    continue
+
+                if null_price_count <= 0 and market not in refresh_priced_markets:
+                    skipped_priced += 1
+                    skipped_priced_by_market[market] += 1
+                    continue
+
+                if market == "polymarket":
+                    expired_s = _polymarket_updown_expired_seconds(symbol, now_ts)
+                    if expired_s is not None and expired_s > _env_int("POLYMARKET_UPDOWN_PRICE_GRACE_SECONDS", 900, minimum=60):
+                        skipped_expired_polymarket += 1
+                        continue
+
+                key = (str(symbol or ""), market, str(token_id), str(outcome))
+                remaining = _price_failure_retry_after(key, now_ts)
+                if remaining > 0:
+                    skipped_cooldown += 1
+                    skipped_cooldown_by_market[market] += 1
+                    continue
+
+                candidates.append({
+                    "symbol": symbol,
+                    "db_market": original_market,
+                    "market": market,
+                    "token_id": token_id,
+                    "outcome": outcome,
+                    "key": key,
+                })
+
+            print(
+                "[Price Update] candidates="
+                f"{len(candidates)}/{len(unique_positions)} "
+                f"skipped_unsupported={skipped_unsupported} "
+                f"skipped_priced={skipped_priced} "
+                f"skipped_expired_polymarket={skipped_expired_polymarket} "
+                f"skipped_cooldown={skipped_cooldown}"
+            )
+            if skipped_unsupported_by_market:
+                print(f"[Price Update] Unsupported markets skipped: {dict(skipped_unsupported_by_market.most_common())}")
+            if skipped_priced_by_market:
+                print(f"[Price Update] Already-priced markets skipped: {dict(skipped_priced_by_market.most_common())}")
+            if skipped_cooldown_by_market:
+                print(f"[Price Update] Failure cooldown skips by market: {dict(skipped_cooldown_by_market.most_common())}")
 
             # Semaphore to control concurrency
             semaphore = asyncio.Semaphore(max_parallel)
 
-            async def fetch_price(row):
+            async def fetch_price(row: dict[str, Any]):
                 symbol = row["symbol"]
                 market = row["market"]
+                db_market = row["db_market"]
                 token_id = row["token_id"]
                 outcome = row["outcome"]
+                key = row["key"]
 
                 async with semaphore:
                     # Run synchronous function in thread pool
                     # Use UTC time for consistent pricing timestamps
                     now = datetime.now(timezone.utc)
                     executed_at = now.strftime("%Y-%m-%dT%H:%M:%SZ")
-                    price = await asyncio.to_thread(
-                        get_price_from_market, symbol, executed_at, market, token_id, outcome
-                    )
-
-                    if price is not None:
-                        print(f"[Price Update] {symbol} ({market}, token={token_id or '-'}): ${price}")
-                    else:
-                        print(f"[Price Update] Failed to get price for {symbol} ({market}, token={token_id or '-'})")
+                    with price_fetch_logging(verbose_fetch):
+                        price = await asyncio.to_thread(
+                            get_price_from_market, symbol, executed_at, market, token_id, outcome
+                        )
 
                 return {
                     "symbol": symbol,
+                    "db_market": db_market,
                     "market": market,
                     "token_id": token_id,
+                    "outcome": outcome,
+                    "key": key,
                     "price": price,
                 }
 
             # Fetch prices in parallel, then write them back in one short transaction.
-            results = await asyncio.gather(*[fetch_price(row) for row in unique_positions])
+            results = await asyncio.gather(*[fetch_price(row) for row in candidates])
             updates = [
-                (item["price"], item["symbol"], item["market"], item["token_id"])
+                (item["price"], item["symbol"], item["db_market"], item["token_id"])
                 for item in results
                 if item["price"] is not None
             ]
+            failed = [item for item in results if item["price"] is None]
+            failures_by_market: Counter[str] = Counter(item["market"] for item in failed)
+            success_by_market: Counter[str] = Counter(item["market"] for item in results if item["price"] is not None)
+
+            cooldown_samples: list[str] = []
+            for item in results:
+                if item["price"] is not None:
+                    _clear_price_failure(item["key"])
+                    continue
+                cooldown_s = _record_price_failure(item["key"], now_ts)
+                if len(cooldown_samples) < 8:
+                    cooldown_samples.append(f"{_format_price_key(item['key'])} retry_in={cooldown_s}s")
 
             if updates:
                 conn = get_db_connection()
@@ -398,6 +628,15 @@ async def update_position_prices():
                     conn.commit()
                 finally:
                     conn.close()
+
+            print(
+                "[Price Update] summary "
+                f"requested={len(results)} updated={len(updates)} failed={len(failed)} "
+                f"success_by_market={dict(success_by_market.most_common())} "
+                f"failed_by_market={dict(failures_by_market.most_common())}"
+            )
+            if cooldown_samples:
+                print(f"[Price Update] Failure cooldown samples: {cooldown_samples}")
 
             # Update trending cache (no additional API call, uses same data)
             _update_trending_cache()
@@ -520,21 +759,21 @@ async def periodic_token_cleanup():
             print(f"[Token Cleanup Error] {e}")
 
 
-async def record_profit_history():
-    """Record profit history for all agents."""
-    from database import get_db_connection
+def _record_profit_history_once() -> int:
+    from database import get_db_connection, using_postgres
 
-    print("[Profit History] Task starting...")
-
-    while True:
-        try:
-            conn = get_db_connection()
-            try:
-                cursor = conn.cursor()
-
-                cursor.execute("""
+    started_at = time.monotonic()
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    initial_capital = 100000.0
+    max_abs_profit = 1e12
+    conn = get_db_connection()
+    try:
+        cursor = conn.cursor()
+        if using_postgres():
+            cursor.execute("""
+                WITH agent_values AS (
                     SELECT
-                        a.id,
+                        a.id AS agent_id,
                         COALESCE(a.cash, 0) AS cash,
                         COALESCE(a.deposited, 0) AS deposited,
                         COALESCE(
@@ -549,50 +788,135 @@ async def record_profit_history():
                         ) AS position_value
                     FROM agents a
                     LEFT JOIN positions p ON p.agent_id = a.id
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM agent_leaderboard_exclusions ale
+                        WHERE ale.agent_id = a.id
+                          AND COALESCE(ale.active, 1) = 1
+                    )
                     GROUP BY a.id, a.cash, a.deposited
+                ),
+                calculated AS (
+                    SELECT
+                        agent_id,
+                        cash,
+                        position_value,
+                        cash + position_value AS total_value,
+                        cash + position_value - (? + deposited) AS raw_profit
+                    FROM agent_values
+                ),
+                inserted AS (
+                    INSERT INTO profit_history (agent_id, total_value, cash, position_value, profit, recorded_at)
+                    SELECT
+                        agent_id,
+                        total_value,
+                        cash,
+                        position_value,
+                        CASE
+                            WHEN ABS(raw_profit) > ? THEN
+                                CASE WHEN raw_profit > 0 THEN ? ELSE -? END
+                            ELSE raw_profit
+                        END AS profit,
+                        ?
+                    FROM calculated
+                    RETURNING 1
+                )
+                SELECT
+                    (SELECT COUNT(*) FROM inserted) AS inserted_count,
+                    (SELECT COUNT(*) FROM calculated WHERE ABS(raw_profit) > ?) AS clamped_count
+            """, (initial_capital, max_abs_profit, max_abs_profit, max_abs_profit, now, max_abs_profit))
+            row = cursor.fetchone()
+            inserted_count = int(row["inserted_count"] or 0) if row else 0
+            clamped_count = int(row["clamped_count"] or 0) if row else 0
+        else:
+            cursor.execute("""
+                WITH agent_values AS (
+                    SELECT
+                        a.id AS agent_id,
+                        COALESCE(a.cash, 0) AS cash,
+                        COALESCE(a.deposited, 0) AS deposited,
+                        COALESCE(
+                            SUM(
+                                CASE
+                                    WHEN p.current_price IS NULL THEN p.entry_price * ABS(p.quantity)
+                                    WHEN p.side = 'long' THEN p.current_price * ABS(p.quantity)
+                                    ELSE (2 * p.entry_price - p.current_price) * ABS(p.quantity)
+                                END
+                            ),
+                            0
+                        ) AS position_value
+                    FROM agents a
+                    LEFT JOIN positions p ON p.agent_id = a.id
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM agent_leaderboard_exclusions ale
+                        WHERE ale.agent_id = a.id
+                          AND COALESCE(ale.active, 1) = 1
+                    )
+                    GROUP BY a.id, a.cash, a.deposited
+                ),
+                calculated AS (
+                    SELECT
+                        agent_id,
+                        cash,
+                        position_value,
+                        cash + position_value AS total_value,
+                        cash + position_value - (? + deposited) AS raw_profit
+                    FROM agent_values
+                )
+                INSERT INTO profit_history (agent_id, total_value, cash, position_value, profit, recorded_at)
+                SELECT
+                    agent_id,
+                    total_value,
+                    cash,
+                    position_value,
+                    CASE
+                        WHEN ABS(raw_profit) > ? THEN
+                            CASE WHEN raw_profit > 0 THEN ? ELSE -? END
+                        ELSE raw_profit
+                    END AS profit,
+                    ?
+                FROM calculated
+            """, (initial_capital, max_abs_profit, max_abs_profit, max_abs_profit, now))
+            inserted_count = cursor.rowcount if cursor.rowcount is not None and cursor.rowcount >= 0 else 0
+            clamped_count = 0
+            if inserted_count == 0:
+                cursor.execute("""
+                    SELECT COUNT(*) AS agent_count
+                    FROM agents a
+                    WHERE NOT EXISTS (
+                        SELECT 1
+                        FROM agent_leaderboard_exclusions ale
+                        WHERE ale.agent_id = a.id
+                          AND COALESCE(ale.active, 1) = 1
+                    )
                 """)
-                agents = cursor.fetchall()
-            finally:
-                conn.close()
+                row = cursor.fetchone()
+                inserted_count = int(row["agent_count"] or 0) if row else 0
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
-            print(f"[Profit History] Found {len(agents)} agents")
+    elapsed_s = time.monotonic() - started_at
+    if clamped_count:
+        print(f"[Profit History] Clamped absurd profit for {clamped_count} agents to ±{max_abs_profit}")
+    print(f"[Profit History] Recorded profit for {inserted_count} agents in {elapsed_s:.2f}s")
+    return inserted_count
 
-            now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-            rows_to_insert = []
 
-            for agent in agents:
-                agent_id = agent["id"]
-                cash = agent["cash"] or 0
-                deposited = agent["deposited"] or 0
-                position_value = agent["position_value"] or 0
-                initial_capital = 100000.0
+async def record_profit_history():
+    """Record profit history for all agents."""
+    print("[Profit History] Task starting...")
+    await asyncio.sleep(_env_int("PROFIT_HISTORY_STARTUP_DELAY_SECONDS", 90, minimum=0))
 
-                # Calculate profit: (cash + position) - (initial + deposited)
-                # This excludes deposited cash from profit calculation
-                total_value = cash + position_value
-                profit = total_value - (initial_capital + deposited)
-                # Clamp profit to avoid absurd values (e.g. from bad Polymarket price or API noise)
-                _max_abs_profit = 1e12
-                if abs(profit) > _max_abs_profit:
-                    print(f"[Profit History] Agent {agent_id}: clamping absurd profit {profit} to ±{_max_abs_profit}")
-                    profit = _max_abs_profit if profit > 0 else -_max_abs_profit
-                rows_to_insert.append((agent_id, total_value, cash, position_value, profit, now))
-
-            if rows_to_insert:
-                conn = get_db_connection()
-                try:
-                    cursor = conn.cursor()
-                    cursor.executemany("""
-                        INSERT INTO profit_history (agent_id, total_value, cash, position_value, profit, recorded_at)
-                        VALUES (?, ?, ?, ?, ?, ?)
-                    """, rows_to_insert)
-                    conn.commit()
-                finally:
-                    conn.close()
-                _maybe_prune_profit_history()
-
-            print(f"[Profit History] Recorded profit for {len(agents)} agents")
-
+    while True:
+        try:
+            recorded_count = await asyncio.to_thread(_record_profit_history_once)
+            if recorded_count:
+                _maybe_schedule_profit_history_prune()
         except Exception as e:
             print(f"[Profit History Error] {e}")
 
@@ -614,9 +938,10 @@ async def settle_polymarket_positions():
     """
     from database import get_db_connection
     from price_fetcher import _polymarket_resolve
+    global _POLYMARKET_SETTLEMENT_CURSOR
 
     # Wait a bit on startup before first settle pass
-    await asyncio.sleep(10)
+    await asyncio.sleep(_env_int("POLYMARKET_SETTLE_STARTUP_DELAY_SECONDS", 180, minimum=0))
 
     while True:
         try:
@@ -630,11 +955,14 @@ async def settle_polymarket_positions():
             try:
                 cursor = conn.cursor()
                 cursor.execute("""
-                    SELECT id, agent_id, symbol, token_id, outcome, quantity, entry_price
+                    SELECT symbol, token_id, outcome, COUNT(*) AS position_count
                     FROM positions
-                    WHERE market = 'polymarket'
+                    WHERE market = 'polymarket' AND token_id IS NOT NULL AND token_id != ''
+                    GROUP BY symbol, token_id, outcome
                 """)
-                rows = cursor.fetchall()
+                contract_rows = cursor.fetchall()
+                cursor.execute("SELECT COUNT(*) AS count FROM positions WHERE market = 'polymarket'")
+                total_positions = int(cursor.fetchone()["count"] or 0)
             finally:
                 conn.close()
 
@@ -644,47 +972,100 @@ async def settle_polymarket_positions():
             settlement_rows: list[tuple[Any, ...]] = []
             delete_rows: list[tuple[int]] = []
 
-            for row in rows:
-                pos_id = row["id"]
-                agent_id = row["agent_id"]
-                symbol = row["symbol"]
+            resolution_by_contract: dict[tuple[str, str, str], Optional[dict[str, Any]]] = {}
+            due_contracts: list[tuple[str, str, str]] = []
+            now_ts = time.time()
+            max_contracts = _env_int("POLYMARKET_SETTLE_MAX_CONTRACTS_PER_RUN", 25, minimum=1)
+            unresolved_recheck_s = _env_int("POLYMARKET_SETTLE_UNRESOLVED_RECHECK_SECONDS", 3600, minimum=interval_s)
+
+            for row in contract_rows:
                 token_id = row["token_id"]
-                outcome = row["outcome"]
-                qty = row["quantity"] or 0
-
-                if not token_id:
-                    skipped += 1
+                contract_key = (
+                    str(row["symbol"] or ""),
+                    str(token_id or ""),
+                    str(row["outcome"] or ""),
+                )
+                if contract_key in resolution_by_contract:
                     continue
+                retry_after = _POLYMARKET_SETTLEMENT_RECHECK_AFTER.get(contract_key, 0.0)
+                if retry_after > now_ts:
+                    resolution_by_contract[contract_key] = None
+                    continue
+                resolution_by_contract[contract_key] = None
+                due_contracts.append(contract_key)
 
-                resolution = _polymarket_resolve(symbol, token_id=token_id, outcome=outcome)
+            due_contracts.sort()
+            if len(due_contracts) > max_contracts:
+                start = _POLYMARKET_SETTLEMENT_CURSOR % len(due_contracts)
+                rotated = due_contracts[start:] + due_contracts[:start]
+                unique_contracts = rotated[:max_contracts]
+                _POLYMARKET_SETTLEMENT_CURSOR = (start + max_contracts) % len(due_contracts)
+            else:
+                unique_contracts = due_contracts
+                _POLYMARKET_SETTLEMENT_CURSOR = 0
+
+            for symbol, token_id, outcome in unique_contracts:
+                resolution = await asyncio.to_thread(_polymarket_resolve, symbol, token_id=token_id, outcome=outcome)
+                resolution_by_contract[(symbol, token_id, outcome)] = resolution
                 if not resolution or not resolution.get("resolved"):
-                    skipped += 1
-                    continue
+                    _POLYMARKET_SETTLEMENT_RECHECK_AFTER[(symbol, token_id, outcome)] = now_ts + unresolved_recheck_s
+                else:
+                    _POLYMARKET_SETTLEMENT_RECHECK_AFTER.pop((symbol, token_id, outcome), None)
 
-                settlement_price = resolution.get("settlementPrice")
-                if settlement_price is None:
-                    skipped += 1
+            skipped_recheck = 0
+            resolved_contracts = {
+                contract_key: resolution
+                for contract_key, resolution in resolution_by_contract.items()
+                if resolution and resolution.get("resolved") and resolution.get("settlementPrice") is not None
+            }
+            for row in contract_rows:
+                contract_key = (str(row["symbol"] or ""), str(row["token_id"] or ""), str(row["outcome"] or ""))
+                position_count = int(row["position_count"] or 0)
+                if contract_key in resolved_contracts:
                     continue
+                skipped += position_count
+                if _POLYMARKET_SETTLEMENT_RECHECK_AFTER.get(contract_key, 0.0) > now_ts:
+                    skipped_recheck += position_count
 
-                proceeds = float(f"{(abs(qty) * float(settlement_price)):.6f}")
-                cash_updates[agent_id] = float(f"{cash_updates.get(agent_id, 0.0) + proceeds:.6f}")
-                settlement_rows.append((
-                    pos_id,
-                    agent_id,
-                    symbol,
-                    token_id,
-                    outcome,
-                    qty,
-                    row["entry_price"],
-                    settlement_price,
-                    proceeds,
-                    resolution.get("market_slug"),
-                    resolution.get("resolved_outcome"),
-                    datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                    json.dumps(resolution),
-                ))
-                delete_rows.append((pos_id,))
-                settled += 1
+            if resolved_contracts:
+                conn = get_db_connection()
+                try:
+                    cursor = conn.cursor()
+                    for (symbol, token_id, outcome), resolution in resolved_contracts.items():
+                        cursor.execute(
+                            """
+                            SELECT id, agent_id, symbol, token_id, outcome, quantity, entry_price
+                            FROM positions
+                            WHERE market = 'polymarket' AND symbol = ? AND token_id = ? AND COALESCE(outcome, '') = COALESCE(?, '')
+                            """,
+                            (symbol, token_id, outcome),
+                        )
+                        for row in cursor.fetchall():
+                            pos_id = row["id"]
+                            agent_id = row["agent_id"]
+                            qty = row["quantity"] or 0
+                            settlement_price = resolution.get("settlementPrice")
+                            proceeds = float(f"{(abs(qty) * float(settlement_price)):.6f}")
+                            cash_updates[agent_id] = float(f"{cash_updates.get(agent_id, 0.0) + proceeds:.6f}")
+                            settlement_rows.append((
+                                pos_id,
+                                agent_id,
+                                row["symbol"],
+                                row["token_id"],
+                                row["outcome"],
+                                qty,
+                                row["entry_price"],
+                                settlement_price,
+                                proceeds,
+                                resolution.get("market_slug"),
+                                resolution.get("resolved_outcome"),
+                                datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                                json.dumps(resolution),
+                            ))
+                            delete_rows.append((pos_id,))
+                            settled += 1
+                finally:
+                    conn.close()
 
             if settlement_rows:
                 conn = get_db_connection()
@@ -704,8 +1085,12 @@ async def settle_polymarket_positions():
                 finally:
                     conn.close()
 
-            if settled > 0:
-                print(f"[Polymarket Settler] settled={settled}, skipped={skipped}")
+            print(
+                "[Polymarket Settler] "
+                f"positions={total_positions} unique_contracts={len(contract_rows)} contracts_due={len(due_contracts)} "
+                f"contracts_checked={len(unique_contracts)} "
+                f"settled={settled} skipped={skipped} recheck_cooldown={skipped_recheck}"
+            )
 
         except Exception as e:
             print(f"[Polymarket Settler Error] {e}")

--- a/service/server/tests/test_price_fetcher.py
+++ b/service/server/tests/test_price_fetcher.py
@@ -16,6 +16,16 @@ def _time_series_payload(rows: dict) -> dict:
 
 
 class UsStockPriceTimezoneTests(unittest.TestCase):
+    def test_market_alias_uses_crypto_price_source(self) -> None:
+        with patch.object(price_fetcher, "_get_hyperliquid_candle_close", return_value=None), \
+             patch.object(price_fetcher, "_get_hyperliquid_mid_price", return_value=4.2) as mock_mid, \
+             patch.object(price_fetcher, "_get_us_stock_price", return_value=125.79) as mock_stock:
+            price = price_fetcher.get_price_from_market("SUI", "2026-05-15T08:00:00Z", "binance")
+
+        self.assertEqual(price, 4.2)
+        mock_mid.assert_called_once_with("SUI")
+        mock_stock.assert_not_called()
+
     def test_us_stock_lookup_uses_est_timestamp_in_winter(self) -> None:
         payload = _time_series_payload({
             "2025-01-15 09:30:00": {"4. close": "100.0"},

--- a/service/server/worker.py
+++ b/service/server/worker.py
@@ -6,8 +6,12 @@ with price refreshes, profit-history compaction, and market-intel snapshots.
 """
 
 import asyncio
+import fcntl
 import logging
 import os
+import signal
+import sys
+from contextlib import suppress
 
 from database import init_database, get_database_status
 from tasks import DEFAULT_BACKGROUND_TASKS, _prune_profit_history, start_background_tasks
@@ -20,22 +24,128 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+async def _renew_redis_lock(lock, timeout_seconds: int) -> None:
+    interval = max(5, timeout_seconds // 3)
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            lock.reacquire()
+        except Exception as exc:
+            logger.error("Lost worker singleton Redis lock: %s", exc)
+            os._exit(1)
+
+
+def _acquire_file_lock():
+    lock_path = os.getenv("AI_TRADER_WORKER_LOCK_FILE", "/tmp/ai-trader-worker.lock")
+    handle = open(lock_path, "w", encoding="utf-8")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        handle.close()
+        logger.warning("Another AI-Trader worker is already running; lock_file=%s", lock_path)
+        return None
+    handle.seek(0)
+    handle.truncate()
+    handle.write(str(os.getpid()))
+    handle.flush()
+    return handle
+
+
+def _release_file_lock(handle) -> None:
+    if handle is None:
+        return
+    with suppress(Exception):
+        fcntl.flock(handle, fcntl.LOCK_UN)
+    with suppress(Exception):
+        handle.close()
+
+
 async def main() -> None:
-    init_database()
-    logger.info("Worker database ready: %s", get_database_status())
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(line_buffering=True)
+        except Exception:
+            pass
+    try:
+        os.nice(int(os.getenv("AI_TRADER_WORKER_NICE", "10")))
+    except Exception:
+        pass
 
-    if os.getenv("AI_TRADER_BACKGROUND_TASKS") is None:
-        os.environ["AI_TRADER_BACKGROUND_TASKS"] = DEFAULT_BACKGROUND_TASKS
+    redis_lock = None
+    file_lock_handle = None
+    lock_renew_task = None
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for signame in ("SIGINT", "SIGTERM"):
+        with suppress(Exception):
+            loop.add_signal_handler(getattr(signal, signame), stop_event.set)
+    tasks: list[asyncio.Task] = []
+    try:
+        lock_timeout_seconds = max(30, int(os.getenv("AI_TRADER_WORKER_LOCK_TIMEOUT_SECONDS", "120")))
+    except Exception:
+        lock_timeout_seconds = 120
+    try:
+        from cache import acquire_lock
 
-    if os.getenv("PROFIT_HISTORY_PRUNE_ON_WORKER_START", "true").strip().lower() in {"1", "true", "yes", "on"}:
-        await asyncio.to_thread(_prune_profit_history)
-
-    tasks = start_background_tasks(logger)
-    if not tasks:
-        logger.warning("No background tasks enabled; set AI_TRADER_BACKGROUND_TASKS to a comma-separated task list.")
+        redis_lock = acquire_lock(
+            "worker:singleton",
+            timeout_seconds=lock_timeout_seconds,
+            blocking=False,
+        )
+        if redis_lock is not None:
+            acquired = bool(redis_lock.acquire(blocking=False))
+            if not acquired:
+                logger.warning("Another AI-Trader worker is already running; Redis singleton lock is held.")
+                return
+            lock_renew_task = asyncio.create_task(
+                _renew_redis_lock(redis_lock, lock_timeout_seconds),
+                name="ai-trader:worker_lock_renew",
+            )
+            logger.info("Acquired worker singleton lock via Redis")
+        else:
+            file_lock_handle = _acquire_file_lock()
+            if file_lock_handle is None:
+                return
+            logger.info("Acquired worker singleton lock via file")
+    except Exception:
+        if redis_lock is not None:
+            with suppress(Exception):
+                redis_lock.release()
+        logger.exception("Failed to acquire worker singleton lock")
         return
 
-    await asyncio.Event().wait()
+    try:
+        init_database()
+        logger.info("Worker database ready: %s", get_database_status())
+
+        if os.getenv("AI_TRADER_BACKGROUND_TASKS") is None:
+            os.environ["AI_TRADER_BACKGROUND_TASKS"] = DEFAULT_BACKGROUND_TASKS
+
+        tasks = start_background_tasks(logger)
+        if not tasks:
+            logger.warning("No background tasks enabled; set AI_TRADER_BACKGROUND_TASKS to a comma-separated task list.")
+            return
+
+        if os.getenv("PROFIT_HISTORY_PRUNE_ON_WORKER_START", "false").strip().lower() in {"1", "true", "yes", "on"}:
+            logger.info("Scheduling startup profit history prune")
+            tasks.append(asyncio.create_task(asyncio.to_thread(_prune_profit_history), name="ai-trader:startup_profit_history_prune"))
+
+        await stop_event.wait()
+        logger.info("Worker shutdown requested")
+    finally:
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            with suppress(Exception):
+                await asyncio.gather(*tasks, return_exceptions=True)
+        if lock_renew_task is not None:
+            lock_renew_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await lock_renew_task
+        if redis_lock is not None:
+            with suppress(Exception):
+                redis_lock.release()
+        _release_file_lock(file_lock_handle)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add worker singleton locking with Redis/file-lock fallback and graceful lock release
- batch profit history recording in SQL and decouple prune from the write path
- reduce noisy/failed price fetches with market filtering, cooldowns, provider metadata caches, and quieter worker fetch logging
- add short-lived Redis/local caches for hot API paths and disable access logs by default

## Verification
- python3 -m py_compile service/server/cache.py service/server/tasks.py service/server/worker.py service/server/main.py service/server/price_fetcher.py service/server/routes_shared.py service/server/routes_agent.py service/server/routes_market.py service/server/routes_signals.py service/server/routes_trading.py service/server/routes.py
- python3 -m pytest service/server/tests -q
