### PR TITLE
Add leaderboard exclusions and data repair tools

### DIFF
--- a/service/server/database.py
+++ b/service/server/database.py
@@ -387,6 +387,19 @@ def init_database():
         )
     """)
 
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS agent_leaderboard_exclusions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL UNIQUE,
+            reason TEXT NOT NULL,
+            details_json TEXT,
+            active INTEGER DEFAULT 1,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
     # Agent messages table
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS agent_messages (
@@ -1167,6 +1180,11 @@ def init_database():
     cursor.execute("""
         CREATE INDEX IF NOT EXISTS idx_profit_history_agent_recorded_at
         ON profit_history(agent_id, recorded_at DESC)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_agent_leaderboard_exclusions_active
+        ON agent_leaderboard_exclusions(active, agent_id)
     """)
 
     cursor.execute("""

--- a/service/server/routes_trading.py
+++ b/service/server/routes_trading.py
@@ -95,6 +95,12 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
             """
             SELECT COUNT(*) AS total
             FROM agents
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM agent_leaderboard_exclusions ale
+                WHERE ale.agent_id = agents.id
+                  AND COALESCE(ale.active, 1) = 1
+            )
             """
         )
         total_row = cursor.fetchone()
@@ -123,6 +129,7 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
                 SELECT
                     a.id AS agent_id,
                     a.name,
+                    ale.reason AS leaderboard_exclusion_reason,
                     COALESCE(a.deposited, 0) AS deposited,
                     (
                         COALESCE(a.cash, 0) +
@@ -165,8 +172,12 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
                         WHERE ops.agent_id = a.id AND ops.message_type = 'operation'
                     ) AS trade_count
                 FROM agents a
+                LEFT JOIN agent_leaderboard_exclusions ale
+                  ON ale.agent_id = a.id
+                 AND COALESCE(ale.active, 1) = 1
                 LEFT JOIN positions p ON p.agent_id = a.id
-                GROUP BY a.id, a.name, a.cash, a.deposited
+                WHERE ale.agent_id IS NULL
+                GROUP BY a.id, a.name, a.cash, a.deposited, ale.reason
             )
             SELECT
                 ap.*,
@@ -198,6 +209,7 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
             {
                 'agent_id': row['agent_id'],
                 'name': row['name'],
+                'leaderboard_exclusion_reason': row['leaderboard_exclusion_reason'],
                 'deposited': row['deposited'],
                 'profit': clamp_profit_for_display(row['profit']),
                 'profit_percent': row['profit_percent'] or 0,
@@ -369,6 +381,12 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
             """
             SELECT id, name
             FROM agents
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM agent_leaderboard_exclusions ale
+                WHERE ale.agent_id = agents.id
+                  AND COALESCE(ale.active, 1) = 1
+            )
             """
         )
         agents = cursor.fetchall()

--- a/service/server/scripts/cleanup_dirty_trade_data.py
+++ b/service/server/scripts/cleanup_dirty_trade_data.py
@@ -47,6 +47,15 @@ from routes_shared import (
 INITIAL_CAPITAL = 100000.0
 EPSILON = 1e-9
 BACKUP_DIR = SERVER_DIR / "data" / "repair_backups"
+US_STOCK_PLACEHOLDER_SYMBOLS = {"PORTFOLIO", "STRATEGY"}
+
+
+def normalized_market(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def normalized_symbol(value: Any) -> str:
+    return str(value or "").strip().upper()
 
 
 @dataclass
@@ -101,19 +110,38 @@ def instrument_key(row: dict[str, Any]) -> tuple[str, str, str, str]:
 
 
 def suspicious_reasons(signal: dict[str, Any]) -> list[str]:
-    market = str(signal.get("market") or "").lower()
-    symbol = str(signal.get("symbol") or "").upper()
+    market = normalized_market(signal.get("market"))
+    symbol = normalized_symbol(signal.get("symbol"))
     entry_price = to_float(signal.get("entry_price"))
+    quantity = abs(to_float(signal.get("quantity")))
+    position_current_price = to_float(signal.get("position_current_price"), default=0.0)
 
     reasons: list[str] = []
     if market == "polymarket" and entry_price > 1.0 + EPSILON:
         reasons.append("polymarket_price_gt_1")
     if market == "crypto" and symbol in {"AAPL", "TSLA"}:
         reasons.append("stock_symbol_in_crypto_market")
-    if market == "crypto" and symbol == "BTC" and entry_price < 1000.0 - EPSILON:
+    if market == "crypto" and symbol in {"BTC", "BTCUSDT"} and entry_price < 1000.0 - EPSILON:
         reasons.append("btc_price_too_low")
-    if market == "crypto" and symbol == "ETH" and entry_price < 100.0 - EPSILON:
+    if market == "crypto" and symbol in {"ETH", "ETHUSDT"} and entry_price < 100.0 - EPSILON:
         reasons.append("eth_price_too_low")
+    if market == "crypto" and symbol in {"BNB", "BNBUSDT"} and entry_price < 10.0 - EPSILON:
+        reasons.append("bnb_price_too_low")
+    if market == "crypto" and symbol in {"SOL", "SOLUSDT"} and entry_price < 10.0 - EPSILON:
+        reasons.append("sol_price_too_low")
+    if market == "crypto" and symbol == "HYPE" and entry_price < 10.0 - EPSILON:
+        reasons.append("hype_price_too_low")
+    if market == "crypto" and symbol in {"PAXG", "PAXGUSD"} and entry_price < 1000.0 - EPSILON:
+        reasons.append("paxg_price_too_low")
+    if (
+        market == "us-stock"
+        and symbol not in US_STOCK_PLACEHOLDER_SYMBOLS
+        and entry_price > EPSILON
+        and position_current_price > EPSILON
+        and position_current_price / entry_price >= 20.0
+        and abs(position_current_price - entry_price) * quantity >= 5000.0
+    ):
+        reasons.append("us_stock_entry_price_outlier")
     return reasons
 
 
@@ -126,17 +154,46 @@ def load_suspicious_operation_signals(cursor: Any) -> list[dict[str, Any]]:
     rows = fetch_all(
         cursor,
         """
+        WITH position_price_refs AS (
+            SELECT
+                agent_id,
+                LOWER(market) AS market_key,
+                UPPER(symbol) AS symbol_key,
+                COALESCE(token_id, '') AS token_key,
+                MAX(current_price) AS current_price
+            FROM positions
+            WHERE current_price IS NOT NULL
+            GROUP BY agent_id, LOWER(market), UPPER(symbol), COALESCE(token_id, '')
+        )
         SELECT
             s.*,
-            a.name AS agent_name
+            a.name AS agent_name,
+            ppr.current_price AS position_current_price
         FROM signals s
         JOIN agents a ON a.id = s.agent_id
+        LEFT JOIN position_price_refs ppr
+          ON ppr.agent_id = s.agent_id
+         AND ppr.market_key = LOWER(s.market)
+         AND ppr.symbol_key = UPPER(s.symbol)
+         AND ppr.token_key = COALESCE(s.token_id, '')
         WHERE s.message_type = 'operation'
           AND (
-            (s.market = 'polymarket' AND s.entry_price > 1.0)
-            OR (s.market = 'crypto' AND s.symbol IN ('AAPL', 'TSLA'))
-            OR (s.market = 'crypto' AND s.symbol = 'BTC' AND s.entry_price < 1000.0)
-            OR (s.market = 'crypto' AND s.symbol = 'ETH' AND s.entry_price < 100.0)
+            (LOWER(s.market) = 'polymarket' AND s.entry_price > 1.0)
+            OR (LOWER(s.market) = 'crypto' AND UPPER(s.symbol) IN ('AAPL', 'TSLA'))
+            OR (LOWER(s.market) = 'crypto' AND UPPER(s.symbol) IN ('BTC', 'BTCUSDT') AND s.entry_price < 1000.0)
+            OR (LOWER(s.market) = 'crypto' AND UPPER(s.symbol) IN ('ETH', 'ETHUSDT') AND s.entry_price < 100.0)
+            OR (LOWER(s.market) = 'crypto' AND UPPER(s.symbol) IN ('BNB', 'BNBUSDT') AND s.entry_price < 10.0)
+            OR (LOWER(s.market) = 'crypto' AND UPPER(s.symbol) IN ('SOL', 'SOLUSDT') AND s.entry_price < 10.0)
+            OR (LOWER(s.market) = 'crypto' AND UPPER(s.symbol) = 'HYPE' AND s.entry_price < 10.0)
+            OR (LOWER(s.market) = 'crypto' AND UPPER(s.symbol) IN ('PAXG', 'PAXGUSD') AND s.entry_price < 1000.0)
+            OR (
+                LOWER(s.market) = 'us-stock'
+                AND UPPER(s.symbol) NOT IN ('PORTFOLIO', 'STRATEGY')
+                AND s.entry_price > 0
+                AND ppr.current_price IS NOT NULL
+                AND ppr.current_price / s.entry_price >= 20.0
+                AND ABS(ppr.current_price - s.entry_price) * COALESCE(s.quantity, 0) >= 5000.0
+            )
           )
         ORDER BY a.name, COALESCE(s.executed_at, s.created_at), s.id
         """,
@@ -144,6 +201,15 @@ def load_suspicious_operation_signals(cursor: Any) -> list[dict[str, Any]]:
     for row in rows:
         row["suspicious_reasons"] = suspicious_reasons(row)
     return rows
+
+
+def filter_suspicious_rows(
+    rows: list[dict[str, Any]],
+    target_agent_ids: set[int] | None,
+) -> list[dict[str, Any]]:
+    if not target_agent_ids:
+        return rows
+    return [row for row in rows if int(row["agent_id"]) in target_agent_ids]
 
 
 def load_agent_rows(cursor: Any, agent_ids: list[int]) -> list[dict[str, Any]]:
@@ -343,11 +409,11 @@ def invalidate_caches() -> None:
     delete(TRENDING_CACHE_KEY)
 
 
-def apply_cleanup() -> dict[str, Any]:
+def apply_cleanup(target_agent_ids: set[int] | None = None) -> dict[str, Any]:
     conn = get_db_connection()
     cursor = conn.cursor()
 
-    suspicious_rows = load_suspicious_operation_signals(cursor)
+    suspicious_rows = filter_suspicious_rows(load_suspicious_operation_signals(cursor), target_agent_ids)
     if not suspicious_rows:
         conn.close()
         return {
@@ -374,7 +440,7 @@ def apply_cleanup() -> dict[str, Any]:
         suspicious_ids_by_agent[int(row["agent_id"])].add(int(row["id"]))
 
     rebuilt_agents: list[dict[str, Any]] = []
-    deleted_signal_ids: set[int] = set(suspicious_ids)
+    deleted_row_ids: set[int] = set(suspicious_ids)
     skipped_rows_by_agent: dict[int, list[dict[str, Any]]] = {}
 
     for agent_id in sorted(agent_rows):
@@ -385,7 +451,7 @@ def apply_cleanup() -> dict[str, Any]:
             previous_positions.get(agent_id, {}),
         )
         skipped_rows_by_agent[agent_id] = skipped_rows
-        deleted_signal_ids.update(int(item["id"]) for item in skipped_rows)
+        deleted_row_ids.update(int(item["id"]) for item in skipped_rows)
         rebuilt_agents.append(
             {
                 "agent_id": agent_id,
@@ -400,15 +466,26 @@ def apply_cleanup() -> dict[str, Any]:
     affected_agent_ids = [int(row["id"]) for row in backup_payload["agents"]]
 
     try:
-        if deleted_signal_ids:
-            placeholders = ",".join("?" for _ in deleted_signal_ids)
+        if deleted_row_ids:
+            deleted_rows = [
+                row for row in backup_payload["signals"]
+                if int(row["id"]) in deleted_row_ids
+            ]
+            deleted_public_signal_ids = sorted({
+                int(row["signal_id"])
+                for row in deleted_rows
+                if row.get("signal_id") is not None
+            })
+            row_placeholders = ",".join("?" for _ in deleted_row_ids)
+            if deleted_public_signal_ids:
+                signal_placeholders = ",".join("?" for _ in deleted_public_signal_ids)
+                cursor.execute(
+                    f"DELETE FROM signal_replies WHERE signal_id IN ({signal_placeholders})",
+                    deleted_public_signal_ids,
+                )
             cursor.execute(
-                f"DELETE FROM signal_replies WHERE signal_id IN ({placeholders})",
-                list(deleted_signal_ids),
-            )
-            cursor.execute(
-                f"DELETE FROM signals WHERE id IN ({placeholders})",
-                list(deleted_signal_ids),
+                f"DELETE FROM signals WHERE id IN ({row_placeholders})",
+                list(deleted_row_ids),
             )
 
         placeholders = ",".join("?" for _ in affected_agent_ids)
@@ -456,16 +533,16 @@ def apply_cleanup() -> dict[str, Any]:
     return {
         "backup_path": str(backup_path),
         "affected_agents": rebuilt_agents,
-        "deleted_signal_ids": sorted(deleted_signal_ids),
+        "deleted_signal_ids": sorted(deleted_row_ids),
         "skipped_rows": skipped_rows_by_agent,
         "message": "Cleanup applied successfully.",
     }
 
 
-def dry_run() -> dict[str, Any]:
+def dry_run(target_agent_ids: set[int] | None = None) -> dict[str, Any]:
     conn = get_db_connection()
     cursor = conn.cursor()
-    suspicious_rows = load_suspicious_operation_signals(cursor)
+    suspicious_rows = filter_suspicious_rows(load_suspicious_operation_signals(cursor), target_agent_ids)
     conn.close()
 
     summary_by_agent: dict[str, dict[str, Any]] = defaultdict(lambda: {"count": 0, "reasons": defaultdict(int)})
@@ -493,17 +570,26 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Clean up known dirty trade data.")
     parser.add_argument("--apply", action="store_true", help="apply the cleanup")
     parser.add_argument("--dry-run", action="store_true", help="show what would be cleaned")
+    parser.add_argument(
+        "--agent-id",
+        action="append",
+        type=int,
+        default=[],
+        help="limit cleanup to one agent id; can be passed multiple times",
+    )
     args = parser.parse_args()
 
     if args.apply and args.dry_run:
         parser.error("choose either --apply or --dry-run, not both")
 
+    target_agent_ids = set(args.agent_id) if args.agent_id else None
+
     if not args.apply:
-        report = dry_run()
+        report = dry_run(target_agent_ids)
         print(json.dumps(report, indent=2, default=str))
         return 0
 
-    result = apply_cleanup()
+    result = apply_cleanup(target_agent_ids)
     print(json.dumps(result, indent=2, default=str))
     return 0
 

--- a/service/server/scripts/manage_leaderboard_exclusions.py
+++ b/service/server/scripts/manage_leaderboard_exclusions.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Audit and apply leaderboard exclusions for agents with non-comparable legacy books.
+
+The script does not delete trading data. It writes active rows to
+agent_leaderboard_exclusions so the public leaderboard can exclude accounts whose
+portfolio cannot be compared fairly under the current market/pricing rules.
+
+Usage:
+  cd /home/AI-Trader/service/server
+  python3 scripts/manage_leaderboard_exclusions.py --dry-run
+  python3 scripts/manage_leaderboard_exclusions.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from cache import delete, delete_pattern
+from database import get_db_connection
+from routes_shared import (
+    AGENT_SIGNALS_CACHE_KEY_PREFIX,
+    GROUPED_SIGNALS_CACHE_KEY_PREFIX,
+    LEADERBOARD_CACHE_KEY_PREFIX,
+    PRICE_CACHE_KEY_PREFIX,
+    SUPPORTED_MARKETS,
+    TRENDING_CACHE_KEY,
+    normalize_market,
+)
+
+
+BACKUP_DIR = SERVER_DIR / "data" / "repair_backups"
+DEFAULT_MAX_RETURN_PCT = 100.0
+
+
+def now_z() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def row_dict(row: Any) -> dict[str, Any]:
+    if isinstance(row, dict):
+        return dict(row)
+    return {key: row[key] for key in row.keys()}
+
+
+def to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if math.isfinite(parsed) else default
+
+
+def fetch_all(cursor: Any, query: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+    cursor.execute(query, params)
+    return [row_dict(row) for row in cursor.fetchall()]
+
+
+def ensure_exclusion_table(cursor: Any) -> None:
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS agent_leaderboard_exclusions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL UNIQUE,
+            reason TEXT NOT NULL,
+            details_json TEXT,
+            active INTEGER DEFAULT 1,
+            created_at TEXT DEFAULT (datetime('now')),
+            updated_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_agent_leaderboard_exclusions_active
+        ON agent_leaderboard_exclusions(active, agent_id)
+    """)
+
+
+def unsupported_position_market_rows(cursor: Any) -> list[dict[str, Any]]:
+    rows = fetch_all(
+        cursor,
+        """
+        SELECT agent_id, market, COUNT(*) AS position_count
+        FROM positions
+        GROUP BY agent_id, market
+        """,
+    )
+    invalid = []
+    for row in rows:
+        normalized = normalize_market(row["market"])
+        if normalized not in SUPPORTED_MARKETS:
+            invalid.append({
+                "agent_id": int(row["agent_id"]),
+                "market": row["market"],
+                "position_count": int(row["position_count"] or 0),
+            })
+    return invalid
+
+
+def unsupported_signal_market_rows(cursor: Any) -> list[dict[str, Any]]:
+    rows = fetch_all(
+        cursor,
+        """
+        SELECT agent_id, market, COUNT(*) AS signal_count
+        FROM signals
+        WHERE message_type = 'operation'
+        GROUP BY agent_id, market
+        """,
+    )
+    invalid = []
+    for row in rows:
+        normalized = normalize_market(row["market"])
+        if normalized not in SUPPORTED_MARKETS:
+            invalid.append({
+                "agent_id": int(row["agent_id"]),
+                "market": row["market"],
+                "signal_count": int(row["signal_count"] or 0),
+            })
+    return invalid
+
+
+def portfolio_rows(cursor: Any) -> list[dict[str, Any]]:
+    return fetch_all(
+        cursor,
+        """
+        SELECT
+            a.id AS agent_id,
+            a.name,
+            COALESCE(a.cash, 0) AS cash,
+            COALESCE(a.deposited, 0) AS deposited,
+            COALESCE(
+                SUM(
+                    CASE
+                        WHEN p.current_price IS NULL THEN p.entry_price * ABS(p.quantity)
+                        WHEN p.side = 'long' THEN p.current_price * ABS(p.quantity)
+                        ELSE (2 * p.entry_price - p.current_price) * ABS(p.quantity)
+                    END
+                ),
+                0
+            ) AS position_value,
+            COUNT(p.id) AS position_count
+        FROM agents a
+        LEFT JOIN positions p ON p.agent_id = a.id
+        GROUP BY a.id, a.name, a.cash, a.deposited
+        """,
+    )
+
+
+def build_exclusions(cursor: Any, max_return_pct: float) -> list[dict[str, Any]]:
+    reasons_by_agent: dict[int, dict[str, Any]] = {}
+    for row in unsupported_position_market_rows(cursor):
+        item = reasons_by_agent.setdefault(
+            row["agent_id"],
+            {
+                "agent_id": row["agent_id"],
+                "reasons": [],
+                "unsupported_markets": [],
+                "unsupported_signal_markets": [],
+            },
+        )
+        item["unsupported_markets"].append({
+            "market": row["market"],
+            "position_count": row["position_count"],
+        })
+        if "unsupported_market_positions" not in item["reasons"]:
+            item["reasons"].append("unsupported_market_positions")
+
+    for row in unsupported_signal_market_rows(cursor):
+        item = reasons_by_agent.setdefault(
+            row["agent_id"],
+            {
+                "agent_id": row["agent_id"],
+                "reasons": [],
+                "unsupported_markets": [],
+                "unsupported_signal_markets": [],
+            },
+        )
+        item["unsupported_signal_markets"].append({
+            "market": row["market"],
+            "signal_count": row["signal_count"],
+        })
+        if "unsupported_operation_signal_markets" not in item["reasons"]:
+            item["reasons"].append("unsupported_operation_signal_markets")
+
+    for row in portfolio_rows(cursor):
+        cash = to_float(row["cash"])
+        deposited = to_float(row["deposited"])
+        position_value = to_float(row["position_value"])
+        base = 100000.0 + deposited
+        if base <= 0:
+            continue
+        total_value = cash + position_value
+        profit = total_value - base
+        return_pct = profit / base * 100
+        if return_pct <= max_return_pct:
+            continue
+        item = reasons_by_agent.setdefault(
+            int(row["agent_id"]),
+            {
+                "agent_id": int(row["agent_id"]),
+                "reasons": [],
+                "unsupported_markets": [],
+                "unsupported_signal_markets": [],
+            },
+        )
+        if "return_above_threshold" not in item["reasons"]:
+            item["reasons"].append("return_above_threshold")
+        item.update({
+            "name": row["name"],
+            "cash": cash,
+            "deposited": deposited,
+            "position_value": position_value,
+            "position_count": int(row["position_count"] or 0),
+            "profit": profit,
+            "return_pct": return_pct,
+            "max_return_pct": max_return_pct,
+        })
+
+    exclusions = []
+    for item in reasons_by_agent.values():
+        reason = ",".join(sorted(item["reasons"]))
+        details = {key: value for key, value in item.items() if key not in {"reasons"}}
+        exclusions.append({
+            "agent_id": item["agent_id"],
+            "reason": reason,
+            "details": details,
+        })
+    return sorted(exclusions, key=lambda item: item["agent_id"])
+
+
+def backup_existing_exclusions(cursor: Any) -> list[dict[str, Any]]:
+    try:
+        return fetch_all(
+            cursor,
+            """
+            SELECT *
+            FROM agent_leaderboard_exclusions
+            ORDER BY agent_id, id
+            """,
+        )
+    except Exception:
+        return []
+
+
+def write_report(payload: dict[str, Any]) -> Path:
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    path = BACKUP_DIR / f"leaderboard_exclusion_report_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False, default=str), encoding="utf-8")
+    return path
+
+
+def invalidate_caches() -> None:
+    delete_pattern(f"{LEADERBOARD_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{GROUPED_SIGNALS_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{AGENT_SIGNALS_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{PRICE_CACHE_KEY_PREFIX}:*")
+    delete(TRENDING_CACHE_KEY)
+
+
+def apply_exclusions(cursor: Any, exclusions: list[dict[str, Any]]) -> None:
+    cursor.execute("UPDATE agent_leaderboard_exclusions SET active = 0, updated_at = ?", (now_z(),))
+    for item in exclusions:
+        details_json = json.dumps(item["details"], ensure_ascii=False, sort_keys=True, default=str)
+        cursor.execute(
+            """
+            INSERT INTO agent_leaderboard_exclusions
+                (agent_id, reason, details_json, active, created_at, updated_at)
+            VALUES (?, ?, ?, 1, ?, ?)
+            ON CONFLICT(agent_id) DO UPDATE SET
+                reason = excluded.reason,
+                details_json = excluded.details_json,
+                active = 1,
+                updated_at = excluded.updated_at
+            """,
+            (item["agent_id"], item["reason"], details_json, now_z(), now_z()),
+        )
+
+
+def run(*, apply: bool, max_return_pct: float) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        ensure_exclusion_table(cursor)
+        exclusions = build_exclusions(cursor, max_return_pct)
+        payload = {
+            "captured_at": now_z(),
+            "mode": "apply" if apply else "dry-run",
+            "max_return_pct": max_return_pct,
+            "exclusion_count": len(exclusions),
+            "previous_exclusions": backup_existing_exclusions(cursor),
+            "exclusions": exclusions,
+        }
+        report_path = write_report(payload)
+        payload["report_path"] = str(report_path)
+
+        if apply:
+            apply_exclusions(cursor, exclusions)
+            conn.commit()
+            invalidate_caches()
+        else:
+            conn.rollback()
+        return payload
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit/apply leaderboard exclusions.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true")
+    mode.add_argument("--apply", action="store_true")
+    parser.add_argument("--max-return-pct", type=float, default=DEFAULT_MAX_RETURN_PCT)
+    args = parser.parse_args()
+
+    result = run(apply=args.apply, max_return_pct=args.max_return_pct)
+    printable = dict(result)
+    printable["exclusions"] = result["exclusions"][:50]
+    printable["truncated"] = len(result["exclusions"]) > 50
+    print(json.dumps(printable, indent=2, ensure_ascii=False, default=str))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/service/server/scripts/repair_market_alias_positions.py
+++ b/service/server/scripts/repair_market_alias_positions.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""
+Repair positions and signals that used deprecated market aliases such as "binance".
+
+Usage:
+  cd /home/AI-Trader/service/server
+  python3 scripts/repair_market_alias_positions.py --dry-run
+  python3 scripts/repair_market_alias_positions.py --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from cache import delete, delete_pattern
+from database import get_db_connection
+from price_fetcher import get_price_from_market
+from routes_shared import (
+    AGENT_SIGNALS_CACHE_KEY_PREFIX,
+    GROUPED_SIGNALS_CACHE_KEY_PREFIX,
+    LEADERBOARD_CACHE_KEY_PREFIX,
+    PRICE_CACHE_KEY_PREFIX,
+    TRENDING_CACHE_KEY,
+    MARKET_ALIASES,
+    normalize_market,
+)
+
+
+BACKUP_DIR = SERVER_DIR / "data" / "repair_backups"
+REPAIRABLE_MARKETS = {alias for alias, normalized in MARKET_ALIASES.items() if normalized in {"crypto", "us-stock"}}
+
+
+@dataclass
+class RepairPlan:
+    old_market: str
+    new_market: str
+    position_count: int
+    signal_count: int
+    affected_agent_ids: list[int]
+    symbols: list[str]
+    price_updates: dict[str, float | None]
+
+
+def now_z() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def row_dict(row: Any) -> dict[str, Any]:
+    if isinstance(row, dict):
+        return dict(row)
+    return {key: row[key] for key in row.keys()}
+
+
+def fetch_all(cursor: Any, query: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+    cursor.execute(query, params)
+    return [row_dict(row) for row in cursor.fetchall()]
+
+
+def to_finite_price(value: Any) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed) or parsed <= 0:
+        return None
+    return parsed
+
+
+def load_alias_markets(cursor: Any) -> list[str]:
+    rows = fetch_all(
+        cursor,
+        """
+        SELECT market FROM positions
+        UNION
+        SELECT market FROM signals WHERE message_type = 'operation'
+        """,
+    )
+    markets = sorted({str(row["market"] or "").strip().lower() for row in rows})
+    return [market for market in markets if market in REPAIRABLE_MARKETS and normalize_market(market) != market]
+
+
+def normalize_crypto_symbol(symbol: Any) -> str:
+    normalized = str(symbol or "").strip().upper()
+    for suffix in ("-PERP", "PERP", "-USD", "/USD", "USD", "USDT"):
+        if normalized.endswith(suffix) and len(normalized) > len(suffix):
+            normalized = normalized[: -len(suffix)]
+            break
+    return {
+        "XBT": "BTC",
+        "XXBT": "BTC",
+        "XXBTZ": "BTC",
+        "XETH": "ETH",
+        "XETHZ": "ETH",
+    }.get(normalized.strip(), normalized.strip())
+
+
+def build_backup_payload(cursor: Any, markets: list[str]) -> dict[str, Any]:
+    if not markets:
+        return {"captured_at": now_z(), "markets": [], "positions": [], "signals": [], "profit_history": []}
+
+    placeholders = ",".join("?" for _ in markets)
+    positions = fetch_all(
+        cursor,
+        f"SELECT * FROM positions WHERE lower(market) IN ({placeholders}) ORDER BY agent_id, market, symbol, id",
+        tuple(markets),
+    )
+    signals = fetch_all(
+        cursor,
+        f"""
+        SELECT *
+        FROM signals
+        WHERE message_type = 'operation' AND lower(market) IN ({placeholders})
+        ORDER BY agent_id, COALESCE(executed_at, created_at), id
+        """,
+        tuple(markets),
+    )
+    agent_ids = sorted({int(row["agent_id"]) for row in positions + signals if row.get("agent_id") is not None})
+    profit_history: list[dict[str, Any]] = []
+    if agent_ids:
+        agent_placeholders = ",".join("?" for _ in agent_ids)
+        profit_history = fetch_all(
+            cursor,
+            f"""
+            SELECT *
+            FROM profit_history
+            WHERE agent_id IN ({agent_placeholders})
+            ORDER BY agent_id, recorded_at, id
+            """,
+            tuple(agent_ids),
+        )
+
+    return {
+        "captured_at": now_z(),
+        "markets": markets,
+        "affected_agent_ids": agent_ids,
+        "positions": positions,
+        "signals": signals,
+        "profit_history": profit_history,
+    }
+
+
+def write_backup(payload: dict[str, Any]) -> Path:
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    backup_path = BACKUP_DIR / f"market_alias_repair_backup_{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.json"
+    backup_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False, default=str), encoding="utf-8")
+    return backup_path
+
+
+def build_repair_plan(cursor: Any, markets: list[str], *, fetch_prices: bool = True) -> list[RepairPlan]:
+    plans: list[RepairPlan] = []
+    executed_at = now_z()
+    for old_market in markets:
+        new_market = normalize_market(old_market)
+        positions = fetch_all(
+            cursor,
+            """
+            SELECT id, agent_id, symbol
+            FROM positions
+            WHERE lower(market) = ?
+            ORDER BY agent_id, symbol, id
+            """,
+            (old_market,),
+        )
+        signals = fetch_all(
+            cursor,
+            """
+            SELECT id, agent_id, symbol
+            FROM signals
+            WHERE message_type = 'operation' AND lower(market) = ?
+            ORDER BY agent_id, symbol, id
+            """,
+            (old_market,),
+        )
+        if new_market == "crypto":
+            symbols = sorted({normalize_crypto_symbol(row["symbol"]) for row in positions if str(row["symbol"] or "").strip()})
+        else:
+            symbols = sorted({str(row["symbol"] or "").strip().upper() for row in positions if str(row["symbol"] or "").strip()})
+        price_updates: dict[str, float | None] = {}
+        for symbol in symbols:
+            price_updates[symbol] = None
+            if fetch_prices and new_market == "crypto":
+                price_updates[symbol] = to_finite_price(get_price_from_market(symbol, executed_at, new_market))
+
+        affected_agent_ids = sorted({int(row["agent_id"]) for row in positions + signals if row.get("agent_id") is not None})
+        plans.append(
+            RepairPlan(
+                old_market=old_market,
+                new_market=new_market,
+                position_count=len(positions),
+                signal_count=len(signals),
+                affected_agent_ids=affected_agent_ids,
+                symbols=symbols,
+                price_updates=price_updates,
+            )
+        )
+    return plans
+
+
+def invalidate_caches() -> None:
+    delete_pattern(f"{LEADERBOARD_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{GROUPED_SIGNALS_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{AGENT_SIGNALS_CACHE_KEY_PREFIX}:*")
+    delete_pattern(f"{PRICE_CACHE_KEY_PREFIX}:*")
+    delete(TRENDING_CACHE_KEY)
+
+
+def apply_plan(cursor: Any, plans: list[RepairPlan], affected_agent_ids: list[int]) -> dict[str, Any]:
+    for plan in plans:
+        if plan.new_market == "crypto":
+            position_rows = fetch_all(
+                cursor,
+                "SELECT id, symbol FROM positions WHERE lower(market) = ?",
+                (plan.old_market,),
+            )
+            for row in position_rows:
+                symbol = normalize_crypto_symbol(row["symbol"])
+                cursor.execute(
+                    "UPDATE positions SET market = ?, symbol = ?, current_price = ? WHERE id = ?",
+                    (plan.new_market, symbol, plan.price_updates.get(symbol), row["id"]),
+                )
+
+            signal_rows = fetch_all(
+                cursor,
+                """
+                SELECT id, symbol
+                FROM signals
+                WHERE message_type = 'operation' AND lower(market) = ?
+                """,
+                (plan.old_market,),
+            )
+            for row in signal_rows:
+                cursor.execute(
+                    "UPDATE signals SET market = ?, symbol = ? WHERE id = ?",
+                    (plan.new_market, normalize_crypto_symbol(row["symbol"]), row["id"]),
+                )
+        else:
+            cursor.execute(
+                "UPDATE positions SET market = ?, symbol = upper(symbol) WHERE lower(market) = ?",
+                (plan.new_market, plan.old_market),
+            )
+            cursor.execute(
+                """
+                UPDATE signals
+                SET market = ?, symbol = upper(symbol)
+                WHERE message_type = 'operation' AND lower(market) = ?
+                """,
+                (plan.new_market, plan.old_market),
+            )
+
+    if affected_agent_ids:
+        placeholders = ",".join("?" for _ in affected_agent_ids)
+        cursor.execute(f"DELETE FROM profit_history WHERE agent_id IN ({placeholders})", tuple(affected_agent_ids))
+
+    return {
+        "updated_markets": [asdict(plan) for plan in plans],
+        "deleted_profit_history_agent_ids": affected_agent_ids,
+    }
+
+
+def repair(*, apply: bool, fetch_prices: bool) -> dict[str, Any]:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        markets = load_alias_markets(cursor)
+        plans = build_repair_plan(cursor, markets, fetch_prices=fetch_prices)
+        affected_agent_ids = sorted({agent_id for plan in plans for agent_id in plan.affected_agent_ids})
+        backup_path = None
+
+        if apply and markets:
+            backup_payload = build_backup_payload(cursor, markets)
+            backup_path = write_backup(backup_payload)
+            result = apply_plan(cursor, plans, affected_agent_ids)
+            conn.commit()
+            invalidate_caches()
+        else:
+            result = {"updated_markets": [asdict(plan) for plan in plans], "deleted_profit_history_agent_ids": affected_agent_ids}
+
+        return {
+            "mode": "apply" if apply else "dry-run",
+            "backup_path": str(backup_path) if backup_path else None,
+            "alias_markets": markets,
+            **result,
+        }
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Repair deprecated market aliases in positions/signals.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Print planned changes without writing.")
+    mode.add_argument("--apply", action="store_true", help="Apply changes and write a backup first.")
+    parser.add_argument("--skip-price-fetch", action="store_true", help="Normalize markets without refreshing current prices.")
+    args = parser.parse_args()
+
+    result = repair(apply=args.apply, fetch_prices=not args.skip_price_fetch)
+    print(json.dumps(result, indent=2, ensure_ascii=False, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/service/server/tests/test_leaderboard_metrics.py
+++ b/service/server/tests/test_leaderboard_metrics.py
@@ -75,6 +75,33 @@ class LeaderboardMetricTests(unittest.TestCase):
         self.assertEqual(top_agents[0]["name"], "high-quality-low-return")
         self.assertEqual(top_agents[0]["quality_score_avg"], 5)
 
+    def test_active_leaderboard_exclusion_is_omitted_before_pagination(self):
+        excluded_agent = self._create_agent("excluded-high-return", 300000.0)
+        eligible_agent = self._create_agent("eligible-low-return", 100000.0)
+
+        now = utc_now_iso_z()
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO agent_leaderboard_exclusions
+                (agent_id, reason, details_json, active, created_at, updated_at)
+            VALUES (?, 'unit_test', '{}', 1, ?, ?)
+            """,
+            (excluded_agent, now, now),
+        )
+        conn.commit()
+        conn.close()
+
+        response = self.client.get("/api/profit/history?limit=10&offset=0&include_history=false")
+
+        self.assertEqual(response.status_code, 200, response.text)
+        payload = response.json()
+        agent_ids = [agent["agent_id"] for agent in payload["top_agents"]]
+        self.assertNotIn(excluded_agent, agent_ids)
+        self.assertIn(eligible_agent, agent_ids)
+        self.assertEqual(payload["total"], 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary\n- add an agent leaderboard exclusion table and omit active exclusions before leaderboard pagination\n- add tooling to audit/apply leaderboard exclusions for non-comparable portfolios\n- expand dirty trade cleanup detection and support agent-scoped cleanup\n- add a market alias repair script for legacy positions and operation signals\n\n## Verification\n- python3 -m pytest service/server/tests/test_leaderboard_metrics.py service/server/tests/test_price_fetcher.py service/server/tests/test_routes_shared.py\n- python3 -m py_compile service/server/scripts/cleanup_dirty_trade_data.py service/server/scripts/manage_leaderboard_exclusions.py service/server/scripts/repair_market_alias_positions.py