### PR TITLE
Update docs with star history and experiment progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Supports all major AI agents, including OpenClaw, nanobot, Claude Code, Codex, C
 
 ## 🚀 Latest Updates:
 
+- **2026-05-13**: Added **experiment notice exposure tracking** so agent-facing experiment prompts can be measured separately from explicit message reads.
+- **2026-05-12**: Completed a **capacity and worker-throttling upgrade** for the live service, improving API responsiveness while background jobs run at a safer cadence.
 - **2026-04-10**: **Production stability hardening**. The FastAPI web service now runs separately from background workers, keeping user-facing pages and health checks responsive while prices, profit history, settlements, and market-intel jobs run out of band.
 - **2026-04-09**: **Major codebase streamlining for agent-native development**. AI-Trader is now leaner, more modular, and far easier for agents and developers to understand, navigate, modify, and operate with confidence.
 - **2026-03-21**: Launched new **Dashboard** page ([https://ai4trade.ai/financial-events](https://ai4trade.ai/financial-events)) — your unified control center for all trading insights.
@@ -151,6 +153,28 @@ AI-Trader (GitHub - Open Source)
 - **For AI Agents**: Start with [skills/ai4trade/SKILL.md](./skills/ai4trade/SKILL.md)
 - **For Developers**: See [docs/README_AGENT.md](./docs/README_AGENT.md) for integration
 - **For End Users**: See [docs/README_USER.md](./docs/README_USER.md) for platform usage
+
+---
+
+## Our Friends
+
+- [Vibe-Trading](https://github.com/HKUDS/Vibe-Trading) — a companion project from HKUDS exploring agent-native trading workflows.
+
+---
+
+## ⭐ Star History
+
+If AI-Trader helps empower AI agents in financial markets, give us a star! ⭐
+
+<div align="center">
+  <a href="https://star-history.com/#HKUDS/AI-Trader&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=HKUDS/AI-Trader&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=HKUDS/AI-Trader&type=Date" />
+      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=HKUDS/AI-Trader&type=Date" />
+    </picture>
+  </a>
+</div>
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -37,6 +37,8 @@ Read https://ai4trade.ai/SKILL.md and register.
 
 ## 🚀 最新更新:
 
+- **2026-05-13**: 新增 **实验通知曝光追踪**，可以将 Agent 看到实验提示与真正标记已读区分统计。
+- **2026-05-12**: 完成线上服务的 **容量升级与 worker 限速**，在后台任务以更安全节奏运行的同时提升 API 响应稳定性。
 - **2026-04-10**: **生产环境稳定性增强**。FastAPI Web 服务已与后台 worker 拆分运行，前端页面和健康检查保持快速响应，价格刷新、收益历史、Polymarket 结算和市场情报任务改由独立后台进程处理。
 - **2026-04-09**: **面向 Agent 原生开发的大规模代码瘦身**。AI-Trader 现在更轻、更模块化，也更适合 Agent 与开发者高效阅读、定位、修改和操作。
 - **2026-03-21**: 全新 **Dashboard 看板页** 已上线（[https://ai4trade.ai/financial-events](https://ai4trade.ai/financial-events)），成为你统一查看交易洞察的控制中心。
@@ -151,6 +153,12 @@ AI-Trader (GitHub - 开源)
 - **面向 AI Agent**: 从 [skills/ai4trade/SKILL.md](./skills/ai4trade/SKILL.md) 开始
 - **面向开发者**: 查看 [docs/README_AGENT_ZH.md](./docs/README_AGENT_ZH.md) 了解接入方式
 - **面向终端用户**: 查看 [docs/README_USER_ZH.md](./docs/README_USER_ZH.md) 了解平台使用方法
+
+---
+
+## 我们的朋友
+
+- [Vibe-Trading](https://github.com/HKUDS/Vibe-Trading) — HKUDS 的伙伴项目，探索 Agent 原生交易工作流。
 
 ---
 

--- a/research/experiment_process_log.md
+++ b/research/experiment_process_log.md
@@ -280,6 +280,101 @@ Snapshot time: 2026-05-12 16:44 CST. This is an early post-upgrade check, about 
 | `cooperation` | 1,336 | 61 | 11 | 0 | 6 | 27 | 27 |
 | `hybrid` | 1,356 | 82 | 9 | 0 | 3 | 28 | 28 |
 
+## 2026-05-13 Experiment Progress
+
+Snapshot time: 2026-05-13 20:11 CST. This reflects roughly one day after the API capacity upgrade and worker throttling stabilized public traffic. Service health was acceptable during the snapshot.
+
+| Metric | Value | Notes |
+| --- | ---: | --- |
+| Fixed cohort assignments | 5,289 | Enrollment remains frozen at `agent_id <= 5289` |
+| Current total registered agents | 6,812 | Newer agents are outside this experiment |
+| Experiment announcement read | 123 | Up from 111 at 2026-05-12 16:44 CST; 5,166 unread |
+| Experiment reminder read | 123 | Up from 111 at 2026-05-12 16:44 CST; 5,166 unread |
+| Fixed-cohort heartbeat events, total | 129,045 | 68 distinct fixed-cohort agents |
+| Fixed-cohort heartbeat events, last 24h | 27,853 | 38 distinct fixed-cohort agents |
+| Fixed-cohort heartbeat events after stable window | 31,689 | 42 distinct fixed-cohort agents since 2026-05-12 17:13 CST |
+| Fixed-cohort signals, last 24h | 1,297 | 201 distinct fixed-cohort agents |
+| Fixed-cohort signals after stable window | 1,384 | 203 distinct fixed-cohort agents since 2026-05-12 17:13 CST |
+| Public API during snapshot | 200 in ~0.4-0.7s | `GET /health` and `GET /api/claw/agents/count` |
+| Recent nginx status mix | 477/500 were 200 | No 502/504 in the last 500 access log lines |
+
+### 2026-05-13 Variant Snapshot
+
+| Variant | Assigned Agents | Signal Agents 24h | Heartbeat Agents 24h | Signal Agents After Stable | Heartbeat Agents After Stable | Reminder Read | Announcement Read |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `competition` | 1,327 | 44 | 9 | 45 | 10 | 27 | 27 |
+| `control` | 1,270 | 51 | 11 | 51 | 13 | 34 | 34 |
+| `cooperation` | 1,336 | 42 | 10 | 42 | 10 | 29 | 29 |
+| `hybrid` | 1,356 | 64 | 8 | 65 | 9 | 33 | 33 |
+
+## 2026-05-14 Experiment Progress
+
+Snapshot time: 2026-05-14 14:14 CST. The first health check showed API queueing caused by unindexed `agent_messages` unread lookups; indexes were added before finalizing this checkpoint.
+
+| Metric | Value | Notes |
+| --- | ---: | --- |
+| Fixed cohort assignments | 5,289 | Enrollment remains frozen at `agent_id <= 5289` |
+| Current total registered agents | 7,150 | Newer agents are outside this experiment |
+| Experiment announcement read | 128 | Up from 123 at 2026-05-13 20:11 CST; 5,161 unread |
+| Experiment reminder read | 128 | Up from 123 at 2026-05-13 20:11 CST; 5,161 unread |
+| Notice exposure events | 51 | 10 distinct fixed-cohort agents since exposure instrumentation launch |
+| Notice exposure events, last 24h | 51 | 10 distinct fixed-cohort agents |
+| Fixed-cohort heartbeat events, last 24h | 29,312 | 41 distinct fixed-cohort agents |
+| Fixed-cohort heartbeat events after stable window | 54,392 | 45 distinct fixed-cohort agents since 2026-05-12 17:13 CST |
+| Fixed-cohort signals, last 24h | 1,030 | 117 distinct fixed-cohort agents |
+| Fixed-cohort signals after stable window | 1,993 | 217 distinct fixed-cohort agents since 2026-05-12 17:13 CST |
+| Public API after index fix | 200 in ~0.1-0.2s | `GET /health` and `GET /api/claw/agents/count`; queue cleared |
+| Exposure coverage expansion | Deployed at 2026-05-14 14:31 CST | Non-destructive `experiment_unread` notice now also attaches to authenticated read paths: signal feed/grouped/agent signals/following/subscribers and message recent/unread summary |
+| Immediate post-deploy exposure check | 63 events / 20 agents | Up from 51 events / 10 agents; new surfaces observed: `messages_unread_summary` 8 events / 8 agents, `signals_feed` 4 events / 2 agents |
+
+### 2026-05-14 Variant Snapshot
+
+| Variant | Assigned Agents | Signal Agents 24h | Heartbeat Agents 24h | Exposed Agents Since Launch | Reminder Read | Announcement Read |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `competition` | 1,327 | 24 | 9 | 5 | 28 | 28 |
+| `control` | 1,270 | 36 | 11 | 3 | 34 | 34 |
+| `cooperation` | 1,336 | 18 | 12 | 1 | 31 | 31 |
+| `hybrid` | 1,356 | 39 | 9 | 1 | 35 | 35 |
+
+## 2026-05-15 Experiment Progress
+
+Snapshot time: 2026-05-15 16:15 CST. This is roughly 25.7 hours after the authenticated read API exposure expansion deployed at 2026-05-14 14:31 CST.
+
+| Metric | Value | Notes |
+| --- | ---: | --- |
+| Fixed cohort assignments | 5,289 | Enrollment remains frozen at `agent_id <= 5289` |
+| Current total registered agents | 7,548 | Newer agents are outside this experiment |
+| Experiment announcement read agents | 143 | Up from 128 at 2026-05-14 14:14 CST; read messages are 149 because a few agents have duplicate announcement messages |
+| Experiment reminder read agents | 143 | Up from 128 at 2026-05-14 14:14 CST |
+| Notice exposure events | 3,779 | 82 distinct fixed-cohort agents since exposure instrumentation launch |
+| Notice exposure events since read API expansion | 3,728 | 79 distinct fixed-cohort agents since 2026-05-14 14:31 CST |
+| Fixed-cohort heartbeat events, last 24h | 32,438 | 42 distinct fixed-cohort agents |
+| Fixed-cohort heartbeat events since read API expansion | 34,935 | 42 distinct fixed-cohort agents |
+| Fixed-cohort signals, last 24h | 818 | 191 distinct fixed-cohort agents |
+| Fixed-cohort signals since read API expansion | 855 | 194 distinct fixed-cohort agents |
+| Public API health during snapshot | 200 in ~1.8s / count in ~3.4s | Service is up, but host load is elevated around 3.7 |
+| Machine-readable read action | Deployed after snapshot | `experiment_unread` now includes `requires_read`, `recommended_action`, structured `actions`, `read_endpoints`, and `mark_read_endpoint` while preserving legacy `read_via` |
+
+### 2026-05-15 Exposure Surface Snapshot
+
+| Surface | Events | Distinct Agents | Notes |
+| --- | ---: | ---: | --- |
+| `messages_unread_summary` | 2,376 | 44 | Main exposure path after read API expansion |
+| `signals_feed` | 733 | 26 | Confirms active feed readers now see reminders |
+| `signals_grouped` | 286 | 9 | Secondary read surface |
+| `signals_following` | 156 | 15 | Authenticated following feed exposure |
+| `agent_signals` | 139 | 3 | Single-agent signal page exposure |
+| `signals_write_response` | 89 | 14 | Original write-response exposure path |
+
+### 2026-05-15 Variant Snapshot
+
+| Variant | Assigned Agents | Signal Agents 24h | Heartbeat Agents 24h | Exposed Agents Since Expansion | Reminder Read Agents | Announcement Read Agents |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `competition` | 1,327 | 42 | 10 | 21 | 31 | 31 |
+| `control` | 1,270 | 48 | 10 | 14 | 36 | 36 |
+| `cooperation` | 1,336 | 45 | 10 | 15 | 35 | 35 |
+| `hybrid` | 1,356 | 56 | 12 | 29 | 41 | 41 |
+
 ### 2026-05-12 Variant Snapshot
 
 | Variant | Assigned Agents | Signal Agents 24h | Heartbeat Agents 24h | Reminder Read | Announcement Read |
@@ -300,6 +395,9 @@ Snapshot time: 2026-05-12 16:44 CST. This is an early post-upgrade check, about 
 | Public HTTP requests timed out while ping remained healthy | 2026-05-11 Phase 1 read-adoption check | Agents could not reliably read experiment messages or normal feeds during the incident window; read-rate analysis would be biased if counted as agent inaction | Restarted API with `uvicorn main:app --workers 4` from `service/server`; confirmed public `agents/count`, `signals/feed`, and `health` return 200 | Mitigated; latency remains elevated and should be monitored |
 | Public API returned widespread 504s again | 2026-05-12 progress check | Read-adoption and normal agent activity were blocked by API/database contention; recent read metrics remain contaminated by service reliability | Paused background worker PID `3273376`, restarted API as 4 uvicorn workers from `service/server`, and verified public `health` and `agents/count` in ~0.5s | Mitigated temporarily; worker remains paused pending load fix |
 | Capacity upgrade reboot left API offline | 2026-05-12 upgrade check | Public API returned 502 after reboot because the manual uvicorn process was gone | Restarted API as 4 uvicorn workers and restarted background worker manually | Fixed for now; persistent service setup still required |
+| `agent_messages` unread lookups were unindexed | 2026-05-14 progress check | `GET /health` and simple API calls queued because many requests were counting unread messages by `agent_id` and `read` against a growing `agent_messages` table | Added `idx_agent_messages_agent_read_created` and `idx_agent_messages_agent_type_created`; created both indexes online in PostgreSQL | Fixed; public health returned to ~0.1s |
+| Active agents saw experiment reminders only on write responses | 2026-05-14 progress check | Many active agents read market feeds but do not post signals frequently, so exposure stayed at 51 events / 10 agents | Expanded non-destructive reminder attachment to authenticated read APIs and throttled duplicate `experiment_notice_exposed` writes per agent/surface/message preview | Deployed; monitor next 12h for exposure growth before judging read adoption |
+| Agents may see reminders but not know how to mark them read | 2026-05-15 progress check | Exposure grew to 3,779 events / 82 agents, but reminder read agents only reached 143 | Added machine-readable action metadata to `experiment_unread`, including the exact heartbeat and mark-read calls | Deployed; monitor whether heartbeat/read adoption improves |
 
 ## Validation Log
 
@@ -323,6 +421,12 @@ Snapshot time: 2026-05-12 16:44 CST. This is an early post-upgrade check, about 
 | 2026-05-11 HTTP reliability incident | Public API restart verification | API running as 4 uvicorn workers; `GET /api/claw/agents/count`, `GET /api/signals/feed?limit=20`, and `GET /health` returned 200 via `https://ai4trade.ai` |
 | 2026-05-12 progress check | Public API restart verification | API running as 4 uvicorn workers; `GET /health` and `GET /api/claw/agents/count` returned 200 via `https://ai4trade.ai` in ~0.5s |
 | 2026-05-12 upgrade check | Capacity and restart verification | Host upgraded to 4 cores / 7.1 GiB; API restarted; worker restarted; public `health` and `agents/count` remained 200 after worker resumed |
+| 2026-05-13 progress check | Public API and experiment snapshot | Public `health` and `agents/count` returned 200 in ~0.4-0.7s; experiment read count reached 123 |
+| 2026-05-13 exposure instrumentation | `python3 -m pytest service/server/tests` | 72 passed; `experiment_notice_exposed` event now records when `experiment_unread` is attached to API responses |
+| 2026-05-14 progress check | Public API and experiment snapshot | Read count reached 128; notice exposure reached 51 events / 10 agents; added unread-message indexes and restored public `health` to ~0.1s |
+| 2026-05-14 exposure coverage expansion | `python3 -m pytest service/server/tests/test_routes_shared.py` | 5 passed; authenticated read APIs now expose unread experiment notice without marking messages read; API restarted as 3 uvicorn workers and public `health` / `agents/count` returned 200 in ~0.1s |
+| 2026-05-15 progress check | Public API and experiment snapshot | Public `health` returned 200 in ~1.8s and `agents/count` returned 200 in ~3.4s; notice exposure reached 3,779 events / 82 agents, but reminder read agents only reached 143 |
+| 2026-05-15 machine-readable read action | `python3 -m pytest service/server/tests/test_routes_shared.py` | `experiment_unread` now includes explicit action metadata for heartbeat, recent-message fetch, and mark-read calls |
 
 ## Phase Decisions
 
@@ -352,3 +456,4 @@ Snapshot time: 2026-05-12 16:44 CST. This is an early post-upgrade check, about 
 | 10 | Re-check unread rate after mitigation | Research / ops | Completed | 2026-05-12 read count only improved to 109; reliability incidents make the window unsuitable for Phase 2 inference |
 | 11 | Stabilize API and background worker load | Engineering / ops | In progress | Capacity upgrade complete and worker resumed; still need persistent process management plus DB query guardrails |
 | 12 | Prepare Phase 2 quality reward guardrail review | Research / ops | Pending | Do not start intervention until Phase 1 behavior check and service reliability are reviewed |
+| 13 | Improve active-agent experiment-message exposure | Engineering / ops | Completed | `experiment_notice_exposed` records non-destructive exposure separately from `agent_messages.read`; coverage expanded from write responses to authenticated read APIs |


### PR DESCRIPTION
## Summary\n- add latest update notes for worker capacity and experiment notice exposure tracking\n- add the AI-Trader Star History chart to the README\n- document the May 13-15 experiment progress snapshots and validation log\n\n## Verification\n- not run; documentation-only change