### PR TITLE
feat: add optional Adanos sentiment context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@ DB_PATH=service/server/data/clawtrader.db
 
 # ==================== API Keys ====================
 ALPHA_VANTAGE_API_KEY=demo
+# Optional: enrich US stock market-intel snapshots with Adanos social/news/prediction-market sentiment.
+ADANOS_API_KEY=
 
 # ==================== Frontend ====================
 # Frontend auto-refresh interval in milliseconds.
@@ -22,6 +24,7 @@ VITE_REFRESH_INTERVAL=300000
 CLAWTRADER_CORS_ORIGINS=http://localhost:3000,https://ai4trade.ai
 
 # ==================== Market Data Endpoints ====================
+ADANOS_API_BASE_URL=https://api.adanos.org
 ALPHA_VANTAGE_BASE_URL=https://www.alphavantage.co/query
 HYPERLIQUID_API_URL=https://api.hyperliquid.xyz/info
 POLYMARKET_GAMMA_BASE_URL=https://gamma-api.polymarket.com
@@ -35,6 +38,8 @@ MARKET_NEWS_REFRESH_INTERVAL=900
 MACRO_SIGNAL_REFRESH_INTERVAL=900
 ETF_FLOW_REFRESH_INTERVAL=900
 STOCK_ANALYSIS_REFRESH_INTERVAL=1800
+ADANOS_SENTIMENT_CACHE_TTL_SECONDS=300
+ADANOS_SENTIMENT_TIMEOUT_SECONDS=4
 
 # ==================== Profit History Retention ====================
 # Keep recent history at full resolution.

--- a/service/server/config.py
+++ b/service/server/config.py
@@ -25,8 +25,10 @@ REDIS_PREFIX = os.getenv("REDIS_PREFIX", "ai_trader").strip() or "ai_trader"
 
 # API Keys
 ALPHA_VANTAGE_API_KEY = os.getenv("ALPHA_VANTAGE_API_KEY", "demo")
+ADANOS_API_KEY = os.getenv("ADANOS_API_KEY", "").strip()
 
 # Market data endpoints
+ADANOS_API_BASE_URL = os.getenv("ADANOS_API_BASE_URL", "https://api.adanos.org").strip().rstrip("/")
 # Hyperliquid public info endpoint (used for crypto quotes; no API key required)
 HYPERLIQUID_API_URL = os.getenv("HYPERLIQUID_API_URL", "https://api.hyperliquid.xyz/info")
 

--- a/service/server/market_intel.py
+++ b/service/server/market_intel.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover - Python < 3.9 fallback
     ZoneInfo = None
 
 from cache import delete_pattern, get_json, set_json
-from config import ALPHA_VANTAGE_API_KEY
+from config import ADANOS_API_BASE_URL, ADANOS_API_KEY, ALPHA_VANTAGE_API_KEY
 from database import get_db_connection
 
 ALPHA_VANTAGE_BASE_URL = os.getenv("ALPHA_VANTAGE_BASE_URL", "https://www.alphavantage.co/query").strip()
@@ -53,6 +53,8 @@ STOCK_ANALYSIS_LATEST_CACHE_TTL_SECONDS = max(30, int(os.getenv("MARKET_INTEL_ST
 STOCK_ANALYSIS_FEATURED_CACHE_TTL_SECONDS = max(30, int(os.getenv("MARKET_INTEL_STOCK_FEATURED_CACHE_TTL", "300")))
 STOCK_QUOTE_CACHE_TTL_SECONDS = max(30, int(os.getenv("MARKET_INTEL_STOCK_QUOTE_CACHE_TTL", "300")))
 STOCK_QUOTE_FAILURE_CACHE_TTL_SECONDS = max(30, int(os.getenv("MARKET_INTEL_STOCK_QUOTE_FAILURE_CACHE_TTL", "60")))
+ADANOS_SENTIMENT_CACHE_TTL_SECONDS = max(30, int(os.getenv("ADANOS_SENTIMENT_CACHE_TTL_SECONDS", "300")))
+ADANOS_SENTIMENT_TIMEOUT_SECONDS = max(1, int(os.getenv("ADANOS_SENTIMENT_TIMEOUT_SECONDS", "4")))
 STOCK_QUOTE_STALE_AFTER_SECONDS = max(
     STOCK_QUOTE_CACHE_TTL_SECONDS,
     int(os.getenv("MARKET_INTEL_STOCK_QUOTE_STALE_AFTER_SECONDS", "900")),
@@ -71,6 +73,7 @@ FALLBACK_STOCK_ANALYSIS_SYMBOLS = [
     for symbol in os.getenv("MARKET_INTEL_STOCK_SYMBOLS", "NVDA,AAPL,MSFT,AMZN,TSLA,META").split(",")
     if symbol.strip()
 ]
+ADANOS_STOCK_SENTIMENT_PLATFORMS = ("reddit", "x", "news", "polymarket")
 
 NEWS_CATEGORY_DEFINITIONS: dict[str, dict[str, str]] = {
     "equities": {
@@ -367,6 +370,73 @@ def _decorate_stock_analysis_with_quote(base_payload: dict[str, Any]) -> dict[st
     payload["price_as_of"] = quote_payload.get("price_as_of")
     payload["price_source"] = quote_payload.get("price_source")
     payload.update(_build_stock_price_metadata(payload.get("price_as_of"), payload.get("price_source")))
+    return payload
+
+
+def _normalize_adanos_stock_sentiment(platform: str, payload: dict[str, Any]) -> Optional[dict[str, Any]]:
+    if not isinstance(payload, dict) or payload.get("found") is False:
+        return None
+    return {
+        "platform": platform,
+        "sentiment_score": payload.get("sentiment_score"),
+        "buzz_score": payload.get("buzz_score"),
+        "mentions": payload.get("mentions"),
+        "bullish_pct": payload.get("bullish_pct"),
+        "bearish_pct": payload.get("bearish_pct"),
+        "trend": payload.get("trend"),
+        "period_days": payload.get("period_days"),
+    }
+
+
+def _fetch_adanos_stock_sentiment(symbol: str, platform: str) -> Optional[dict[str, Any]]:
+    response = requests.get(
+        f"{ADANOS_API_BASE_URL}/{platform}/stocks/v1/stock/{symbol}",
+        headers={"X-API-Key": ADANOS_API_KEY},
+        timeout=ADANOS_SENTIMENT_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return _normalize_adanos_stock_sentiment(platform, payload)
+
+
+def _get_adanos_stock_sentiment_payload(symbol: str) -> dict[str, Any]:
+    symbol = symbol.strip().upper()
+    if not ADANOS_API_KEY:
+        return {"available": False, "reason": "ADANOS_API_KEY is not configured"}
+
+    cache_key = _cache_key("adanos", "stock_sentiment_v1", symbol)
+    cached = get_json(cache_key)
+    if isinstance(cached, dict):
+        return cached
+
+    sources: list[dict[str, Any]] = []
+    errors: dict[str, str] = {}
+    for platform in ADANOS_STOCK_SENTIMENT_PLATFORMS:
+        try:
+            normalized = _fetch_adanos_stock_sentiment(symbol, platform)
+            if normalized:
+                sources.append(normalized)
+        except Exception as exc:
+            errors[platform] = str(exc)
+
+    payload = {
+        "available": bool(sources),
+        "source": "Adanos Market Sentiment API",
+        "docs_url": "https://api.adanos.org/docs",
+        "sources": sources,
+    }
+    if errors and not sources:
+        payload["errors"] = errors
+
+    set_json(cache_key, payload, ttl_seconds=ADANOS_SENTIMENT_CACHE_TTL_SECONDS)
+    return payload
+
+
+def _decorate_stock_analysis_with_adanos_sentiment(base_payload: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(base_payload)
+    if not payload.get("available"):
+        return payload
+    payload["adanos_sentiment"] = _get_adanos_stock_sentiment_payload(payload["symbol"])
     return payload
 
 
@@ -1629,12 +1699,14 @@ def _get_stock_analysis_snapshot_payload(symbol: str) -> dict[str, Any]:
 
 def get_stock_analysis_latest_payload(symbol: str) -> dict[str, Any]:
     symbol = symbol.strip().upper()
-    cache_key = _cache_key("stocks", "latest_v2", symbol)
+    cache_key = _cache_key("stocks", "latest_v3", symbol)
     cached = get_json(cache_key)
     if isinstance(cached, dict):
         return cached
 
-    payload = _decorate_stock_analysis_with_quote(_get_stock_analysis_snapshot_payload(symbol))
+    payload = _decorate_stock_analysis_with_adanos_sentiment(
+        _decorate_stock_analysis_with_quote(_get_stock_analysis_snapshot_payload(symbol))
+    )
     set_json(cache_key, payload, ttl_seconds=STOCK_ANALYSIS_LATEST_CACHE_TTL_SECONDS)
     return payload
 

--- a/service/server/tests/test_env_example.py
+++ b/service/server/tests/test_env_example.py
@@ -21,5 +21,6 @@ class EnvExampleTests(unittest.TestCase):
         self.assertEqual(values["ENVIRONMENT"], "development")
         self.assertEqual(values["DATABASE_URL"], "")
         self.assertEqual(values["DB_PATH"], "service/server/data/clawtrader.db")
+        self.assertEqual(values["ADANOS_API_BASE_URL"], "https://api.adanos.org")
         self.assertEqual(values["ALPHA_VANTAGE_BASE_URL"], "https://www.alphavantage.co/query")
         self.assertNotIn("ai_trader:change-me", values.values())

--- a/service/server/tests/test_market_intel.py
+++ b/service/server/tests/test_market_intel.py
@@ -42,16 +42,72 @@ def _snapshot_payload(symbol: str = "HD") -> dict:
 class MarketIntelLatestPayloadTests(unittest.TestCase):
     @patch("market_intel.set_json")
     @patch("market_intel.get_json", return_value=None)
+    @patch("market_intel.ADANOS_API_KEY", "")
+    def test_adanos_sentiment_is_disabled_without_api_key(self, _mock_get_json, _mock_set_json) -> None:
+        payload = market_intel._get_adanos_stock_sentiment_payload("AAPL")
+
+        self.assertFalse(payload["available"])
+        self.assertEqual(payload["reason"], "ADANOS_API_KEY is not configured")
+
+    @patch("market_intel.set_json")
+    @patch("market_intel.get_json", return_value=None)
+    @patch("market_intel.ADANOS_API_KEY", "sk_live_test")
+    @patch("market_intel.requests.get")
+    def test_adanos_sentiment_payload_collects_available_sources(
+        self,
+        mock_get,
+        _mock_get_json,
+        _mock_set_json,
+    ) -> None:
+        class Response:
+            def __init__(self, payload: dict) -> None:
+                self._payload = payload
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict:
+                return self._payload
+
+        mock_get.side_effect = [
+            Response({
+                "found": True,
+                "sentiment_score": 0.22,
+                "buzz_score": 72.4,
+                "mentions": 120,
+                "bullish_pct": 48,
+                "bearish_pct": 19,
+                "trend": "rising",
+                "period_days": 7,
+            }),
+            Response({"found": False}),
+            Response({"found": False}),
+            Response({"found": False}),
+        ]
+
+        payload = market_intel._get_adanos_stock_sentiment_payload("TSLA")
+
+        self.assertTrue(payload["available"])
+        self.assertEqual(payload["source"], "Adanos Market Sentiment API")
+        self.assertEqual(payload["sources"][0]["platform"], "reddit")
+        self.assertEqual(payload["sources"][0]["sentiment_score"], 0.22)
+        self.assertEqual(mock_get.call_count, 4)
+
+    @patch("market_intel.set_json")
+    @patch("market_intel.get_json", return_value=None)
     @patch("market_intel._get_stock_quote_payload")
+    @patch("market_intel._get_adanos_stock_sentiment_payload")
     @patch("market_intel._get_stock_analysis_snapshot_payload")
     def test_latest_payload_prefers_intraday_quote(
         self,
         mock_snapshot_payload,
+        mock_adanos_payload,
         mock_quote_payload,
         _mock_get_json,
         _mock_set_json,
     ) -> None:
         mock_snapshot_payload.return_value = _snapshot_payload("HD")
+        mock_adanos_payload.return_value = {"available": False, "reason": "ADANOS_API_KEY is not configured"}
         mock_quote_payload.return_value = {
             "available": True,
             "current_price": 352.11,
@@ -68,19 +124,23 @@ class MarketIntelLatestPayloadTests(unittest.TestCase):
         self.assertFalse(payload["price_stale"])
         self.assertEqual(payload["price_status"], "realtime")
         self.assertEqual(payload["analysis"]["as_of"], "2026-04-17")
+        self.assertFalse(payload["adanos_sentiment"]["available"])
 
     @patch("market_intel.set_json")
     @patch("market_intel.get_json", return_value=None)
     @patch("market_intel._get_stock_quote_payload", return_value=None)
+    @patch("market_intel._get_adanos_stock_sentiment_payload")
     @patch("market_intel._get_stock_analysis_snapshot_payload")
     def test_latest_payload_falls_back_to_daily_snapshot_when_quote_missing(
         self,
         mock_snapshot_payload,
+        mock_adanos_payload,
         _mock_quote_payload,
         _mock_get_json,
         _mock_set_json,
     ) -> None:
         mock_snapshot_payload.return_value = _snapshot_payload("AAPL")
+        mock_adanos_payload.return_value = {"available": False, "reason": "ADANOS_API_KEY is not configured"}
 
         with patch("market_intel._utc_now", return_value=datetime(2026, 4, 20, 14, 40, tzinfo=timezone.utc)):
             payload = market_intel.get_stock_analysis_latest_payload("AAPL")

--- a/skills/market-intel/SKILL.md
+++ b/skills/market-intel/SKILL.md
@@ -74,6 +74,9 @@ Use when you want a small set of server-generated stock analysis snapshots for t
 `GET /api/market-intel/stocks/{symbol}/latest`
 
 Use when you need the latest read-only analysis snapshot for one stock.
+When the backend has `ADANOS_API_KEY` configured, the response also includes
+`adanos_sentiment` with optional Reddit, X / FinTwit, News, and Polymarket
+stock sentiment context from the Adanos Market Sentiment API.
 
 ### Stock Analysis History
 
@@ -165,6 +168,8 @@ if overview.get("available"):
 ## Decision Rules
 
 - Use this skill when you need market context
+- Treat `adanos_sentiment` as optional alternative-data context, never as the
+  sole reason to trade
 - Use `tradesync` when you need to publish signals
 - Use `copytrade` when you need follow/unfollow behavior
 - Use `heartbeat` when you need messages or tasks


### PR DESCRIPTION
## Summary
- add optional Adanos Market Sentiment API enrichment for US stock market-intel latest snapshots
- expose per-source Reddit, X / FinTwit, News, and Polymarket sentiment context under `adanos_sentiment`
- document the optional environment variables and agent-facing market-intel behavior

## Verification
- `. .venv/bin/activate && python -m pytest service/server/tests -q` -> 91 passed
- `. .venv/bin/activate && python -m py_compile service/server/market_intel.py service/server/config.py service/server/tests/test_market_intel.py service/server/tests/test_env_example.py`
- `git diff --check`

Notes: `service/requirements.txt` currently pins `openrouter>=1.0.0`, which is not resolvable from PyPI in this environment. I installed the remaining test dependencies locally in a venv to run the server test suite.