### PR TITLE
Add optional agent email field

### DIFF
--- a/service/frontend/src/appShared.tsx
+++ b/service/frontend/src/appShared.tsx
@@ -19,6 +19,7 @@ export type AgentPermissions = {
 export type AgentInfo = {
   id: number
   name: string
+  email?: string | null
   token?: string
   role?: string
   permissions?: AgentPermissions

--- a/service/server/database.py
+++ b/service/server/database.py
@@ -373,6 +373,7 @@ def init_database():
         CREATE TABLE IF NOT EXISTS agents (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT UNIQUE NOT NULL,
+            email TEXT,
             token TEXT,
             token_expires_at TEXT,
             password_hash TEXT,
@@ -1119,6 +1120,12 @@ def init_database():
     # Add role column if it doesn't exist (for existing databases)
     try:
         cursor.execute("ALTER TABLE agents ADD COLUMN role TEXT DEFAULT 'agent'")
+    except Exception:
+        pass
+
+    # Add email column if it doesn't exist (for existing databases)
+    try:
+        cursor.execute("ALTER TABLE agents ADD COLUMN email TEXT")
     except Exception:
         pass
 

--- a/service/server/routes_agent.py
+++ b/service/server/routes_agent.py
@@ -564,13 +564,14 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
 
             password_hash = hash_password(data.password)
             wallet = validate_address(data.wallet_address) if data.wallet_address else ''
+            email = str(data.email).strip().lower() if data.email else None
 
             cursor.execute(
                 """
-                INSERT INTO agents (name, password_hash, wallet_address, cash)
-                VALUES (?, ?, ?, ?)
+                INSERT INTO agents (name, email, password_hash, wallet_address, cash)
+                VALUES (?, ?, ?, ?, ?)
                 """,
-                (agent_name, password_hash, wallet, data.initial_balance),
+                (agent_name, email, password_hash, wallet, data.initial_balance),
             )
 
             agent_id = cursor.lastrowid
@@ -627,6 +628,7 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
                 'token': token,
                 'agent_id': agent_id,
                 'name': agent_name,
+                'email': email,
                 'initial_balance': data.initial_balance,
                 'experiment_assignments': experiment_assignments,
             }
@@ -792,6 +794,7 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
         payload = {
             'id': agent['id'],
             'name': agent['name'],
+            'email': agent.get('email'),
             'token': token,
             'role': agent_role(agent),
             'permissions': agent_permissions(agent),

--- a/service/server/routes_models.py
+++ b/service/server/routes_models.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 
 
 class AgentLogin(BaseModel):
@@ -10,10 +10,19 @@ class AgentLogin(BaseModel):
 
 class AgentRegister(BaseModel):
     name: str
+    email: Optional[EmailStr] = None
     password: str
     wallet_address: Optional[str] = None
     initial_balance: float = 100000.0
     positions: Optional[List[dict]] = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def normalize_email(cls, value):
+        if value is None:
+            return None
+        normalized = str(value).strip().lower()
+        return normalized or None
 
 
 class AgentTokenRecoveryRequest(BaseModel):

--- a/service/server/tests/test_agent_login_token_stability.py
+++ b/service/server/tests/test_agent_login_token_stability.py
@@ -54,6 +54,33 @@ class AgentLoginTokenStabilityTests(unittest.TestCase):
             headers={"Authorization": f"Bearer {original_token}"},
         )
         self.assertEqual(me.status_code, 200, me.text)
+        self.assertIsNone(me.json()["email"])
+
+    def test_agent_registration_stores_normalized_email(self) -> None:
+        register = self.client.post(
+            "/api/claw/agents/selfRegister",
+            json={
+                "name": "email-agent",
+                "email": "  Trader@Example.COM  ",
+                "password": "password123",
+            },
+        )
+        self.assertEqual(register.status_code, 200, register.text)
+        self.assertEqual(register.json()["email"], "trader@example.com")
+        token = register.json()["token"]
+
+        me = self.client.get(
+            "/api/claw/agents/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        self.assertEqual(me.status_code, 200, me.text)
+        self.assertEqual(me.json()["email"], "trader@example.com")
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT email FROM agents WHERE name = ?", ("email-agent",))
+        self.assertEqual(cursor.fetchone()["email"], "trader@example.com")
+        conn.close()
 
     def test_agent_login_issues_token_only_for_legacy_empty_token(self) -> None:
         conn = database.get_db_connection()


### PR DESCRIPTION
## Summary
- Add nullable `email` column to `agents` with migration support for existing databases
- Store normalized email during agent self-registration
- Return agent email from `/api/claw/agents/me`
- Add regression coverage for email storage and legacy registrations without email

## Verification
- `python3 -m pytest service/server/tests/test_agent_login_token_stability.py service/server/tests/test_agent_registration_experiments.py`
- `npm run build`