### PR TITLE
Guard challenge trade prices

### DIFF
--- a/service/server/challenges.py
+++ b/service/server/challenges.py
@@ -27,6 +27,7 @@ class ChallengeNotFound(ChallengeError):
 DEFAULT_CHALLENGE_REWARDS = {'1': 100, '2': 50, '3': 25}
 SUPPORTED_SCORING_METHODS = {'return-only', 'risk-adjusted'}
 SUPPORTED_CHALLENGE_TRACKS = {'crypto', 'us-stock', 'polymarket'}
+AUTHORITATIVE_CHALLENGE_PRICE_MARKETS = {'crypto', 'us-stock'}
 
 
 def _row_dict(row: Any) -> dict[str, Any]:
@@ -124,6 +125,31 @@ def _fetch_live_mark_prices(scored_results: list[dict[str, Any]], mark_timestamp
             if math.isfinite(parsed) and parsed > 0:
                 mark_prices[(market, symbol)] = parsed
     return mark_prices
+
+
+def _fetch_authoritative_challenge_trade_price(market: str, symbol: str, executed_at: str) -> Optional[float]:
+    if market not in AUTHORITATIVE_CHALLENGE_PRICE_MARKETS:
+        return None
+
+    try:
+        import price_fetcher
+        from price_fetcher import price_fetch_logging
+    except Exception as exc:
+        raise ChallengeError('Server price fetcher is unavailable') from exc
+
+    with price_fetch_logging(False):
+        try:
+            price = price_fetcher.get_price_from_market(symbol, executed_at, market)
+        except Exception as exc:
+            raise ChallengeError(f'Unable to fetch server price for {symbol}') from exc
+
+    try:
+        parsed = float(price) if price is not None else 0.0
+    except Exception:
+        parsed = 0.0
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise ChallengeError(f'Unable to fetch server price for {symbol}')
+    return parsed
 
 
 def _score_challenge_results_with_live_marks(
@@ -743,6 +769,10 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
             raise ChallengeError('Challenge participant is not tradeable')
 
         symbol = _normalize_challenge_trade_symbol(challenge, payload.get('symbol'))
+        requested_price = price
+        server_price = _fetch_authoritative_challenge_trade_price(challenge['market'], symbol, executed_at)
+        if server_price is not None:
+            price = server_price
         cursor.execute(
             """
             SELECT *
@@ -813,6 +843,7 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
                 'symbol': symbol,
                 'side': side,
                 'price': price,
+                'requested_price': requested_price,
                 'quantity': quantity,
             },
             cursor=cursor,

--- a/service/server/routes_agent.py
+++ b/service/server/routes_agent.py
@@ -1,4 +1,5 @@
 import json
+import math
 import secrets
 from datetime import datetime, timedelta, timezone
 
@@ -32,6 +33,7 @@ from routes_shared import (
     invalidate_agent_message_caches,
     push_agent_message,
     set_short_cached_payload,
+    should_fetch_server_trade_price,
     utc_now_iso_z,
     validate_market,
 )
@@ -53,6 +55,8 @@ from utils import (
     verify_password,
 )
 
+
+INITIAL_CAPITAL = 100000.0
 
 DISCUSSION_NOTIFICATION_TYPES = (
     'discussion_started',
@@ -567,21 +571,24 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
             password_hash = hash_password(data.password)
             wallet = validate_address(data.wallet_address) if data.wallet_address else ''
             email = str(data.email).strip().lower() if data.email else None
+            try:
+                initial_cash = float(data.initial_balance)
+            except Exception:
+                raise HTTPException(status_code=400, detail='Invalid initial balance')
 
-            cursor.execute(
-                """
-                INSERT INTO agents (name, email, password_hash, wallet_address, cash)
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                (agent_name, email, password_hash, wallet, data.initial_balance),
-            )
-
-            agent_id = cursor.lastrowid
-            token = secrets.token_urlsafe(32)
-            cursor.execute('UPDATE agents SET token = ? WHERE id = ?', (token, agent_id))
+            if not math.isfinite(initial_cash) or initial_cash < 0:
+                raise HTTPException(status_code=400, detail='Invalid initial balance')
 
             now = utc_now_iso_z()
+            initial_positions: list[dict] = []
+            initial_position_value = 0.0
             if data.positions:
+                get_price_from_market = None
+                if any(should_fetch_server_trade_price(pos.get('market', 'us-stock')) for pos in data.positions):
+                    from price_fetcher import get_price_from_market as _get_price_from_market
+
+                    get_price_from_market = _get_price_from_market
+
                 for pos in data.positions:
                     market = validate_market(pos.get('market', 'us-stock'))
                     symbol = str(pos.get('symbol') or '').strip()
@@ -589,18 +596,86 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
                         raise HTTPException(status_code=400, detail='Position symbol is required')
                     if market != 'polymarket':
                         symbol = symbol.upper()
+
+                    side = str(pos.get('side') or 'long').strip().lower()
+                    if side not in {'long', 'short'}:
+                        raise HTTPException(status_code=400, detail='Position side must be long or short')
+
+                    try:
+                        quantity = float(pos.get('quantity', 0))
+                    except Exception:
+                        raise HTTPException(status_code=400, detail='Invalid position quantity')
+                    if not math.isfinite(quantity) or quantity <= 0:
+                        raise HTTPException(status_code=400, detail='Invalid position quantity')
+
+                    token_id = str(pos.get('token_id') or '').strip() or None
+                    outcome = str(pos.get('outcome') or '').strip() or None
+
+                    if should_fetch_server_trade_price(market):
+                        server_price = get_price_from_market(
+                            symbol,
+                            now,
+                            market,
+                            token_id=token_id,
+                            outcome=outcome,
+                        ) if get_price_from_market else None
+                        if not server_price:
+                            raise HTTPException(status_code=400, detail=f'Unable to fetch current price for {symbol}')
+                        entry_price = float(server_price)
+                    else:
+                        try:
+                            entry_price = float(pos.get('entry_price', 0))
+                        except Exception:
+                            raise HTTPException(status_code=400, detail='Invalid position entry price')
+
+                    if not math.isfinite(entry_price) or entry_price <= 0:
+                        raise HTTPException(status_code=400, detail='Invalid position entry price')
+
+                    initial_position_value += entry_price * abs(quantity)
+                    initial_positions.append({
+                        'market': market,
+                        'symbol': symbol,
+                        'token_id': token_id,
+                        'outcome': outcome,
+                        'side': side,
+                        'quantity': quantity,
+                        'entry_price': entry_price,
+                    })
+
+            deposited = max(0.0, initial_cash + initial_position_value - INITIAL_CAPITAL)
+
+            cursor.execute(
+                """
+                INSERT INTO agents (name, email, password_hash, wallet_address, cash, deposited)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (agent_name, email, password_hash, wallet, initial_cash, deposited),
+            )
+
+            agent_id = cursor.lastrowid
+            token = secrets.token_urlsafe(32)
+            cursor.execute('UPDATE agents SET token = ? WHERE id = ?', (token, agent_id))
+
+            if initial_positions:
+                for pos in initial_positions:
                     cursor.execute(
                         """
-                        INSERT INTO positions (agent_id, symbol, market, side, quantity, entry_price, opened_at)
-                        VALUES (?, ?, ?, ?, ?, ?, ?)
+                        INSERT INTO positions (
+                            agent_id, symbol, market, token_id, outcome,
+                            side, quantity, entry_price, current_price, opened_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             agent_id,
-                            symbol,
-                            market,
-                            pos.get('side', 'long'),
-                            pos.get('quantity', 0),
-                            pos.get('entry_price', 0),
+                            pos['symbol'],
+                            pos['market'],
+                            pos['token_id'],
+                            pos['outcome'],
+                            pos['side'],
+                            pos['quantity'],
+                            pos['entry_price'],
+                            pos['entry_price'],
                             now,
                         ),
                     )
@@ -609,7 +684,12 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
                 actor_agent_id=agent_id,
                 object_type='agent',
                 object_id=agent_id,
-                metadata={'name': agent_name, 'initial_balance': data.initial_balance, 'position_count': len(data.positions or [])},
+                metadata={
+                    'name': agent_name,
+                    'initial_balance': initial_cash,
+                    'deposited': deposited,
+                    'position_count': len(initial_positions),
+                },
                 cursor=cursor,
             )
 
@@ -633,7 +713,8 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
                 'email': email,
                 'identity_status': 'normal',
                 'is_verified': False,
-                'initial_balance': data.initial_balance,
+                'initial_balance': initial_cash,
+                'deposited': deposited,
                 'experiment_assignments': experiment_assignments,
             }
         except HTTPException:

--- a/service/server/scripts/cleanup_dirty_trade_data.py
+++ b/service/server/scripts/cleanup_dirty_trade_data.py
@@ -48,6 +48,8 @@ INITIAL_CAPITAL = 100000.0
 EPSILON = 1e-9
 BACKUP_DIR = SERVER_DIR / "data" / "repair_backups"
 US_STOCK_PLACEHOLDER_SYMBOLS = {"PORTFOLIO", "STRATEGY"}
+US_STOCK_OUTLIER_RATIO = 2.0
+US_STOCK_OUTLIER_MIN_IMPACT = 5000.0
 
 
 def normalized_market(value: Any) -> str:
@@ -138,8 +140,8 @@ def suspicious_reasons(signal: dict[str, Any]) -> list[str]:
         and symbol not in US_STOCK_PLACEHOLDER_SYMBOLS
         and entry_price > EPSILON
         and position_current_price > EPSILON
-        and position_current_price / entry_price >= 20.0
-        and abs(position_current_price - entry_price) * quantity >= 5000.0
+        and position_current_price / entry_price >= US_STOCK_OUTLIER_RATIO
+        and abs(position_current_price - entry_price) * quantity >= US_STOCK_OUTLIER_MIN_IMPACT
     ):
         reasons.append("us_stock_entry_price_outlier")
     return reasons
@@ -191,12 +193,13 @@ def load_suspicious_operation_signals(cursor: Any) -> list[dict[str, Any]]:
                 AND UPPER(s.symbol) NOT IN ('PORTFOLIO', 'STRATEGY')
                 AND s.entry_price > 0
                 AND ppr.current_price IS NOT NULL
-                AND ppr.current_price / s.entry_price >= 20.0
-                AND ABS(ppr.current_price - s.entry_price) * COALESCE(s.quantity, 0) >= 5000.0
+                AND ppr.current_price / s.entry_price >= ?
+                AND ABS(ppr.current_price - s.entry_price) * COALESCE(s.quantity, 0) >= ?
             )
           )
         ORDER BY a.name, COALESCE(s.executed_at, s.created_at), s.id
         """,
+        (US_STOCK_OUTLIER_RATIO, US_STOCK_OUTLIER_MIN_IMPACT),
     )
     for row in rows:
         row["suspicious_reasons"] = suspicious_reasons(row)

--- a/service/server/scripts/repair_challenge_trade_prices.py
+++ b/service/server/scripts/repair_challenge_trade_prices.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Repair challenge trade snapshots that used client-supplied prices.
+
+The repair is intentionally conservative:
+- supported by default for crypto/us-stock challenge trades;
+- if quantity is close to the authoritative quote and price is not, treat the
+  row as a price/quantity swap;
+- otherwise correct price to the authoritative quote and keep quantity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+PROJECT_ROOT = SERVER_DIR.parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from database import begin_write_transaction, get_db_connection  # noqa: E402
+from price_fetcher import get_price_from_market, price_fetch_logging  # noqa: E402
+
+
+BACKUP_DIR = SERVER_DIR / "data" / "repair_backups"
+SUPPORTED_MARKETS = {"crypto", "us-stock"}
+PRICE_REL_TOLERANCE = 0.05
+SWAP_REL_TOLERANCE = 0.05
+MIN_MISMATCH_RATIO = 2.0
+DEFAULT_CRYPTO_SYMBOL_CANDIDATES = {
+    "BTC",
+    "ETH",
+    "SOL",
+    "BNB",
+    "SUI",
+    "FET",
+    "ADA",
+    "XRP",
+    "LINK",
+    "LTC",
+    "AVAX",
+    "NEAR",
+    "OP",
+    "ONDO",
+    "TIA",
+    "DOT",
+    "KAS",
+    "ZEC",
+}
+
+
+def utc_now_iso_z() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def row_dict(row: Any) -> dict[str, Any]:
+    return dict(row) if row is not None and not isinstance(row, dict) else (row or {})
+
+
+def as_float(value: Any) -> float:
+    try:
+        parsed = float(value)
+    except Exception:
+        return 0.0
+    return parsed if math.isfinite(parsed) else 0.0
+
+
+def relative_diff(a: float, b: float) -> float:
+    denominator = max(abs(a), abs(b), 1e-12)
+    return abs(a - b) / denominator
+
+
+def mismatch_ratio(a: float, b: float) -> float:
+    if a <= 0 or b <= 0:
+        return float("inf")
+    return max(a / b, b / a)
+
+
+def fetch_trade_rows(cursor: Any, challenge_key: str | None, market: str | None, trade_ids: list[int]) -> list[dict[str, Any]]:
+    where = ["ct.market IN ('crypto', 'us-stock')"]
+    params: list[Any] = []
+    if challenge_key:
+        where.append("c.challenge_key = ?")
+        params.append(challenge_key)
+    if market:
+        where.append("ct.market = ?")
+        params.append(market)
+    if trade_ids:
+        placeholders = ",".join("?" for _ in trade_ids)
+        where.append(f"ct.id IN ({placeholders})")
+        params.extend(trade_ids)
+
+    cursor.execute(
+        f"""
+        SELECT
+            ct.*,
+            c.challenge_key,
+            c.title AS challenge_title,
+            a.name AS agent_name
+        FROM challenge_trades ct
+        JOIN challenges c ON c.id = ct.challenge_id
+        JOIN agents a ON a.id = ct.agent_id
+        WHERE {' AND '.join(where)}
+        ORDER BY c.challenge_key, ct.agent_id, ct.executed_at, ct.id
+        """,
+        params,
+    )
+    return [row_dict(row) for row in cursor.fetchall()]
+
+
+def build_price_repair(row: dict[str, Any], quote: float, repaired_at: str) -> dict[str, Any] | None:
+    old_price = as_float(row.get("price"))
+    old_quantity = as_float(row.get("quantity"))
+    if old_price <= 0 or old_quantity <= 0 or quote <= 0:
+        return None
+    if relative_diff(old_price, quote) <= PRICE_REL_TOLERANCE:
+        return None
+    if mismatch_ratio(old_price, quote) < MIN_MISMATCH_RATIO:
+        return None
+
+    reason = "server_price_correction"
+    new_price = quote
+    new_quantity = old_quantity
+    if relative_diff(old_quantity, quote) <= SWAP_REL_TOLERANCE:
+        reason = "price_quantity_swapped"
+        new_quantity = old_price
+
+    return {
+        "trade_id": row["id"],
+        "challenge_key": row["challenge_key"],
+        "agent_id": row["agent_id"],
+        "agent_name": row["agent_name"],
+        "market": row["market"],
+        "symbol": row["symbol"],
+        "side": row["side"],
+        "executed_at": row["executed_at"],
+        "old_price": old_price,
+        "old_quantity": old_quantity,
+        "new_price": new_price,
+        "new_quantity": new_quantity,
+        "old_symbol": row["symbol"],
+        "new_symbol": row["symbol"],
+        "quote": quote,
+        "reason": reason,
+        "repaired_at": repaired_at,
+    }
+
+
+def build_symbol_repair(
+    row: dict[str, Any],
+    candidate_symbols: set[str],
+    quote_cache: dict[tuple[str, str, str], float | None],
+    repaired_at: str,
+) -> dict[str, Any] | None:
+    if str(row.get("market") or "") != "crypto":
+        return None
+    old_price = as_float(row.get("price"))
+    old_quantity = as_float(row.get("quantity"))
+    if old_price <= 0 or old_quantity <= 0:
+        return None
+
+    current_symbol = str(row.get("symbol") or "").strip().upper()
+    best_symbol = None
+    best_quote = 0.0
+    best_diff = float("inf")
+    with price_fetch_logging(False):
+        for symbol in sorted(candidate_symbols):
+            if not symbol or symbol == current_symbol:
+                continue
+            key = ("crypto", symbol, str(row.get("executed_at") or ""))
+            if key not in quote_cache:
+                try:
+                    quote = get_price_from_market(symbol, key[2], "crypto")
+                    quote_cache[key] = as_float(quote) if quote is not None else None
+                except Exception:
+                    quote_cache[key] = None
+            quote = quote_cache[key]
+            if not quote:
+                continue
+            diff = relative_diff(old_price, float(quote))
+            if diff < best_diff:
+                best_symbol = symbol
+                best_quote = float(quote)
+                best_diff = diff
+
+    if not best_symbol or best_diff > PRICE_REL_TOLERANCE:
+        return None
+    return {
+        "trade_id": row["id"],
+        "challenge_key": row["challenge_key"],
+        "agent_id": row["agent_id"],
+        "agent_name": row["agent_name"],
+        "market": row["market"],
+        "symbol": row["symbol"],
+        "side": row["side"],
+        "executed_at": row["executed_at"],
+        "old_price": old_price,
+        "old_quantity": old_quantity,
+        "new_price": best_quote,
+        "new_quantity": old_quantity,
+        "old_symbol": row["symbol"],
+        "new_symbol": best_symbol,
+        "quote": best_quote,
+        "reason": "invalid_symbol_inferred",
+        "repaired_at": repaired_at,
+    }
+
+
+def candidate_symbols_by_challenge(rows: list[dict[str, Any]]) -> dict[str, set[str]]:
+    result: dict[str, set[str]] = {}
+    for row in rows:
+        if row.get("market") != "crypto":
+            continue
+        challenge_key = str(row.get("challenge_key") or "")
+        symbol = str(row.get("symbol") or "").strip().upper()
+        if symbol and symbol not in {"ALL", "PORTFOLIO", "STRATEGY"} and not symbol.startswith("0X"):
+            result.setdefault(challenge_key, set()).add(symbol)
+    for challenge_key in {str(row.get("challenge_key") or "") for row in rows}:
+        result.setdefault(challenge_key, set()).update(DEFAULT_CRYPTO_SYMBOL_CANDIDATES)
+    return result
+
+
+def load_trade_event(cursor: Any, trade_id: int) -> dict[str, Any] | None:
+    cursor.execute(
+        """
+        SELECT *
+        FROM experiment_events
+        WHERE event_type = 'challenge_trade_submitted'
+          AND object_type = 'challenge_trade'
+          AND object_id = ?
+        ORDER BY id DESC
+        LIMIT 1
+        """,
+        (str(trade_id),),
+    )
+    row = cursor.fetchone()
+    return row_dict(row) if row else None
+
+
+def update_trade_event(cursor: Any, repair: dict[str, Any]) -> None:
+    event = load_trade_event(cursor, int(repair["trade_id"]))
+    if not event:
+        return
+    try:
+        metadata = json.loads(event.get("metadata_json") or "{}")
+        if not isinstance(metadata, dict):
+            metadata = {}
+    except Exception:
+        metadata = {}
+
+    metadata.update(
+        {
+            "price": repair["new_price"],
+            "quantity": repair["new_quantity"],
+            "symbol": repair["new_symbol"],
+            "repaired_at": repair["repaired_at"],
+            "repair_reason": repair["reason"],
+            "previous_price": repair["old_price"],
+            "previous_quantity": repair["old_quantity"],
+            "previous_symbol": repair["old_symbol"],
+        }
+    )
+    cursor.execute(
+        "UPDATE experiment_events SET metadata_json = ? WHERE id = ?",
+        (json.dumps(metadata, ensure_ascii=True, sort_keys=True), event["id"]),
+    )
+
+
+def write_backup(repairs: list[dict[str, Any]], rows: list[dict[str, Any]], events: list[dict[str, Any]]) -> str:
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    path = BACKUP_DIR / f"challenge_trade_price_repair_backup_{stamp}.json"
+    path.write_text(
+        json.dumps(
+            {
+                "captured_at": utc_now_iso_z(),
+                "repairs": repairs,
+                "challenge_trades": rows,
+                "experiment_events": events,
+            },
+            ensure_ascii=True,
+            indent=2,
+            sort_keys=True,
+            default=str,
+        ),
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Apply repairs. Defaults to dry-run.")
+    parser.add_argument("--challenge-key", help="Limit repair to one challenge key.")
+    parser.add_argument("--market", choices=sorted(SUPPORTED_MARKETS), help="Limit repair to one market.")
+    parser.add_argument("--trade-id", action="append", type=int, default=[], help="Limit repair to specific trade id; repeatable.")
+    parser.add_argument("--limit", type=int, default=0, help="Limit number of scanned rows after filtering.")
+    args = parser.parse_args()
+
+    repaired_at = utc_now_iso_z()
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        rows = fetch_trade_rows(cursor, args.challenge_key, args.market, args.trade_id)
+        if args.limit and args.limit > 0:
+            rows = rows[: args.limit]
+
+        repairs: list[dict[str, Any]] = []
+        quote_cache: dict[tuple[str, str, str], float | None] = {}
+        candidate_symbols = candidate_symbols_by_challenge(rows)
+        with price_fetch_logging(False):
+            for row in rows:
+                key = (str(row.get("market") or ""), str(row.get("symbol") or ""), str(row.get("executed_at") or ""))
+                if key not in quote_cache:
+                    try:
+                        quote = get_price_from_market(key[1], key[2], key[0])
+                        quote_cache[key] = as_float(quote) if quote is not None else None
+                    except Exception:
+                        quote_cache[key] = None
+                quote = quote_cache[key]
+                if quote:
+                    repair = build_price_repair(row, float(quote), repaired_at)
+                else:
+                    repair = build_symbol_repair(
+                        row,
+                        candidate_symbols.get(str(row.get("challenge_key") or ""), set()),
+                        quote_cache,
+                        repaired_at,
+                    )
+                if repair:
+                    repairs.append(repair)
+
+        events = []
+        if repairs:
+            ids = [int(repair["trade_id"]) for repair in repairs]
+            placeholders = ",".join("?" for _ in ids)
+            cursor.execute(
+                f"""
+                SELECT *
+                FROM experiment_events
+                WHERE event_type = 'challenge_trade_submitted'
+                  AND object_type = 'challenge_trade'
+                  AND object_id IN ({placeholders})
+                ORDER BY id
+                """,
+                [str(item) for item in ids],
+            )
+            events = [row_dict(row) for row in cursor.fetchall()]
+
+        summary = {
+            "captured_at": repaired_at,
+            "mode": "apply" if args.apply else "dry-run",
+            "scanned_trade_count": len(rows),
+            "repair_count": len(repairs),
+            "reasons": dict(Counter(repair["reason"] for repair in repairs)),
+            "repairs": repairs,
+        }
+
+        if not args.apply or not repairs:
+            print(json.dumps(summary, ensure_ascii=True, indent=2, sort_keys=True, default=str))
+            return 0
+
+        backup_path = write_backup(repairs, [row for row in rows if int(row["id"]) in {int(r["trade_id"]) for r in repairs}], events)
+        conn.commit()
+        begin_write_transaction(cursor)
+        for repair in repairs:
+            cursor.execute(
+                """
+                UPDATE challenge_trades
+                SET symbol = ?, price = ?, quantity = ?
+                WHERE id = ?
+                """,
+                (repair["new_symbol"], repair["new_price"], repair["new_quantity"], repair["trade_id"]),
+            )
+            update_trade_event(cursor, repair)
+        conn.commit()
+        summary["backup_path"] = backup_path
+        print(json.dumps(summary, ensure_ascii=True, indent=2, sort_keys=True, default=str))
+        return 0
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/service/server/tasks.py
+++ b/service/server/tasks.py
@@ -473,7 +473,7 @@ async def update_position_prices():
     # Get max parallel requests from environment variable
     max_parallel = _env_int("MAX_PARALLEL_PRICE_FETCH", 2, minimum=1)
     verbose_fetch = _env_bool("POSITION_PRICE_VERBOSE_FETCH_LOGS", False)
-    refresh_priced_markets = _env_csv_set("POSITION_PRICE_REFRESH_PRICED_MARKETS", "crypto")
+    refresh_priced_markets = _env_csv_set("POSITION_PRICE_REFRESH_PRICED_MARKETS", "crypto,us-stock")
 
     # Wait a bit on startup before first update
     await asyncio.sleep(_env_int("POSITION_PRICE_STARTUP_DELAY_SECONDS", 15, minimum=0))

--- a/service/server/tests/test_agent_login_token_stability.py
+++ b/service/server/tests/test_agent_login_token_stability.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
@@ -80,6 +81,97 @@ class AgentLoginTokenStabilityTests(unittest.TestCase):
         cursor = conn.cursor()
         cursor.execute("SELECT email FROM agents WHERE name = ?", ("email-agent",))
         self.assertEqual(cursor.fetchone()["email"], "trader@example.com")
+        conn.close()
+
+    def test_registration_tracks_extra_initial_cash_as_deposit(self) -> None:
+        register = self.client.post(
+            "/api/claw/agents/selfRegister",
+            json={
+                "name": "funded-agent",
+                "password": "password123",
+                "initial_balance": 150000,
+            },
+        )
+        self.assertEqual(register.status_code, 200, register.text)
+        self.assertEqual(register.json()["deposited"], 50000.0)
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT cash, deposited FROM agents WHERE name = ?", ("funded-agent",))
+        row = cursor.fetchone()
+        conn.close()
+
+        self.assertEqual(float(row["cash"]), 150000.0)
+        self.assertEqual(float(row["deposited"]), 50000.0)
+
+    def test_registration_marks_initial_positions_to_server_quote(self) -> None:
+        with patch("price_fetcher.get_price_from_market", return_value=250.0):
+            register = self.client.post(
+                "/api/claw/agents/selfRegister",
+                json={
+                    "name": "position-agent",
+                    "password": "password123",
+                    "initial_balance": 100000,
+                    "positions": [
+                        {
+                            "market": "us-stock",
+                            "symbol": "tsla",
+                            "side": "long",
+                            "quantity": 2,
+                            "entry_price": 1,
+                        }
+                    ],
+                },
+            )
+
+        self.assertEqual(register.status_code, 200, register.text)
+        self.assertEqual(register.json()["deposited"], 500.0)
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id, cash, deposited FROM agents WHERE name = ?", ("position-agent",))
+        agent = cursor.fetchone()
+        cursor.execute(
+            "SELECT symbol, market, quantity, entry_price, current_price FROM positions WHERE agent_id = ?",
+            (agent["id"],),
+        )
+        position = cursor.fetchone()
+        conn.close()
+
+        self.assertEqual(float(agent["cash"]), 100000.0)
+        self.assertEqual(float(agent["deposited"]), 500.0)
+        self.assertEqual(position["symbol"], "TSLA")
+        self.assertEqual(position["market"], "us-stock")
+        self.assertEqual(float(position["quantity"]), 2.0)
+        self.assertEqual(float(position["entry_price"]), 250.0)
+        self.assertEqual(float(position["current_price"]), 250.0)
+
+    def test_registration_rejects_initial_position_without_server_quote(self) -> None:
+        with patch("price_fetcher.get_price_from_market", return_value=None):
+            register = self.client.post(
+                "/api/claw/agents/selfRegister",
+                json={
+                    "name": "bad-position-agent",
+                    "password": "password123",
+                    "positions": [
+                        {
+                            "market": "us-stock",
+                            "symbol": "tsla",
+                            "side": "long",
+                            "quantity": 2,
+                            "entry_price": 1,
+                        }
+                    ],
+                },
+            )
+
+        self.assertEqual(register.status_code, 400, register.text)
+        self.assertIn("Unable to fetch current price for TSLA", register.json()["detail"])
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) AS count FROM agents WHERE name = ?", ("bad-position-agent",))
+        self.assertEqual(int(cursor.fetchone()["count"]), 0)
         conn.close()
 
     def test_agent_identity_defaults_normal_and_can_be_verified_manually(self) -> None:

--- a/service/server/tests/test_challenges.py
+++ b/service/server/tests/test_challenges.py
@@ -89,17 +89,18 @@ class ChallengeTests(unittest.TestCase):
         quantity: float,
         symbol: str = "BTC",
     ):
-        return create_challenge_trade(
-            challenge_key,
-            agent_id=agent_id,
-            data={
-                "symbol": symbol,
-                "side": side,
-                "price": price,
-                "quantity": quantity,
-                "executed_at": iso(datetime.now(timezone.utc)),
-            },
-        )
+        with patch("price_fetcher.get_price_from_market", return_value=price):
+            return create_challenge_trade(
+                challenge_key,
+                agent_id=agent_id,
+                data={
+                    "symbol": symbol,
+                    "side": side,
+                    "price": price,
+                    "quantity": quantity,
+                    "executed_at": iso(datetime.now(timezone.utc)),
+                },
+            )
 
     def test_create_and_join_challenge_is_idempotent(self):
         challenge = self._create_active_challenge(challenge_key="join-check")
@@ -147,9 +148,21 @@ class ChallengeTests(unittest.TestCase):
         challenge = self._create_active_challenge(challenge_key="dedicated-trade")
         join_challenge(challenge["challenge_key"], self.agent_2)
 
-        result = self._submit_challenge_trade(challenge["challenge_key"], self.agent_2, "buy", 100.0, 2.0)
+        with patch("price_fetcher.get_price_from_market", return_value=100.0):
+            result = create_challenge_trade(
+                challenge["challenge_key"],
+                agent_id=self.agent_2,
+                data={
+                    "symbol": "BTC",
+                    "side": "buy",
+                    "price": 1.0,
+                    "quantity": 2.0,
+                    "executed_at": iso(datetime.now(timezone.utc)),
+                },
+            )
 
         self.assertIsNone(result["trade"]["source_signal_id"])
+        self.assertEqual(result["trade"]["price"], 100.0)
         self.assertEqual(result["portfolio"]["trade_count"], 1)
         self.assertAlmostEqual(result["portfolio"]["cash"], 800.0)
         self.assertEqual(result["portfolio"]["positions"][0]["quantity"], 2.0)
@@ -170,6 +183,30 @@ class ChallengeTests(unittest.TestCase):
 
         portfolio = get_agent_challenge_portfolio(challenge["challenge_key"], self.agent_2)
         self.assertEqual(portfolio["portfolio"]["trade_count"], 1)
+
+    def test_dedicated_challenge_trade_requires_server_price(self):
+        challenge = self._create_active_challenge(challenge_key="dedicated-trade-no-price")
+        join_challenge(challenge["challenge_key"], self.agent_2)
+
+        with patch("price_fetcher.get_price_from_market", return_value=None):
+            with self.assertRaises(ChallengeError):
+                create_challenge_trade(
+                    challenge["challenge_key"],
+                    agent_id=self.agent_2,
+                    data={
+                        "symbol": "BTC",
+                        "side": "buy",
+                        "price": 1.0,
+                        "quantity": 2.0,
+                        "executed_at": iso(datetime.now(timezone.utc)),
+                    },
+                )
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) AS count FROM challenge_trades WHERE challenge_id = ?", (challenge["id"],))
+        self.assertEqual(cursor.fetchone()["count"], 0)
+        conn.close()
 
     def test_active_leaderboard_marks_open_positions_to_market(self):
         challenge = self._create_active_challenge(challenge_key="live-mark-leaderboard")


### PR DESCRIPTION
## Summary
- add live challenge mark-to-market and yfinance fallback prerequisite from production
- force crypto/us-stock challenge trades to use server-side market prices instead of client-submitted prices
- add a repair script for bad challenge trade snapshots, including price/quantity swaps and invalid inferred crypto symbols
- tighten registration initial-position accounting and us-stock price refresh defaults

## Verification
- python3 -m py_compile service/server/challenges.py service/server/routes_agent.py service/server/tasks.py service/server/scripts/cleanup_dirty_trade_data.py service/server/scripts/repair_challenge_trade_prices.py service/server/tests/test_challenges.py service/server/tests/test_agent_login_token_stability.py
- python3 -m unittest service.server.tests.test_challenges service.server.tests.test_agent_login_token_stability service.server.tests.test_realtime_trade_price_guard service.server.tests.test_price_fetcher

## Data note
Runtime repair backups and production DB changes are intentionally not committed.