### PR TITLE
Guard Polymarket challenge trades

### DIFF
--- a/service/server/challenge_scoring.py
+++ b/service/server/challenge_scoring.py
@@ -6,6 +6,8 @@ import json
 import math
 from typing import Any
 
+PositionKey = tuple[str, str, str, str]
+
 
 def _row_dict(row: Any) -> dict[str, Any]:
     return dict(row) if row is not None and not isinstance(row, dict) else (row or {})
@@ -40,10 +42,26 @@ def _position_value(position: dict[str, Any], mark_price: float) -> float:
     return (2 * entry - mark_price) * abs(qty)
 
 
-def _portfolio_value(cash: float, positions: dict[tuple[str, str], dict[str, Any]], marks: dict[tuple[str, str], float]) -> float:
+def _position_key(market: str, symbol: str, token_id: Any = None, outcome: Any = None) -> PositionKey:
+    token = str(token_id or '').strip()
+    resolved_outcome = str(outcome or '').strip()
+    if market != 'polymarket':
+        token = ''
+        resolved_outcome = ''
+    return (market, symbol, token, resolved_outcome)
+
+
+def _mark_price(marks: dict[Any, float], key: PositionKey) -> float:
+    mark = marks.get(key)
+    if mark is None:
+        mark = marks.get((key[0], key[1]))
+    return _safe_float(mark, 0.0)
+
+
+def _portfolio_value(cash: float, positions: dict[PositionKey, dict[str, Any]], marks: dict[Any, float]) -> float:
     value = cash
     for key, position in positions.items():
-        mark_price = marks.get(key) or _safe_float(position.get('entry_price'))
+        mark_price = _mark_price(marks, key) or _safe_float(position.get('entry_price'))
         value += _position_value(position, mark_price)
     return value
 
@@ -52,7 +70,7 @@ def score_agent_trades(
     challenge: Any,
     participant: Any,
     trades: list[Any],
-    mark_prices: dict[tuple[str, str], float] | None = None,
+    mark_prices: dict[Any, float] | None = None,
     mark_timestamp: str | None = None,
 ) -> dict[str, Any]:
     challenge_data = _row_dict(challenge)
@@ -67,8 +85,8 @@ def score_agent_trades(
     max_drawdown_pct = _safe_float(challenge_data.get('max_drawdown_pct'), 100.0)
 
     cash = starting_cash
-    positions: dict[tuple[str, str], dict[str, Any]] = {}
-    marks: dict[tuple[str, str], float] = {}
+    positions: dict[PositionKey, dict[str, Any]] = {}
+    marks: dict[Any, float] = {}
     equity_curve = [starting_cash]
     peak = starting_cash
     max_drawdown = 0.0
@@ -92,7 +110,9 @@ def score_agent_trades(
         side = str(trade.get('side') or '').lower()
         market = str(trade.get('market') or '')
         symbol = str(trade.get('symbol') or '')
-        key = (market, symbol)
+        token_id = str(trade.get('token_id') or '').strip() or None
+        outcome = str(trade.get('outcome') or '').strip() or None
+        key = _position_key(market, symbol, token_id, outcome)
         price = _safe_float(trade.get('price'))
         quantity = _safe_float(trade.get('quantity'))
 
@@ -119,6 +139,8 @@ def score_agent_trades(
             positions[key] = {
                 'market': market,
                 'symbol': symbol,
+                'token_id': token_id,
+                'outcome': outcome,
                 'quantity': new_qty,
                 'entry_price': new_entry,
             }
@@ -134,6 +156,8 @@ def score_agent_trades(
                 positions[key] = {
                     'market': market,
                     'symbol': symbol,
+                    'token_id': token_id,
+                    'outcome': outcome,
                     'quantity': new_qty,
                     'entry_price': current_entry,
                 }
@@ -152,6 +176,8 @@ def score_agent_trades(
             positions[key] = {
                 'market': market,
                 'symbol': symbol,
+                'token_id': token_id,
+                'outcome': outcome,
                 'quantity': new_qty,
                 'entry_price': new_entry,
             }
@@ -167,6 +193,8 @@ def score_agent_trades(
                 positions[key] = {
                     'market': market,
                     'symbol': symbol,
+                    'token_id': token_id,
+                    'outcome': outcome,
                     'quantity': new_qty,
                     'entry_price': current_entry,
                 }
@@ -179,7 +207,7 @@ def score_agent_trades(
         update_drawdown(equity)
 
         if max_position_pct > 0 and equity > 0:
-            max_notional = max((abs(pos['quantity']) * (marks.get(pos_key) or pos['entry_price'])) for pos_key, pos in positions.items()) if positions else 0.0
+            max_notional = max((abs(pos['quantity']) * (_mark_price(marks, pos_key) or pos['entry_price'])) for pos_key, pos in positions.items()) if positions else 0.0
             if (max_notional / equity) * 100 > max_position_pct + 1e-9:
                 disqualified_reason = 'max_position_pct_exceeded'
                 break
@@ -187,13 +215,15 @@ def score_agent_trades(
     live_marks: list[dict[str, Any]] = []
     if mark_prices and positions:
         for key in positions:
-            live_mark = _safe_float(mark_prices.get(key), 0.0)
+            live_mark = _mark_price(mark_prices, key)
             if live_mark <= 0:
                 continue
             marks[key] = live_mark
             live_marks.append({
                 'market': key[0],
                 'symbol': key[1],
+                'token_id': key[2] or None,
+                'outcome': key[3] or None,
                 'price': live_mark,
             })
         if live_marks:
@@ -264,7 +294,7 @@ def score_challenge_results(
     challenge: Any,
     participants: list[Any],
     trades_by_agent: dict[int, list[Any]],
-    mark_prices: dict[tuple[str, str], float] | None = None,
+    mark_prices: dict[Any, float] | None = None,
     mark_timestamp: str | None = None,
 ) -> list[dict[str, Any]]:
     scored = [

--- a/service/server/challenges.py
+++ b/service/server/challenges.py
@@ -27,7 +27,8 @@ class ChallengeNotFound(ChallengeError):
 DEFAULT_CHALLENGE_REWARDS = {'1': 100, '2': 50, '3': 25}
 SUPPORTED_SCORING_METHODS = {'return-only', 'risk-adjusted'}
 SUPPORTED_CHALLENGE_TRACKS = {'crypto', 'us-stock', 'polymarket'}
-AUTHORITATIVE_CHALLENGE_PRICE_MARKETS = {'crypto', 'us-stock'}
+AUTHORITATIVE_CHALLENGE_PRICE_MARKETS = {'crypto', 'us-stock', 'polymarket'}
+POLYMARKET_CHALLENGE_CLOCK_SKEW_SECONDS = 300
 
 
 def _row_dict(row: Any) -> dict[str, Any]:
@@ -90,20 +91,24 @@ def _live_mark_timestamp(challenge: dict[str, Any]) -> Optional[str]:
     return _iso(now)
 
 
-def _fetch_live_mark_prices(scored_results: list[dict[str, Any]], mark_timestamp: str) -> dict[tuple[str, str], float]:
-    position_keys: set[tuple[str, str]] = set()
+def _fetch_live_mark_prices(scored_results: list[dict[str, Any]], mark_timestamp: str) -> dict[tuple[str, str, str, str], float]:
+    position_keys: set[tuple[str, str, str, str]] = set()
     for result in scored_results:
         metrics = result.get('metrics') or {}
         for position in metrics.get('positions') or []:
             market = str(position.get('market') or '').strip()
             symbol = str(position.get('symbol') or '').strip()
+            token_id = str(position.get('token_id') or '').strip()
+            outcome = str(position.get('outcome') or '').strip()
             quantity = position.get('quantity')
             try:
                 quantity_float = float(quantity)
             except Exception:
                 quantity_float = 0.0
             if market and symbol and abs(quantity_float) > 1e-12:
-                position_keys.add((market, symbol))
+                if market == 'polymarket' and not (token_id or outcome):
+                    continue
+                position_keys.add((market, symbol, token_id, outcome))
 
     if not position_keys:
         return {}
@@ -114,20 +119,59 @@ def _fetch_live_mark_prices(scored_results: list[dict[str, Any]], mark_timestamp
     except Exception:
         return {}
 
-    mark_prices: dict[tuple[str, str], float] = {}
+    mark_prices: dict[tuple[str, str, str, str], float] = {}
     with price_fetch_logging(False):
-        for market, symbol in sorted(position_keys):
+        for market, symbol, token_id, outcome in sorted(position_keys):
             try:
-                price = price_fetcher.get_price_from_market(symbol, mark_timestamp, market)
+                price = price_fetcher.get_price_from_market(
+                    symbol,
+                    mark_timestamp,
+                    market,
+                    token_id=token_id or None,
+                    outcome=outcome or None,
+                )
                 parsed = float(price) if price is not None else 0.0
             except Exception:
                 continue
             if math.isfinite(parsed) and parsed > 0:
-                mark_prices[(market, symbol)] = parsed
+                mark_prices[(market, symbol, token_id, outcome)] = parsed
     return mark_prices
 
 
-def _fetch_authoritative_challenge_trade_price(market: str, symbol: str, executed_at: str) -> Optional[float]:
+def _resolve_polymarket_challenge_contract(symbol: str, token_id: Any = None, outcome: Any = None) -> tuple[Optional[str], Optional[str]]:
+    resolved_token_id = str(token_id or '').strip() or None
+    resolved_outcome = str(outcome or '').strip() or None
+    if not (resolved_token_id or resolved_outcome):
+        raise ChallengeError('Polymarket challenge trades require an explicit token_id or outcome')
+
+    try:
+        import price_fetcher
+        from price_fetcher import price_fetch_logging
+    except Exception as exc:
+        raise ChallengeError('Server price fetcher is unavailable') from exc
+
+    with price_fetch_logging(False):
+        try:
+            contract = price_fetcher.describe_polymarket_contract(
+                symbol,
+                token_id=resolved_token_id,
+                outcome=resolved_outcome,
+            )
+        except Exception as exc:
+            raise ChallengeError(f'Unable to resolve Polymarket contract for {symbol}') from exc
+
+    if not contract or not contract.get('token_id'):
+        raise ChallengeError('Polymarket challenge trade must resolve to a single outcome token')
+    return str(contract.get('token_id') or '').strip() or None, str(contract.get('outcome') or resolved_outcome or '').strip() or None
+
+
+def _fetch_authoritative_challenge_trade_price(
+    market: str,
+    symbol: str,
+    executed_at: str,
+    token_id: Any = None,
+    outcome: Any = None,
+) -> Optional[float]:
     if market not in AUTHORITATIVE_CHALLENGE_PRICE_MARKETS:
         return None
 
@@ -139,7 +183,13 @@ def _fetch_authoritative_challenge_trade_price(market: str, symbol: str, execute
 
     with price_fetch_logging(False):
         try:
-            price = price_fetcher.get_price_from_market(symbol, executed_at, market)
+            price = price_fetcher.get_price_from_market(
+                symbol,
+                executed_at,
+                market,
+                token_id=str(token_id or '').strip() or None,
+                outcome=str(outcome or '').strip() or None,
+            )
         except Exception as exc:
             raise ChallengeError(f'Unable to fetch server price for {symbol}') from exc
 
@@ -149,6 +199,8 @@ def _fetch_authoritative_challenge_trade_price(market: str, symbol: str, execute
         parsed = 0.0
     if not math.isfinite(parsed) or parsed <= 0:
         raise ChallengeError(f'Unable to fetch server price for {symbol}')
+    if market == 'polymarket' and parsed > 1:
+        raise ChallengeError(f'Invalid Polymarket price for {symbol}')
     return parsed
 
 
@@ -640,7 +692,7 @@ def _serialize_challenge_portfolio(
     challenge: dict[str, Any],
     participant: dict[str, Any],
     trades: list[dict[str, Any]],
-    mark_prices: Optional[dict[tuple[str, str], float]] = None,
+    mark_prices: Optional[dict[Any, float]] = None,
     mark_timestamp: Optional[str] = None,
 ) -> dict[str, Any]:
     scored = score_agent_trades(
@@ -707,7 +759,7 @@ def get_agent_challenge_portfolio(challenge_key: str, agent_id: int) -> dict[str
             (challenge['id'], agent_id),
         )
         trades = [dict(trade) for trade in cursor.fetchall()]
-        mark_prices: dict[tuple[str, str], float] = {}
+        mark_prices: dict[Any, float] = {}
         mark_timestamp = _live_mark_timestamp(challenge)
         if mark_timestamp:
             baseline = score_agent_trades(challenge, participant, trades)
@@ -749,6 +801,10 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
         executed_dt = _parse_dt(executed_at)
         if executed_dt < _parse_dt(challenge['start_at']) or executed_dt > _parse_dt(challenge['end_at']):
             raise ChallengeError('Challenge trade must be inside challenge time window')
+        if challenge['market'] == 'polymarket':
+            current_dt = datetime.now(timezone.utc)
+            if abs((current_dt - executed_dt).total_seconds()) > POLYMARKET_CHALLENGE_CLOCK_SKEW_SECONDS:
+                raise ChallengeError('Polymarket challenge trades must use current execution time')
 
         cursor.execute(
             """
@@ -769,8 +825,20 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
             raise ChallengeError('Challenge participant is not tradeable')
 
         symbol = _normalize_challenge_trade_symbol(challenge, payload.get('symbol'))
+        token_id = str(payload.get('token_id') or '').strip() or None
+        outcome = str(payload.get('outcome') or '').strip() or None
+        if challenge['market'] == 'polymarket':
+            if side in {'short', 'cover'}:
+                raise ChallengeError('Polymarket challenge trades support buy/sell outcome tokens only')
+            token_id, outcome = _resolve_polymarket_challenge_contract(symbol, token_id=token_id, outcome=outcome)
         requested_price = price
-        server_price = _fetch_authoritative_challenge_trade_price(challenge['market'], symbol, executed_at)
+        server_price = _fetch_authoritative_challenge_trade_price(
+            challenge['market'],
+            symbol,
+            executed_at,
+            token_id=token_id,
+            outcome=outcome,
+        )
         if server_price is not None:
             price = server_price
         cursor.execute(
@@ -787,6 +855,8 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
             'id': (max([int(trade.get('id') or 0) for trade in existing_trades], default=0) + 1),
             'market': challenge['market'],
             'symbol': symbol,
+            'token_id': token_id,
+            'outcome': outcome,
             'side': side,
             'price': price,
             'quantity': quantity,
@@ -801,8 +871,8 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
         cursor.execute(
             """
             INSERT INTO challenge_trades
-            (challenge_id, agent_id, source_signal_id, market, symbol, side, price, quantity, executed_at, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (challenge_id, agent_id, source_signal_id, market, symbol, token_id, outcome, side, price, quantity, executed_at, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 challenge['id'],
@@ -810,6 +880,8 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
                 None,
                 challenge['market'],
                 symbol,
+                token_id,
+                outcome,
                 side,
                 price,
                 quantity,
@@ -818,6 +890,15 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
             ),
         )
         trade_id = cursor.lastrowid
+        updated_trade_count = len(existing_trades) + 1
+        cursor.execute(
+            """
+            UPDATE challenge_participants
+            SET trade_count = ?
+            WHERE challenge_id = ? AND agent_id = ?
+            """,
+            (updated_trade_count, challenge['id'], agent_id),
+        )
         content = (payload.get('content') or '').strip() or None
         if content:
             _create_submission_with_cursor(
@@ -841,10 +922,13 @@ def create_challenge_trade(challenge_key: str, agent_id: int, data: Any) -> dict
                 'challenge_key': challenge['challenge_key'],
                 'challenge_id': challenge['id'],
                 'symbol': symbol,
+                'token_id': token_id,
+                'outcome': outcome,
                 'side': side,
                 'price': price,
                 'requested_price': requested_price,
                 'quantity': quantity,
+                'trade_count': updated_trade_count,
             },
             cursor=cursor,
         )

--- a/service/server/database.py
+++ b/service/server/database.py
@@ -380,6 +380,8 @@ def _ensure_challenge_trades_source_signal_nullable(cursor: Any) -> None:
             source_signal_id INTEGER,
             market TEXT NOT NULL,
             symbol TEXT NOT NULL,
+            token_id TEXT,
+            outcome TEXT,
             side TEXT NOT NULL,
             price REAL NOT NULL,
             quantity REAL NOT NULL,
@@ -831,6 +833,8 @@ def init_database():
             source_signal_id INTEGER,
             market TEXT NOT NULL,
             symbol TEXT NOT NULL,
+            token_id TEXT,
+            outcome TEXT,
             side TEXT NOT NULL,
             price REAL NOT NULL,
             quantity REAL NOT NULL,
@@ -860,6 +864,16 @@ def init_database():
     """)
 
     _ensure_challenge_trades_source_signal_nullable(cursor)
+
+    try:
+        cursor.execute("ALTER TABLE challenge_trades ADD COLUMN token_id TEXT")
+    except Exception:
+        pass
+
+    try:
+        cursor.execute("ALTER TABLE challenge_trades ADD COLUMN outcome TEXT")
+    except Exception:
+        pass
 
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS signal_predictions (

--- a/service/server/research_exports.py
+++ b/service/server/research_exports.py
@@ -46,7 +46,8 @@ CHALLENGE_EXPORTS: dict[str, dict[str, Any]] = {
         'join': 'JOIN challenges c ON c.id = ct.challenge_id',
         'columns': [
             'id', 'challenge_id', 'agent_id', 'source_signal_id', 'market',
-            'symbol', 'side', 'price', 'quantity', 'executed_at', 'created_at',
+            'symbol', 'token_id', 'outcome', 'side', 'price', 'quantity',
+            'executed_at', 'created_at',
         ],
     },
     'challenge_results.csv': {
@@ -883,6 +884,7 @@ RESEARCH_EXPORTS = {
             ("id", "ct.id"), ("challenge_id", "ct.challenge_id"), ("challenge_key", "c.challenge_key"),
             ("agent_id", "ct.agent_id"), ("agent_hash", "ct.agent_id"),
             ("source_signal_id", "ct.source_signal_id"), ("market", "ct.market"), ("symbol", "ct.symbol"),
+            ("token_id", "ct.token_id"), ("outcome", "ct.outcome"),
             ("side", "ct.side"), ("price", "ct.price"), ("quantity", "ct.quantity"),
             ("executed_at", "ct.executed_at"), ("created_at", "ct.created_at"),
             ("experiment_key", "c.experiment_key"),

--- a/service/server/routes_models.py
+++ b/service/server/routes_models.py
@@ -117,6 +117,8 @@ class ChallengeSubmissionRequest(BaseModel):
 class ChallengeTradeRequest(BaseModel):
     side: str
     symbol: Optional[str] = None
+    token_id: Optional[str] = None
+    outcome: Optional[str] = None
     price: float
     quantity: float
     content: Optional[str] = None

--- a/service/server/scripts/repair_challenge_polymarket_trades.py
+++ b/service/server/scripts/repair_challenge_polymarket_trades.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Quarantine legacy Polymarket challenge trades that cannot be marked.
+
+Polymarket challenge trades need an explicit outcome token to be valued against
+the live CLOB. Legacy rows created before that guard may only contain a market
+slug or even a non-Polymarket symbol, so they cannot be repaired safely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from database import begin_write_transaction, get_db_connection  # noqa: E402
+
+
+BACKUP_DIR = SERVER_DIR / "data" / "repair_backups"
+LEGACY_REASON = "legacy_polymarket_trade_missing_token"
+
+
+def now_z() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def row_dict(row: Any) -> dict[str, Any]:
+    return dict(row) if row is not None and not isinstance(row, dict) else (row or {})
+
+
+def as_float(value: Any) -> float:
+    try:
+        parsed = float(value)
+    except Exception:
+        return 0.0
+    return parsed if math.isfinite(parsed) else 0.0
+
+
+def fetch_invalid_rows(cursor: Any, challenge_key: str | None, include_settled: bool) -> list[dict[str, Any]]:
+    where = [
+        "ct.market = 'polymarket'",
+        """(
+            ct.token_id IS NULL OR ct.token_id = ''
+            OR ct.price <= 0 OR ct.price > 1
+            OR ct.quantity <= 0
+            OR LOWER(ct.side) NOT IN ('buy', 'sell')
+        )""",
+    ]
+    params: list[Any] = []
+    if challenge_key:
+        where.append("c.challenge_key = ?")
+        params.append(challenge_key)
+    if not include_settled:
+        where.append("c.status = 'active'")
+
+    cursor.execute(
+        f"""
+        SELECT
+            ct.*,
+            c.challenge_key,
+            c.status AS challenge_status,
+            a.name AS agent_name
+        FROM challenge_trades ct
+        JOIN challenges c ON c.id = ct.challenge_id
+        JOIN agents a ON a.id = ct.agent_id
+        WHERE {' AND '.join(where)}
+        ORDER BY c.challenge_key, ct.agent_id, ct.executed_at, ct.id
+        """,
+        params,
+    )
+    return [row_dict(row) for row in cursor.fetchall()]
+
+
+def invalid_reason(row: dict[str, Any]) -> str:
+    token_id = str(row.get("token_id") or "").strip()
+    price = as_float(row.get("price"))
+    quantity = as_float(row.get("quantity"))
+    side = str(row.get("side") or "").strip().lower()
+    if not token_id:
+        return "missing_token_id"
+    if price <= 0 or price > 1:
+        return "invalid_price"
+    if quantity <= 0:
+        return "invalid_quantity"
+    if side not in {"buy", "sell"}:
+        return "invalid_side"
+    return "invalid_polymarket_trade"
+
+
+def write_backup(rows: list[dict[str, Any]], action: str, repaired_at: str) -> str | None:
+    if not rows:
+        return None
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    backup_path = BACKUP_DIR / f"polymarket_challenge_trades_{action}_{repaired_at.replace(':', '').replace('-', '')}.json"
+    payload = {
+        "created_at": repaired_at,
+        "action": action,
+        "row_count": len(rows),
+        "rows": rows,
+    }
+    backup_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False, default=str), encoding="utf-8")
+    return str(backup_path)
+
+
+def refresh_participant_trade_counts(cursor: Any, rows: list[dict[str, Any]]) -> None:
+    affected_pairs = {(int(row["challenge_id"]), int(row["agent_id"])) for row in rows}
+    for challenge_id, agent_id in sorted(affected_pairs):
+        cursor.execute(
+            "SELECT COUNT(*) AS count FROM challenge_trades WHERE challenge_id = ? AND agent_id = ?",
+            (challenge_id, agent_id),
+        )
+        count = int(cursor.fetchone()["count"])
+        cursor.execute(
+            """
+            UPDATE challenge_participants
+            SET trade_count = ?, ending_value = NULL, return_pct = NULL,
+                max_drawdown = NULL, rank = NULL,
+                status = CASE
+                    WHEN status = 'disqualified' AND disqualified_reason = ? THEN 'active'
+                    ELSE status
+                END,
+                disqualified_reason = CASE
+                    WHEN disqualified_reason = ? THEN NULL
+                    ELSE disqualified_reason
+                END
+            WHERE challenge_id = ? AND agent_id = ?
+            """,
+            (count, LEGACY_REASON, LEGACY_REASON, challenge_id, agent_id),
+        )
+
+
+def apply_delete(cursor: Any, rows: list[dict[str, Any]]) -> None:
+    for row in rows:
+        cursor.execute("DELETE FROM challenge_trades WHERE id = ?", (row["id"],))
+    refresh_participant_trade_counts(cursor, rows)
+
+
+def apply_disqualify(cursor: Any, rows: list[dict[str, Any]]) -> None:
+    affected_pairs = {(int(row["challenge_id"]), int(row["agent_id"])) for row in rows}
+    for challenge_id, agent_id in sorted(affected_pairs):
+        cursor.execute(
+            "SELECT COUNT(*) AS count FROM challenge_trades WHERE challenge_id = ? AND agent_id = ?",
+            (challenge_id, agent_id),
+        )
+        count = int(cursor.fetchone()["count"])
+        cursor.execute(
+            """
+            UPDATE challenge_participants
+            SET status = 'disqualified', disqualified_reason = ?, trade_count = ?
+            WHERE challenge_id = ? AND agent_id = ?
+            """,
+            (LEGACY_REASON, count, challenge_id, agent_id),
+        )
+
+
+def summarize(rows: list[dict[str, Any]], action: str, mode: str, backup_path: str | None = None) -> dict[str, Any]:
+    reasons = Counter(invalid_reason(row) for row in rows)
+    affected_agents = sorted(
+        {
+            f"{row.get('challenge_key')}:{row.get('agent_id')}:{row.get('agent_name')}"
+            for row in rows
+        }
+    )
+    return {
+        "captured_at": now_z(),
+        "mode": mode,
+        "action": action,
+        "invalid_trade_count": len(rows),
+        "affected_participant_count": len(affected_agents),
+        "reasons": dict(reasons),
+        "backup_path": backup_path,
+        "affected_participants": affected_agents,
+        "trades": [
+            {
+                "id": row.get("id"),
+                "challenge_key": row.get("challenge_key"),
+                "agent_id": row.get("agent_id"),
+                "agent_name": row.get("agent_name"),
+                "symbol": row.get("symbol"),
+                "token_id": row.get("token_id"),
+                "outcome": row.get("outcome"),
+                "side": row.get("side"),
+                "price": row.get("price"),
+                "quantity": row.get("quantity"),
+                "reason": invalid_reason(row),
+            }
+            for row in rows
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--challenge-key")
+    parser.add_argument("--include-settled", action="store_true")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--action", choices=["delete-trades", "disqualify"], default="delete-trades")
+    args = parser.parse_args()
+
+    repaired_at = now_z()
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        rows = fetch_invalid_rows(cursor, args.challenge_key, args.include_settled)
+        if not args.apply:
+            print(json.dumps(summarize(rows, args.action, "dry-run"), indent=2, ensure_ascii=False, default=str))
+            return 0
+
+        backup_path = write_backup(rows, args.action, repaired_at)
+        begin_write_transaction(cursor)
+        if args.action == "delete-trades":
+            apply_delete(cursor, rows)
+        else:
+            apply_disqualify(cursor, rows)
+        conn.commit()
+        print(json.dumps(summarize(rows, args.action, "apply", backup_path), indent=2, ensure_ascii=False, default=str))
+        return 0
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/service/server/tests/test_challenges.py
+++ b/service/server/tests/test_challenges.py
@@ -177,6 +177,11 @@ class ChallengeTests(unittest.TestCase):
         self.assertEqual(cursor.fetchone()["count"], 0)
         cursor.execute("SELECT cash FROM agents WHERE id = ?", (self.agent_2,))
         self.assertEqual(cursor.fetchone()["cash"], 100000.0)
+        cursor.execute(
+            "SELECT trade_count FROM challenge_participants WHERE challenge_id = ? AND agent_id = ?",
+            (challenge["id"], self.agent_2),
+        )
+        self.assertEqual(cursor.fetchone()["trade_count"], 1)
         cursor.execute("SELECT COUNT(*) AS count FROM experiment_events WHERE event_type = 'challenge_trade_submitted'")
         self.assertEqual(cursor.fetchone()["count"], 1)
         conn.close()
@@ -207,6 +212,97 @@ class ChallengeTests(unittest.TestCase):
         cursor.execute("SELECT COUNT(*) AS count FROM challenge_trades WHERE challenge_id = ?", (challenge["id"],))
         self.assertEqual(cursor.fetchone()["count"], 0)
         conn.close()
+
+    def test_polymarket_challenge_trade_requires_resolved_contract(self):
+        challenge = self._create_active_challenge(
+            challenge_key="poly-trade-no-contract",
+            market="polymarket",
+            symbol="will-btc-be-above-120k-on-june-30",
+        )
+        join_challenge(challenge["challenge_key"], self.agent_2)
+
+        with self.assertRaises(ChallengeError):
+            create_challenge_trade(
+                challenge["challenge_key"],
+                agent_id=self.agent_2,
+                data={
+                    "symbol": "will-btc-be-above-120k-on-june-30",
+                    "side": "buy",
+                    "price": 0.5,
+                    "quantity": 10.0,
+                    "executed_at": iso(datetime.now(timezone.utc)),
+                },
+            )
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) AS count FROM challenge_trades WHERE challenge_id = ?", (challenge["id"],))
+        self.assertEqual(cursor.fetchone()["count"], 0)
+        conn.close()
+
+    def test_polymarket_challenge_trade_rejects_stale_execution_time(self):
+        now = datetime.now(timezone.utc)
+        challenge = self._create_active_challenge(
+            challenge_key="poly-trade-stale-time",
+            market="polymarket",
+            symbol="will-btc-be-above-120k-on-june-30",
+            start_at=iso(now - timedelta(hours=2)),
+            end_at=iso(now + timedelta(hours=1)),
+        )
+        join_challenge(challenge["challenge_key"], self.agent_2)
+
+        with self.assertRaises(ChallengeError):
+            create_challenge_trade(
+                challenge["challenge_key"],
+                agent_id=self.agent_2,
+                data={
+                    "symbol": "will-btc-be-above-120k-on-june-30",
+                    "token_id": "123456789",
+                    "outcome": "Yes",
+                    "side": "buy",
+                    "price": 0.5,
+                    "quantity": 10.0,
+                    "executed_at": iso(now - timedelta(hours=1)),
+                },
+            )
+
+    def test_polymarket_challenge_trade_marks_by_token(self):
+        challenge = self._create_active_challenge(
+            challenge_key="poly-live-mark-token",
+            market="polymarket",
+            symbol="will-btc-be-above-120k-on-june-30",
+        )
+        join_challenge(challenge["challenge_key"], self.agent_2)
+
+        with patch(
+            "price_fetcher.describe_polymarket_contract",
+            return_value={"token_id": "123456789", "outcome": "Yes"},
+        ), patch("price_fetcher.get_price_from_market", side_effect=[0.42, 0.55]) as mock_price:
+            result = create_challenge_trade(
+                challenge["challenge_key"],
+                agent_id=self.agent_2,
+                data={
+                    "symbol": "will-btc-be-above-120k-on-june-30",
+                    "token_id": "123456789",
+                    "outcome": "Yes",
+                    "side": "buy",
+                    "price": 0.01,
+                    "quantity": 100.0,
+                    "executed_at": iso(datetime.now(timezone.utc)),
+                },
+            )
+            portfolio = get_agent_challenge_portfolio(challenge["challenge_key"], self.agent_2)
+
+        self.assertEqual(result["trade"]["token_id"], "123456789")
+        self.assertEqual(result["trade"]["outcome"], "Yes")
+        self.assertEqual(result["trade"]["price"], 0.42)
+        self.assertTrue(portfolio["portfolio"]["marked_to_market"])
+        self.assertAlmostEqual(portfolio["portfolio"]["ending_value"], 1013.0)
+        self.assertAlmostEqual(portfolio["portfolio"]["return_pct"], 1.3)
+        self.assertEqual(portfolio["portfolio"]["positions"][0]["token_id"], "123456789")
+        self.assertEqual(portfolio["portfolio"]["live_marks"][0]["token_id"], "123456789")
+        self.assertEqual(mock_price.call_args_list[-1].kwargs["token_id"], "123456789")
+        self.assertEqual(mock_price.call_args_list[-1].kwargs["outcome"], "Yes")
 
     def test_active_leaderboard_marks_open_positions_to_market(self):
         challenge = self._create_active_challenge(challenge_key="live-mark-leaderboard")


### PR DESCRIPTION
## Summary
- require Polymarket challenge trades to resolve to an explicit outcome token and use server-side prices
- carry token_id/outcome through challenge portfolio scoring and live mark-to-market
- add challenge_trades token/outcome schema columns, exports, participant trade_count sync, and a repair script for legacy invalid Polymarket challenge trades

## Verification
- `python3 -m py_compile service/server/challenges.py service/server/challenge_scoring.py service/server/database.py service/server/routes_models.py service/server/research_exports.py service/server/scripts/repair_challenge_polymarket_trades.py`
- `python3 -m unittest service.server.tests.test_challenges service.server.tests.test_research_exports service.server.tests.test_realtime_trade_price_guard service.server.tests.test_agent_login_token_stability`