### PR TITLE
Add experiment challenge progress reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Supports all major AI agents, including OpenClaw, nanobot, Claude Code, Codex, C
 
 ## 🚀 Latest Updates:
 
+- **2026-06-11**: Improved **experiment/challenge progress tracking**. Expired active experiments now auto-complete on experiment reads, monthly challenges can be created with `MONTHLY_CHALLENGE_EXPERIMENT_KEY`, and the Experiment Console shows linked challenge performance by variant using the same live mark-to-market scoring as leaderboards.
 - **2026-06-08**: Added a **yfinance fallback for US stock prices**. AI-Trader still prefers Alpha Vantage when available, but automatically falls back to yfinance when Alpha Vantage is missing, rate-limited, or returns no usable price.
 - **2026-05-13**: Added **experiment notice exposure tracking** so agent-facing experiment prompts can be measured separately from explicit message reads.
 - **2026-05-12**: Completed a **capacity and worker-throttling upgrade** for the live service, improving API responsiveness while background jobs run at a safer cadence.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -37,6 +37,7 @@ Read https://ai4trade.ai/SKILL.md and register.
 
 ## 🚀 最新更新:
 
+- **2026-06-11**: 完善 **实验 / 比赛进度追踪**。已过期的 active 实验会在读取实验数据时自动转为 completed；月赛创建脚本支持通过 `MONTHLY_CHALLENGE_EXPERIMENT_KEY` 绑定实验；实验控制台会按 variant 展示已绑定挑战的参与率、交易数、实时浮盈/浮亏和回撤，评分口径与排行榜一致。
 - **2026-06-08**: 新增 **美股价格 yfinance fallback**。AI-Trader 仍优先使用 Alpha Vantage；当 Alpha Vantage 未配置、触发限流或没有返回可用价格时，会自动回退到 yfinance 获取美股价格。
 - **2026-05-13**: 新增 **实验通知曝光追踪**，可以将 Agent 看到实验提示与真正标记已读区分统计。
 - **2026-05-12**: 完成线上服务的 **容量升级与 worker 限速**，在后台任务以更安全节奏运行的同时提升 API 响应稳定性。

--- a/service/frontend/src/ExperimentAdminPage.tsx
+++ b/service/frontend/src/ExperimentAdminPage.tsx
@@ -21,6 +21,9 @@ const experimentMessageTypes = [
   'team_mission_invite'
 ]
 
+const formatPct = (value: any) => `${Number(value || 0).toFixed(2)}%`
+const formatNumber = (value: any) => Number(value || 0).toLocaleString()
+
 export function ExperimentAdminPage({ token }: ExperimentAdminPageProps) {
   const { language } = useLanguage()
   const [experiments, setExperiments] = useState<any[]>([])
@@ -28,6 +31,7 @@ export function ExperimentAdminPage({ token }: ExperimentAdminPageProps) {
   const [assignments, setAssignments] = useState<any[]>([])
   const [variantCounts, setVariantCounts] = useState<any[]>([])
   const [variantMetrics, setVariantMetrics] = useState<any[]>([])
+  const [challengeReport, setChallengeReport] = useState<any | null>(null)
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
   const [notificationBusy, setNotificationBusy] = useState(false)
@@ -86,11 +90,18 @@ export function ExperimentAdminPage({ token }: ExperimentAdminPageProps) {
       setVariantCounts(data.variant_counts || [])
       setVariantMetrics(data.variant_metrics || [])
       setNotificationForm((prev) => ({ ...prev, experiment_key: experimentKey }))
+      const reportRes = await fetch(`${API_BASE}/experiments/${experimentKey}/challenge-report`, {
+        headers: token ? { 'Authorization': `Bearer ${token}` } : {}
+      })
+      const reportData = await reportRes.json()
+      if (!reportRes.ok) throw new Error(reportData.detail || 'challenge_report_load_failed')
+      setChallengeReport(reportData)
     } catch (e) {
       console.error(e)
       setAssignments([])
       setVariantCounts([])
       setVariantMetrics([])
+      setChallengeReport(null)
     }
   }
 
@@ -452,6 +463,43 @@ export function ExperimentAdminPage({ token }: ExperimentAdminPageProps) {
               </div>
             ))}
           </div>
+          {challengeReport?.challenges?.length > 0 && (
+            <div className="experiment-challenge-reports">
+              {challengeReport.challenges.map((item: any) => (
+                <div key={item.challenge.challenge_key} className="experiment-challenge-report">
+                  <div className="experiment-challenge-title">
+                    <strong>{item.challenge.title}</strong>
+                    <span>{item.challenge.challenge_key}</span>
+                    <span>{item.provisional ? (language === 'zh' ? '实时口径' : 'Live marks') : (language === 'zh' ? '已结算' : 'Settled')}</span>
+                  </div>
+                  <div className="experiment-challenge-table">
+                    <div className="experiment-challenge-row experiment-challenge-row-head">
+                      <span>Variant</span>
+                      <span>{language === 'zh' ? '分配' : 'Assigned'}</span>
+                      <span>{language === 'zh' ? '参赛' : 'Joined'}</span>
+                      <span>{language === 'zh' ? '交易人数' : 'Traders'}</span>
+                      <span>{language === 'zh' ? '交易' : 'Trades'}</span>
+                      <span>{language === 'zh' ? '平均收益' : 'Avg return'}</span>
+                      <span>{language === 'zh' ? '最佳收益' : 'Best return'}</span>
+                      <span>{language === 'zh' ? '平均回撤' : 'Avg DD'}</span>
+                    </div>
+                    {item.variant_summary.map((row: any) => (
+                      <div key={`${item.challenge.challenge_key}-${row.variant_key}`} className="experiment-challenge-row">
+                        <strong>{row.variant_key}</strong>
+                        <span>{formatNumber(row.assigned_agent_count)}</span>
+                        <span>{formatNumber(row.participant_count)} <small>{formatPct(row.participation_rate_pct)}</small></span>
+                        <span>{formatNumber(row.trading_participant_count)} <small>{formatPct(row.trading_participation_rate_pct)}</small></span>
+                        <span>{formatNumber(row.trade_count)}</span>
+                        <span>{formatPct(row.avg_return_pct)}</span>
+                        <span>{formatPct(row.best_return_pct)}</span>
+                        <span>{formatPct(row.avg_max_drawdown_pct)}</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
           <div className="experiment-assignment-table">
             {assignments.slice(0, 60).map((assignment) => (
               <div key={assignment.id} className="experiment-assignment-row">

--- a/service/frontend/src/index.css
+++ b/service/frontend/src/index.css
@@ -3099,6 +3099,77 @@ a {
   line-height: 1.55;
 }
 
+.experiment-challenge-reports {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.experiment-challenge-report {
+  min-width: 0;
+}
+
+.experiment-challenge-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.experiment-challenge-title strong {
+  color: var(--text-primary);
+  font-size: 15px;
+}
+
+.experiment-challenge-title span {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 11px;
+}
+
+.experiment-challenge-table {
+  width: 100%;
+  overflow-x: auto;
+  border-top: 1px solid var(--border-color);
+}
+
+.experiment-challenge-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1.2fr) repeat(7, minmax(86px, 0.8fr));
+  gap: 10px;
+  align-items: center;
+  min-width: 820px;
+  padding: 11px 0;
+  border-bottom: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.experiment-challenge-row-head {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.experiment-challenge-row strong {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+}
+
+.experiment-challenge-row small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
 .experiment-assignment-row,
 .research-event-row {
   display: grid;

--- a/service/server/experiments.py
+++ b/service/server/experiments.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 from database import begin_write_transaction, get_db_connection
-from experiment_events import record_assignment_event
+from experiment_events import record_assignment_event, record_event
 from routes_shared import utc_now_iso_z
 
 
@@ -80,6 +81,15 @@ def _normalize_key(value: Optional[str], fallback: str) -> str:
     if not candidate:
         raise ExperimentError("experiment_key is required")
     return candidate[:90]
+
+
+def _parse_dt(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+    except Exception:
+        return None
 
 
 def _serialize_experiment(row: Any) -> dict[str, Any]:
@@ -190,6 +200,18 @@ def _rows_by_variant(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return {str(row.get("variant_key") or ""): row for row in rows}
 
 
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+    except Exception:
+        return default
+    return parsed if math.isfinite(parsed) else default
+
+
+def _avg(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
 def _experiment_behavior_metrics(cursor: Any, experiment_key: str, *, since: str) -> list[dict[str, Any]]:
     """Return recent behavior metrics by variant without depending on message read state."""
     behavior_placeholders = ",".join("?" for _ in EXPERIMENT_BEHAVIOR_EVENT_TYPES)
@@ -253,37 +275,80 @@ def _experiment_read_diagnostics(cursor: Any, experiment_key: str) -> list[dict[
     return [dict(row) for row in cursor.fetchall()]
 
 
+def refresh_experiment_statuses(cursor: Any, *, now: Optional[str] = None) -> int:
+    """Complete active experiments whose end time has elapsed."""
+    now_text = now or utc_now_iso_z()
+    cursor.execute(
+        """
+        SELECT experiment_key, end_at
+        FROM experiments
+        WHERE status = 'active' AND end_at IS NOT NULL AND end_at != '' AND end_at <= ?
+        """,
+        (now_text,),
+    )
+    expired = [dict(row) for row in cursor.fetchall()]
+    if not expired:
+        return 0
+
+    cursor.execute(
+        """
+        UPDATE experiments
+        SET status = 'completed', updated_at = ?
+        WHERE status = 'active' AND end_at IS NOT NULL AND end_at != '' AND end_at <= ?
+        """,
+        (now_text, now_text),
+    )
+    for row in expired:
+        record_event(
+            "experiment_completed",
+            object_type="experiment",
+            object_id=row["experiment_key"],
+            experiment_key=row["experiment_key"],
+            metadata={"reason": "end_at_elapsed", "end_at": row.get("end_at")},
+            cursor=cursor,
+        )
+    return len(expired)
+
+
 def agent_experiment_behavior_context(agent_id: int) -> Optional[dict[str, Any]]:
     """Return active experiment context for high-frequency agent APIs without enrolling new agents."""
     now = utc_now_iso_z()
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute(
-        """
-        SELECT
-            e.experiment_key,
-            e.title,
-            e.description,
-            e.status,
-            e.unit_type,
-            e.start_at,
-            e.end_at,
-            ea.variant_key,
-            ea.assignment_reason,
-            ea.created_at AS assignment_created_at
-        FROM experiment_assignments ea
-        JOIN experiments e ON e.experiment_key = ea.experiment_key
-        WHERE ea.unit_type = 'agent'
-          AND ea.unit_id = ?
-          AND e.status = 'active'
-          AND (e.start_at IS NULL OR e.start_at <= ?)
-          AND (e.end_at IS NULL OR e.end_at >= ?)
-        ORDER BY e.created_at DESC, e.id DESC
-        """,
-        (agent_id, now, now),
-    )
-    rows = [dict(row) for row in cursor.fetchall()]
-    conn.close()
+    try:
+        begin_write_transaction(cursor)
+        refresh_experiment_statuses(cursor, now=now)
+        conn.commit()
+        cursor.execute(
+            """
+            SELECT
+                e.experiment_key,
+                e.title,
+                e.description,
+                e.status,
+                e.unit_type,
+                e.start_at,
+                e.end_at,
+                ea.variant_key,
+                ea.assignment_reason,
+                ea.created_at AS assignment_created_at
+            FROM experiment_assignments ea
+            JOIN experiments e ON e.experiment_key = ea.experiment_key
+            WHERE ea.unit_type = 'agent'
+              AND ea.unit_id = ?
+              AND e.status = 'active'
+              AND (e.start_at IS NULL OR e.start_at <= ?)
+              AND (e.end_at IS NULL OR e.end_at >= ?)
+            ORDER BY e.created_at DESC, e.id DESC
+            """,
+            (agent_id, now, now),
+        )
+        rows = [dict(row) for row in cursor.fetchall()]
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
     if not rows:
         return None
 
@@ -390,24 +455,37 @@ def list_experiments(status: Optional[str] = None, limit: int = 100, offset: int
 
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute(f"SELECT COUNT(*) AS total FROM experiments WHERE {where}", params)
-    total = cursor.fetchone()["total"]
-    cursor.execute(
-        f"""
-        SELECT *
-        FROM experiments
-        WHERE {where}
-        ORDER BY created_at DESC, id DESC
-        LIMIT ? OFFSET ?
-        """,
-        params + [limit, offset],
-    )
-    experiments = [_serialize_experiment(row) for row in cursor.fetchall()]
-    conn.close()
-    return {"experiments": experiments, "total": total, "limit": limit, "offset": offset}
+    try:
+        begin_write_transaction(cursor)
+        refresh_experiment_statuses(cursor)
+        conn.commit()
+        cursor.execute(f"SELECT COUNT(*) AS total FROM experiments WHERE {where}", params)
+        total = cursor.fetchone()["total"]
+        cursor.execute(
+            f"""
+            SELECT *
+            FROM experiments
+            WHERE {where}
+            ORDER BY created_at DESC, id DESC
+            LIMIT ? OFFSET ?
+            """,
+            params + [limit, offset],
+        )
+        experiments = [_serialize_experiment(row) for row in cursor.fetchall()]
+        return {"experiments": experiments, "total": total, "limit": limit, "offset": offset}
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
 
-def get_active_experiments(unit_type: Optional[str] = None, *, now: Optional[str] = None) -> list[dict[str, Any]]:
+def get_active_experiments(
+    unit_type: Optional[str] = None,
+    *,
+    now: Optional[str] = None,
+    refresh_statuses: bool = True,
+) -> list[dict[str, Any]]:
     now = now or utc_now_iso_z()
     conditions = ["status = 'active'", "(start_at IS NULL OR start_at <= ?)", "(end_at IS NULL OR end_at >= ?)"]
     params: list[Any] = [now, now]
@@ -417,18 +495,27 @@ def get_active_experiments(unit_type: Optional[str] = None, *, now: Optional[str
 
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute(
-        f"""
-        SELECT *
-        FROM experiments
-        WHERE {' AND '.join(conditions)}
-        ORDER BY created_at DESC, id DESC
-        """,
-        params,
-    )
-    experiments = [_serialize_experiment(row) for row in cursor.fetchall()]
-    conn.close()
-    return experiments
+    try:
+        if refresh_statuses:
+            begin_write_transaction(cursor)
+            refresh_experiment_statuses(cursor, now=now)
+            conn.commit()
+        cursor.execute(
+            f"""
+            SELECT *
+            FROM experiments
+            WHERE {' AND '.join(conditions)}
+            ORDER BY created_at DESC, id DESC
+            """,
+            params,
+        )
+        experiments = [_serialize_experiment(row) for row in cursor.fetchall()]
+        return experiments
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
 
 def get_assignment(experiment_key: str, unit_type: str, unit_id: int | str) -> Optional[dict[str, Any]]:
@@ -464,11 +551,22 @@ def assign_unit_to_experiment(
     cursor = conn.cursor()
     try:
         begin_write_transaction(cursor)
+        refresh_experiment_statuses(cursor)
         cursor.execute("SELECT * FROM experiments WHERE experiment_key = ?", (experiment_key,))
         experiment = cursor.fetchone()
         if not experiment:
             raise ExperimentError("Experiment not found")
         experiment_data = _serialize_experiment(experiment)
+        now = utc_now_iso_z()
+        starts_at = _parse_dt(experiment_data.get("start_at"))
+        ends_at = _parse_dt(experiment_data.get("end_at"))
+        now_dt = _parse_dt(now) or datetime.now(timezone.utc)
+        if experiment_data.get("status") != "active":
+            raise ExperimentError("Experiment is not active")
+        if starts_at and starts_at > now_dt:
+            raise ExperimentError("Experiment has not started")
+        if ends_at and ends_at <= now_dt:
+            raise ExperimentError("Experiment has ended")
         variants = experiment_data["variants"]
         if not experiment_accepts_unit(experiment_data, unit_type, unit_id):
             raise ExperimentError(f"Experiment enrollment is closed for {unit_type} {unit_id}")
@@ -529,6 +627,14 @@ def get_experiment_assignments(experiment_key: str, limit: int = 1000, offset: i
     offset = max(0, offset)
     conn = get_db_connection()
     cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        refresh_experiment_statuses(cursor)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        conn.close()
+        raise
     cursor.execute("SELECT * FROM experiments WHERE experiment_key = ?", (experiment_key,))
     experiment_row = cursor.fetchone()
     if not experiment_row:
@@ -638,6 +744,175 @@ def get_experiment_assignments(experiment_key: str, limit: int = 1000, offset: i
         "limit": limit,
         "offset": offset,
     }
+
+
+def get_experiment_challenge_report(
+    experiment_key: str,
+    *,
+    challenge_key: Optional[str] = None,
+) -> dict[str, Any]:
+    """Return linked challenge performance grouped by experiment variant."""
+    from challenges import (
+        _fetch_participants_and_trades,
+        _score_challenge_results_with_live_marks,
+        _serialize_challenge,
+    )
+
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    try:
+        begin_write_transaction(cursor)
+        refresh_experiment_statuses(cursor)
+        conn.commit()
+
+        cursor.execute("SELECT * FROM experiments WHERE experiment_key = ?", (experiment_key,))
+        experiment_row = cursor.fetchone()
+        if not experiment_row:
+            raise ExperimentError("Experiment not found")
+        experiment = _serialize_experiment(experiment_row)
+
+        cursor.execute(
+            """
+            SELECT unit_id, variant_key
+            FROM experiment_assignments
+            WHERE experiment_key = ? AND unit_type = 'agent'
+            """,
+            (experiment_key,),
+        )
+        assignments_by_agent = {int(row["unit_id"]): row["variant_key"] for row in cursor.fetchall()}
+        assigned_counts: dict[str, int] = {}
+        for variant_key in assignments_by_agent.values():
+            assigned_counts[variant_key] = assigned_counts.get(variant_key, 0) + 1
+
+        params: list[Any] = [experiment_key]
+        challenge_filter = ""
+        if challenge_key:
+            challenge_filter = "AND challenge_key = ?"
+            params.append(challenge_key)
+        cursor.execute(
+            f"""
+            SELECT *
+            FROM challenges
+            WHERE experiment_key = ?
+              {challenge_filter}
+            ORDER BY start_at DESC, id DESC
+            """,
+            params,
+        )
+        challenge_rows = [dict(row) for row in cursor.fetchall()]
+
+        variant_order = [str(variant.get("key")) for variant in experiment.get("variants", []) if variant.get("key")]
+        for variant_key in sorted(assigned_counts):
+            if variant_key not in variant_order:
+                variant_order.append(variant_key)
+
+        challenge_reports = []
+        for challenge in challenge_rows:
+            participants, trades_by_agent = _fetch_participants_and_trades(cursor, challenge["id"])
+            scored_results = _score_challenge_results_with_live_marks(challenge, participants, trades_by_agent)
+            participants_by_agent = {int(row["agent_id"]): row for row in participants}
+
+            by_variant: dict[str, dict[str, Any]] = {}
+
+            def ensure_variant(variant_key: Optional[str]) -> dict[str, Any]:
+                resolved = (variant_key or "").strip() or "unassigned"
+                if resolved not in by_variant:
+                    by_variant[resolved] = {
+                        "variant_key": resolved,
+                        "assigned_agent_count": assigned_counts.get(resolved, 0),
+                        "participant_count": 0,
+                        "trading_participant_count": 0,
+                        "trade_count": 0,
+                        "ranked_count": 0,
+                        "disqualified_count": 0,
+                        "return_values": [],
+                        "drawdown_values": [],
+                        "score_values": [],
+                        "ranks": [],
+                    }
+                return by_variant[resolved]
+
+            for variant_key in variant_order:
+                ensure_variant(variant_key)
+
+            for result in scored_results:
+                agent_id = int(result.get("agent_id") or 0)
+                participant = participants_by_agent.get(agent_id, {})
+                variant_key = participant.get("variant_key") or assignments_by_agent.get(agent_id) or "unassigned"
+                if variant_key not in variant_order:
+                    variant_order.append(variant_key)
+                row = ensure_variant(variant_key)
+                trade_count = int(result.get("trade_count") or 0)
+                row["participant_count"] += 1
+                row["trade_count"] += trade_count
+                if trade_count > 0:
+                    row["trading_participant_count"] += 1
+                if result.get("disqualified_reason"):
+                    row["disqualified_count"] += 1
+                if result.get("rank") is not None:
+                    row["ranked_count"] += 1
+                    row["ranks"].append(int(result["rank"]))
+                if result.get("final_score") is not None:
+                    row["score_values"].append(_safe_float(result.get("final_score")))
+                row["return_values"].append(_safe_float(result.get("return_pct")))
+                row["drawdown_values"].append(_safe_float(result.get("max_drawdown")))
+
+            variant_summary = []
+            for variant_key in variant_order:
+                row = ensure_variant(variant_key)
+                participant_count = int(row["participant_count"])
+                assigned_count = int(row["assigned_agent_count"])
+                disqualified_count = int(row["disqualified_count"])
+                returns = row.pop("return_values")
+                drawdowns = row.pop("drawdown_values")
+                scores = row.pop("score_values")
+                ranks = row.pop("ranks")
+                row.update({
+                    "participation_rate_pct": (participant_count / assigned_count * 100) if assigned_count else 0.0,
+                    "trading_participation_rate_pct": (row["trading_participant_count"] / participant_count * 100) if participant_count else 0.0,
+                    "disqualification_rate_pct": (disqualified_count / participant_count * 100) if participant_count else 0.0,
+                    "avg_return_pct": _avg(returns),
+                    "best_return_pct": max(returns) if returns else 0.0,
+                    "worst_return_pct": min(returns) if returns else 0.0,
+                    "avg_max_drawdown_pct": _avg(drawdowns),
+                    "max_drawdown_pct": max(drawdowns) if drawdowns else 0.0,
+                    "avg_final_score": _avg(scores),
+                    "best_final_score": max(scores) if scores else None,
+                    "best_rank": min(ranks) if ranks else None,
+                })
+                variant_summary.append(row)
+
+            totals = {
+                "assigned_agent_count": sum(row["assigned_agent_count"] for row in variant_summary),
+                "participant_count": sum(row["participant_count"] for row in variant_summary),
+                "trading_participant_count": sum(row["trading_participant_count"] for row in variant_summary),
+                "trade_count": sum(row["trade_count"] for row in variant_summary),
+                "ranked_count": sum(row["ranked_count"] for row in variant_summary),
+                "disqualified_count": sum(row["disqualified_count"] for row in variant_summary),
+            }
+            totals["participation_rate_pct"] = (
+                totals["participant_count"] / totals["assigned_agent_count"] * 100
+                if totals["assigned_agent_count"]
+                else 0.0
+            )
+            challenge_reports.append({
+                "challenge": _serialize_challenge(challenge, participant_count=len(participants)),
+                "variant_summary": variant_summary,
+                "totals": totals,
+                "provisional": challenge.get("status") != "settled",
+            })
+
+        return {
+            "experiment": experiment,
+            "challenge_count": len(challenge_reports),
+            "report_generated_at": utc_now_iso_z(),
+            "challenges": challenge_reports,
+        }
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
 
 
 def update_experiment_status(experiment_key: str, status: str) -> dict[str, Any]:

--- a/service/server/routes_experiments.py
+++ b/service/server/routes_experiments.py
@@ -29,6 +29,7 @@ from experiments import (
     assign_unit_to_experiment,
     create_experiment,
     get_experiment_assignments,
+    get_experiment_challenge_report,
     list_experiments,
     update_experiment_status,
     variant_for_agent,
@@ -151,6 +152,21 @@ def register_experiment_routes(app: FastAPI, ctx: RouteContext) -> None:
         require_capability(authorization, EXPERIMENT_ADMIN_CAPABILITY)
         try:
             return get_experiment_assignments(experiment_key, limit=limit, offset=offset)
+        except Exception as exc:
+            raise _to_http_error(exc)
+
+    @app.get("/api/experiments/{experiment_key}/challenge-report")
+    async def api_experiment_challenge_report(
+        experiment_key: str,
+        challenge_key: str | None = None,
+        authorization: str = Header(None),
+    ):
+        require_any_capability(
+            authorization,
+            (EXPERIMENT_ADMIN_CAPABILITY, RESEARCH_EXPORTS_CAPABILITY),
+        )
+        try:
+            return get_experiment_challenge_report(experiment_key, challenge_key=challenge_key)
         except Exception as exc:
             raise _to_http_error(exc)
 

--- a/service/server/routes_signals.py
+++ b/service/server/routes_signals.py
@@ -60,7 +60,7 @@ def _variant_config(experiment: dict[str, Any], variant_key: str | None) -> dict
 def _agent_experiment_context(agent_id: int) -> list[dict[str, Any]]:
     contexts = []
     try:
-        for experiment in get_active_experiments('agent'):
+        for experiment in get_active_experiments('agent', refresh_statuses=False):
             if not experiment_accepts_unit(experiment, 'agent', agent_id):
                 continue
             assignment = variant_for_agent(agent_id, experiment['experiment_key'])
@@ -393,7 +393,6 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
         try:
             conn = get_db_connection()
             cursor = conn.cursor()
-            begin_write_transaction(cursor)
             cursor.execute(
                 """
                 SELECT follower_id FROM subscriptions
@@ -401,10 +400,14 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                 """,
                 (agent_id,),
             )
-            followers = cursor.fetchall()
+            follower_ids = [row['follower_id'] for row in cursor.fetchall()]
+            conn.close()
+            follower_contexts = {follower_id: _primary_experiment_context(follower_id) for follower_id in follower_ids}
 
-            for follower in followers:
-                follower_id = follower['follower_id']
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            begin_write_transaction(cursor)
+            for follower_id in follower_ids:
                 try:
                     cursor.execute(f'SAVEPOINT follower_{follower_id}')
                     follower_position = None
@@ -498,7 +501,7 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
                         },
                         cursor=cursor,
                     )
-                    follower_context = _primary_experiment_context(follower_id)
+                    follower_context = follower_contexts.get(follower_id)
                     follower_experiment_key, follower_variant_key = _context_keys(follower_context)
                     record_signal_event(
                         'signal_published',

--- a/service/server/scripts/monthly_challenges.py
+++ b/service/server/scripts/monthly_challenges.py
@@ -136,9 +136,10 @@ def build_payload(
     max_position_pct: float,
     max_drawdown_pct: float,
     scoring_method: str,
+    experiment_key: str = "",
 ) -> dict[str, Any]:
     month_label = f"{calendar.month_name[start.month]} {start.year}"
-    return {
+    payload = {
         "challenge_key": challenge_key_for(track, start),
         "title": f"{month_label} {track.title} Monthly Challenge",
         "description": f"Auto-created monthly {track.market} track competition for {start:%Y-%m}.",
@@ -157,6 +158,9 @@ def build_payload(
             "reward_points": {"1": 100, "2": 50, "3": 25},
         },
     }
+    if experiment_key:
+        payload["experiment_key"] = experiment_key
+    return payload
 
 
 def ensure_month(
@@ -169,6 +173,7 @@ def ensure_month(
     max_position_pct: float = DEFAULT_MAX_POSITION_PCT,
     max_drawdown_pct: float = DEFAULT_MAX_DRAWDOWN_PCT,
     scoring_method: str = DEFAULT_SCORING_METHOD,
+    experiment_key: str = "",
 ) -> list[dict[str, Any]]:
     local_now = now.astimezone(tz)
     start = month_start(local_now)
@@ -190,6 +195,7 @@ def ensure_month(
             max_position_pct=max_position_pct,
             max_drawdown_pct=max_drawdown_pct,
             scoring_method=scoring_method,
+            experiment_key=experiment_key,
         )
         if dry_run:
             results.append({"challenge_key": key, "market": track.market, "status": "dry-run", "payload": payload})
@@ -218,6 +224,7 @@ def run_once(args: argparse.Namespace) -> list[dict[str, Any]]:
         max_position_pct=args.max_position_pct,
         max_drawdown_pct=args.max_drawdown_pct,
         scoring_method=args.scoring_method,
+        experiment_key=args.experiment_key,
     )
 
 
@@ -256,6 +263,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--max-position-pct", type=float, default=float(os.getenv("MONTHLY_CHALLENGE_MAX_POSITION_PCT", DEFAULT_MAX_POSITION_PCT)))
     parser.add_argument("--max-drawdown-pct", type=float, default=float(os.getenv("MONTHLY_CHALLENGE_MAX_DRAWDOWN_PCT", DEFAULT_MAX_DRAWDOWN_PCT)))
     parser.add_argument("--scoring-method", default=os.getenv("MONTHLY_CHALLENGE_SCORING_METHOD", DEFAULT_SCORING_METHOD))
+    parser.add_argument("--experiment-key", default=os.getenv("MONTHLY_CHALLENGE_EXPERIMENT_KEY", ""))
     parser.add_argument("--retry-seconds", type=int, default=int(os.getenv("MONTHLY_CHALLENGE_RETRY_SECONDS", "3600")))
     parser.add_argument(
         "--no-catch-up-current-month",

--- a/service/server/tests/test_experiment_assignments.py
+++ b/service/server/tests/test_experiment_assignments.py
@@ -2,7 +2,9 @@ import os
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 
 SERVER_DIR = Path(__file__).resolve().parents[1]
@@ -14,10 +16,13 @@ from experiments import (
     ExperimentError,
     assign_unit_to_experiment,
     create_experiment,
+    get_experiment_challenge_report,
     get_experiment_assignments,
+    list_experiments,
     stable_bucket,
     variant_for_agent,
 )
+from challenges import create_challenge, create_challenge_trade, join_challenge
 from routes_shared import utc_now_iso_z
 
 
@@ -46,6 +51,23 @@ class ExperimentAssignmentTests(unittest.TestCase):
         conn.commit()
         conn.close()
         return agent_id
+
+    def _iso(self, value: datetime) -> str:
+        return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    def _insert_assignment(self, experiment_key: str, agent_id: int, variant_key: str) -> None:
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO experiment_assignments
+            (experiment_key, unit_type, unit_id, variant_key, assignment_reason, metadata_json, created_at)
+            VALUES (?, 'agent', ?, ?, 'test_fixture', '{}', ?)
+            """,
+            (experiment_key, agent_id, variant_key, utc_now_iso_z()),
+        )
+        conn.commit()
+        conn.close()
 
     def test_same_agent_stably_assigns_to_same_variant(self):
         create_experiment({
@@ -184,6 +206,98 @@ class ExperimentAssignmentTests(unittest.TestCase):
         )
         self.assertEqual(cursor.fetchone()["count"], 0)
         conn.close()
+
+    def test_expired_active_experiment_auto_completes_on_list(self):
+        ended_at = self._iso(datetime.now(timezone.utc) - timedelta(days=1))
+        create_experiment({
+            "experiment_key": "expired-exp",
+            "title": "Expired experiment",
+            "status": "active",
+            "end_at": ended_at,
+            "variants_json": [{"key": "control", "weight": 1}, {"key": "treatment", "weight": 1}],
+        })
+
+        active = list_experiments(status="active")
+        self.assertNotIn("expired-exp", {row["experiment_key"] for row in active["experiments"]})
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT status FROM experiments WHERE experiment_key = 'expired-exp'")
+        self.assertEqual(cursor.fetchone()["status"], "completed")
+        cursor.execute(
+            """
+            SELECT COUNT(*) AS count
+            FROM experiment_events
+            WHERE experiment_key = 'expired-exp' AND event_type = 'experiment_completed'
+            """
+        )
+        self.assertEqual(cursor.fetchone()["count"], 1)
+        conn.close()
+
+    def test_challenge_report_groups_live_leaderboard_by_variant(self):
+        now = datetime.now(timezone.utc)
+        create_experiment({
+            "experiment_key": "challenge-report-exp",
+            "title": "Challenge report experiment",
+            "variants_json": [{"key": "control", "weight": 1}, {"key": "treatment", "weight": 1}],
+        })
+        self._insert_assignment("challenge-report-exp", self.agent_ids[0], "control")
+        self._insert_assignment("challenge-report-exp", self.agent_ids[1], "treatment")
+
+        create_challenge(
+            {
+                "challenge_key": "variant-report-challenge",
+                "title": "Variant report challenge",
+                "market": "crypto",
+                "symbol": "all",
+                "experiment_key": "challenge-report-exp",
+                "initial_capital": 1000.0,
+                "max_position_pct": 100.0,
+                "start_at": self._iso(now - timedelta(hours=1)),
+                "end_at": self._iso(now + timedelta(hours=1)),
+            },
+            self.agent_ids[0],
+        )
+        join_challenge("variant-report-challenge", self.agent_ids[0])
+        join_challenge("variant-report-challenge", self.agent_ids[1])
+
+        with patch("challenges._fetch_authoritative_challenge_trade_price", side_effect=[100.0, 110.0]):
+            create_challenge_trade(
+                "variant-report-challenge",
+                self.agent_ids[0],
+                {
+                    "side": "buy",
+                    "symbol": "BTC",
+                    "price": 1.0,
+                    "quantity": 1.0,
+                    "executed_at": self._iso(now),
+                },
+            )
+            create_challenge_trade(
+                "variant-report-challenge",
+                self.agent_ids[0],
+                {
+                    "side": "sell",
+                    "symbol": "BTC",
+                    "price": 1.0,
+                    "quantity": 1.0,
+                    "executed_at": self._iso(now + timedelta(minutes=1)),
+                },
+            )
+
+        report = get_experiment_challenge_report("challenge-report-exp")
+        challenge_report = report["challenges"][0]
+        rows = {row["variant_key"]: row for row in challenge_report["variant_summary"]}
+
+        self.assertEqual(report["challenge_count"], 1)
+        self.assertEqual(rows["control"]["assigned_agent_count"], 1)
+        self.assertEqual(rows["control"]["participant_count"], 1)
+        self.assertEqual(rows["control"]["trading_participant_count"], 1)
+        self.assertEqual(rows["control"]["trade_count"], 2)
+        self.assertAlmostEqual(rows["control"]["avg_return_pct"], 1.0)
+        self.assertEqual(rows["treatment"]["assigned_agent_count"], 1)
+        self.assertEqual(rows["treatment"]["participant_count"], 1)
+        self.assertEqual(rows["treatment"]["trade_count"], 0)
 
 
 if __name__ == "__main__":

--- a/service/server/tests/test_monthly_challenges.py
+++ b/service/server/tests/test_monthly_challenges.py
@@ -80,6 +80,20 @@ class MonthlyChallengeScriptTests(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             ensure_month(now, tz, creator_identifier="not-admin")
 
+    def test_ensure_month_applies_experiment_key(self):
+        tz = ZoneInfo("Asia/Shanghai")
+        now = datetime(2026, 6, 3, 10, 0, tzinfo=tz)
+
+        ensure_month(now, tz, creator_identifier="admin_ai-trader", experiment_key="monthly-exp")
+
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT DISTINCT experiment_key FROM challenges")
+        rows = cursor.fetchall()
+        conn.close()
+
+        self.assertEqual({row["experiment_key"] for row in rows}, {"monthly-exp"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Auto-complete expired active experiments when experiment data is read
- Add an experiment challenge report endpoint and Experiment Console variant summary using live leaderboard mark-to-market scoring
- Allow monthly challenge creation to bind an experiment via MONTHLY_CHALLENGE_EXPERIMENT_KEY
- Avoid SQLite nested-write locking when signal copy attribution reads experiment context

## Verification
- `python3 -m unittest service.server.tests.test_experiment_assignments service.server.tests.test_monthly_challenges service.server.tests.test_agent_registration_experiments service.server.tests.test_experiment_notifications service.server.tests.test_experiment_events service.server.tests.test_challenges`
- `npm run build`

## Data note
Production data linking for the current June 2026 monthly challenges was applied separately and is intentionally not committed.