### PR TITLE
Fix frontend build output permissions

### DIFF
--- a/service/frontend/package.json
+++ b/service/frontend/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "postbuild": "chmod -R a+rX dist",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Add a frontend postbuild step that makes Vite dist files readable by Nginx
- Prevent strict production umask settings from generating 403 Forbidden responses after rebuilds

## Verification
- `umask 0077 && npm run build`
- Confirmed generated `dist` directories are 755 and files are 644
- Confirmed https://ai4trade.ai/ and the built JS asset return 200 in production after applying the same fix