### PR TITLE
Rank only traded challenge participants

### DIFF
--- a/service/server/challenge_scoring.py
+++ b/service/server/challenge_scoring.py
@@ -266,7 +266,7 @@ def score_agent_trades(
         'max_drawdown': max_drawdown,
         'risk_adjusted_score': risk_adjusted_score,
         'quality_score': 0.0,
-        'final_score': None if disqualified_reason else final_score,
+        'final_score': None if disqualified_reason or not ordered_trades else final_score,
         'trade_count': len(ordered_trades),
         'disqualified_reason': disqualified_reason,
         'metrics': metrics,
@@ -277,7 +277,11 @@ def rank_scored_results(scored_results: list[dict[str, Any]]) -> list[dict[str, 
     ranked_candidates = [
         result
         for result in scored_results
-        if not result.get('disqualified_reason') and result.get('final_score') is not None
+        if (
+            not result.get('disqualified_reason')
+            and result.get('final_score') is not None
+            and int(result.get('trade_count') or 0) > 0
+        )
     ]
     ranked_candidates.sort(key=lambda item: item['final_score'], reverse=True)
     rank_by_agent = {item['agent_id']: index + 1 for index, item in enumerate(ranked_candidates)}

--- a/service/server/tests/test_challenges.py
+++ b/service/server/tests/test_challenges.py
@@ -322,6 +322,24 @@ class ChallengeTests(unittest.TestCase):
         self.assertTrue(marked_row["metrics"]["marked_to_market"])
         self.assertEqual(marked_row["metrics"]["live_marks"][0]["price"], 90.0)
 
+    def test_zero_trade_participants_do_not_rank_above_traders(self):
+        challenge = self._create_active_challenge(challenge_key="zero-trade-unranked")
+        join_challenge(challenge["challenge_key"], self.agent_2)
+        join_challenge(challenge["challenge_key"], self.agent_3)
+        self._submit_challenge_trade(challenge["challenge_key"], self.agent_2, "buy", 100.0, 10.0)
+        self._submit_challenge_trade(challenge["challenge_key"], self.agent_2, "sell", 90.0, 10.0)
+
+        result = get_challenge_leaderboard(challenge["challenge_key"])
+        trader = next(row for row in result["leaderboard"] if row["agent_id"] == self.agent_2)
+        inactive = next(row for row in result["leaderboard"] if row["agent_id"] == self.agent_3)
+
+        self.assertEqual(result["leaderboard"][0]["agent_id"], self.agent_2)
+        self.assertEqual(trader["rank"], 1)
+        self.assertLess(trader["return_pct"], 0)
+        self.assertIsNone(inactive["rank"])
+        self.assertIsNone(inactive["final_score"])
+        self.assertEqual(inactive["trade_count"], 0)
+
     def test_active_leaderboard_ignores_stale_results_and_marks_to_market(self):
         challenge = self._create_active_challenge(challenge_key="live-mark-stale-results")
         join_challenge(challenge["challenge_key"], self.agent_2)


### PR DESCRIPTION
## Summary
- Exclude zero-trade challenge participants from ranking candidates
- Return null final_score for participants with no trades so inactive entrants cannot outrank real traders
- Add regression coverage for a negative-return trader ranking above a zero-trade participant

## Verification
- `python3 -m unittest service.server.tests.test_challenges`
- Verified production monthly US stock leaderboard now starts with traded participants instead of zero-trade 0% rows