### PR TITLE
Fix Polymarket best bid ask pricing

### DIFF
--- a/service/server/price_fetcher.py
+++ b/service/server/price_fetcher.py
@@ -482,19 +482,28 @@ def _get_polymarket_mid_price(reference: str, token_id: Optional[str] = None, ou
         bids = data.get("bids") if isinstance(data.get("bids"), list) else []
         asks = data.get("asks") if isinstance(data.get("asks"), list) else []
 
-        def _best_px(levels: list) -> Optional[float]:
-            if not levels:
-                return None
-            first = levels[0]
-            if isinstance(first, dict) and "price" in first:
-                try:
-                    return float(first["price"])
-                except Exception:
-                    return None
-            return None
+        def _level_prices(levels: list) -> list[float]:
+            prices = []
+            for level in levels:
+                if isinstance(level, dict) and "price" in level:
+                    try:
+                        price = float(level["price"])
+                    except Exception:
+                        continue
+                    if _polymarket_price_valid(price):
+                        prices.append(price)
+            return prices
 
-        best_bid = _best_px(bids)
-        best_ask = _best_px(asks)
+        def _best_bid(levels: list) -> Optional[float]:
+            prices = _level_prices(levels)
+            return max(prices) if prices else None
+
+        def _best_ask(levels: list) -> Optional[float]:
+            prices = _level_prices(levels)
+            return min(prices) if prices else None
+
+        best_bid = _best_bid(bids)
+        best_ask = _best_ask(asks)
         if best_bid is not None or best_ask is not None:
             mid = (best_bid + best_ask) / 2 if (best_bid is not None and best_ask is not None) else (best_bid if best_bid is not None else best_ask)
             mid = float(f"{mid:.6f}")

--- a/service/server/tests/test_price_fetcher.py
+++ b/service/server/tests/test_price_fetcher.py
@@ -96,6 +96,29 @@ class UsStockPriceTimezoneTests(unittest.TestCase):
         mock_alpha.assert_not_called()
         mock_yfinance.assert_called_once_with("AAPL", "2025-08-01T14:30:00Z")
 
+    def test_polymarket_mid_price_uses_best_bid_and_ask_from_unsorted_book(self) -> None:
+        book = {
+            "bids": [
+                {"price": "0.001", "size": "1000"},
+                {"price": "0.41", "size": "1000"},
+                {"price": "0.421", "size": "1000"},
+            ],
+            "asks": [
+                {"price": "0.999", "size": "1000"},
+                {"price": "0.45", "size": "1000"},
+                {"price": "0.422", "size": "1000"},
+            ],
+        }
+
+        with patch.object(
+            price_fetcher,
+            "_polymarket_resolve_reference",
+            return_value={"token_id": "123", "outcome": "Yes", "market": {}},
+        ), patch.object(price_fetcher, "_polymarket_get_json", return_value=book):
+            price = price_fetcher._get_polymarket_mid_price("market-slug", token_id="123", outcome="Yes")
+
+        self.assertEqual(price, 0.4215)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- derive Polymarket CLOB marks from the true best bid and ask instead of assuming the first book level is best
- add a regression test for unsorted Polymarket order books

## Verification
- `python3 -m py_compile service/server/price_fetcher.py`
- `python3 -m unittest service.server.tests.test_price_fetcher service.server.tests.test_challenges`

## Production check
- verified `monthly-2026-06-polymarket` now marks Hemry-Trader at `0.4215`, producing return `-0.923474%` instead of `0.0%`.