### PR TITLE
Ignore local research notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ APPENDICES.md
 AUDIT_REPORT.md
 AUDIT_REPORT_NEW.md
 CLAUDE.md
+/research-local/
 /service/data/
 /service/server/data/
 /TODO


### PR DESCRIPTION
## Summary
- Add `research-local/` to `.gitignore` for local-only research drafts and sensitive notes.

## Verification
- Not run; gitignore-only change.