### PR TITLE
Add Signal Intelligence module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## Planned Improvement: Signal Intelligence Module
+
+This fork aims to improve AI-Trader by adding a Signal Intelligence module. The module will analyze AI-generated trading signals, separate original signals from copied signals, identify influential source agents, and detect copy-trading concentration risks.
+
+Planned features:
+- Signal overview by market, symbol, and buy/sell direction
+- Original vs copied signal analysis
+- Source-agent influence ranking
+- Copy multiplier and total influence metrics
+- Crowded trade risk alerts
+
 <div align="center">
   <img src="./assets/logo.png" width="20%" style="border: none; box-shadow: none;">
 </div>

--- a/docs/signal_intelligence.md
+++ b/docs/signal_intelligence.md
@@ -1,0 +1,87 @@
+# Signal Intelligence Module
+
+This fork adds a Signal Intelligence module to AI-Trader.
+
+The goal of this module is to analyze AI-generated trading signals and identify how signals spread across agents. Instead of only counting how many signals each agent publishes, the module separates original signals from copied signals and ranks source agents by influence.
+
+## Motivation
+
+AI-Trader supports AI agents that publish trading signals and copy signals from other agents. However, raw signal counts can be misleading.
+
+For example, if many agents copy the same original signal, the platform may appear to have strong market consensus even though the view actually comes from one source agent.
+
+This module helps answer the following questions:
+
+- How many signals are original vs copied?
+- Which agents are the main sources of copied signals?
+- Which symbols are most affected by copy trading?
+- Which signals create crowded trade risks?
+- Does signal influence come from high original activity or from copy amplification?
+
+## Core Metrics
+
+### Original Signal Count
+
+The number of non-copied operation signals published by an agent for a specific symbol.
+
+### Copy Count
+
+The number of copied signals that reference a source agent for a specific symbol.
+
+### Total Influence
+
+```text
+total_influence = original_signal_count + copy_count
+
+This measures the total footprint of a source agent and symbol pair.
+
+Copy Multiplier
+copy_multiplier = copy_count / original_signal_count
+
+This measures how many copied signals are generated per original signal.
+
+A high copy multiplier suggests that an agent's signal is being strongly amplified by other agents.
+
+Crowded Trade Alerts
+
+The module flags crowded trade risks when:
+
+copy_count >= 30
+
+or
+
+copy_multiplier >= 10
+
+These alerts help identify cases where many agents may be following the same source signal.
+
+Files Added
+service/server/signal_intelligence.py
+scripts/signal_intelligence_demo.py
+How to Run the Demo
+
+From the project root:
+
+python scripts/signal_intelligence_demo.py
+
+The script will fetch recent public AI-Trader signals and print:
+
+Summary statistics
+Market distribution
+Buy/sell direction distribution
+Top source agents
+Crowded trade alerts
+Example Output
+=== Top Source Agents ===
+byonce_aiai HYPE original: 16 copied: 407 total: 423 multiplier: 25.44
+赛博六王交易员 ONDO original: 2 copied: 68 total: 70 multiplier: 34.0
+赛博六王交易员 NEAR original: 1 copied: 48 total: 49 multiplier: 48.0
+
+=== Crowded Trade Alerts ===
+byonce_aiai HYPE copy_count: 407 copy_multiplier: 25.44
+赛博六王交易员 ONDO copy_count: 68 copy_multiplier: 34.0
+赛博六王交易员 NEAR copy_count: 48 copy_multiplier: 48.0
+Interpretation
+
+The demo result suggests that AI-Trader signals may be highly concentrated around a small number of influential source agents.
+
+This means that raw buy/sell signal counts should be interpreted carefully. A large number of similar signals may not represent many independent agent opinions. It may instead reflect copy-trading amplification from one or a few source agents.

--- a/docs/signal_intelligence.md
+++ b/docs/signal_intelligence.md
@@ -2,21 +2,21 @@
 
 This fork adds a Signal Intelligence module to AI-Trader.
 
-The goal of this module is to analyze AI-generated trading signals and identify how signals spread across agents. Instead of only counting how many signals each agent publishes, the module separates original signals from copied signals and ranks source agents by influence.
+The module analyzes AI-generated trading signals and helps users understand how signals spread across agents. It separates original signals from copied signals, ranks source agents by influence, and detects crowded copy-trading risks.
 
 ## Motivation
 
-AI-Trader supports AI agents that publish trading signals and copy signals from other agents. However, raw signal counts can be misleading.
+AI-Trader supports AI agents that publish and copy trading signals. However, raw signal counts can be misleading.
 
-For example, if many agents copy the same original signal, the platform may appear to have strong market consensus even though the view actually comes from one source agent.
+For example, if many agents copy the same original signal, the platform may appear to have strong market consensus, even though the view actually comes from one source agent.
 
-This module helps answer the following questions:
+This module helps answer:
 
 - How many signals are original vs copied?
 - Which agents are the main sources of copied signals?
 - Which symbols are most affected by copy trading?
-- Which signals create crowded trade risks?
-- Does signal influence come from high original activity or from copy amplification?
+- Which trades may be overcrowded?
+- Which agents have the highest signal influence?
 
 ## Core Metrics
 
@@ -32,19 +32,14 @@ The number of copied signals that reference a source agent for a specific symbol
 
 ```text
 total_influence = original_signal_count + copy_count
-
-This measures the total footprint of a source agent and symbol pair.
-
 Copy Multiplier
 copy_multiplier = copy_count / original_signal_count
 
-This measures how many copied signals are generated per original signal.
-
-A high copy multiplier suggests that an agent's signal is being strongly amplified by other agents.
+A high copy multiplier means that each original signal creates many copied signals.
 
 Crowded Trade Alerts
 
-The module flags crowded trade risks when:
+The module flags crowded trades when:
 
 copy_count >= 30
 
@@ -56,32 +51,44 @@ These alerts help identify cases where many agents may be following the same sou
 
 Files Added
 service/server/signal_intelligence.py
+service/server/routes_signal_intelligence.py
 scripts/signal_intelligence_demo.py
-How to Run the Demo
+service/server/tests/test_signal_intelligence.py
+Demo Usage
 
-From the project root:
+Run the demo script from the project root:
 
 python scripts/signal_intelligence_demo.py
 
-The script will fetch recent public AI-Trader signals and print:
+The script fetches recent public AI-Trader signals and prints:
 
 Summary statistics
 Market distribution
 Buy/sell direction distribution
 Top source agents
 Crowded trade alerts
-Example Output
-=== Top Source Agents ===
-byonce_aiai HYPE original: 16 copied: 407 total: 423 multiplier: 25.44
-赛博六王交易员 ONDO original: 2 copied: 68 total: 70 multiplier: 34.0
-赛博六王交易员 NEAR original: 1 copied: 48 total: 49 multiplier: 48.0
+API Usage
 
-=== Crowded Trade Alerts ===
-byonce_aiai HYPE copy_count: 407 copy_multiplier: 25.44
-赛博六王交易员 ONDO copy_count: 68 copy_multiplier: 34.0
-赛博六王交易员 NEAR copy_count: 48 copy_multiplier: 48.0
+Start the backend:
+
+python service/server/main.py
+
+Then open:
+
+http://localhost:8000/api/analytics/signal-intelligence?limit=1000
+
+The API returns:
+
+summary
+distributions
+source_agent_rankings
+crowded_trade_alerts
+Run Tests
+python -m pytest service/server/tests/test_signal_intelligence.py -q
+
+Expected result:
+
+4 passed
 Interpretation
 
-The demo result suggests that AI-Trader signals may be highly concentrated around a small number of influential source agents.
-
-This means that raw buy/sell signal counts should be interpreted carefully. A large number of similar signals may not represent many independent agent opinions. It may instead reflect copy-trading amplification from one or a few source agents.
+This module shows that AI-Trader signals can be highly concentrated around a small number of influential source agents. Therefore, raw buy/sell counts should be interpreted carefully. A large number of similar signals may reflect copy-trading amplification rather than many independent agent opinions.

--- a/scripts/signal_intelligence_demo.py
+++ b/scripts/signal_intelligence_demo.py
@@ -1,0 +1,92 @@
+from pathlib import Path
+import sys
+import time
+import requests
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SERVER_DIR = ROOT_DIR / "service" / "server"
+
+sys.path.append(str(SERVER_DIR))
+
+from signal_intelligence import analyze_signal_intelligence
+
+
+AI4TRADE_API_BASE = "https://ai4trade.ai/api"
+
+
+def fetch_public_signals(limit=1000, page_size=100):
+    all_signals = []
+
+    for offset in range(0, limit, page_size):
+        url = f"{AI4TRADE_API_BASE}/signals/feed?limit={page_size}&offset={offset}"
+
+        response = requests.get(url, timeout=30)
+        response.raise_for_status()
+
+        data = response.json()
+        signals = data.get("signals", [])
+
+        print(f"offset={offset}, fetched={len(signals)}")
+
+        if not signals:
+            break
+
+        all_signals.extend(signals)
+
+        if len(signals) < page_size:
+            break
+
+        time.sleep(0.5)
+
+    return all_signals[:limit]
+
+
+def main():
+    signals = fetch_public_signals(limit=1000)
+
+    result = analyze_signal_intelligence(signals)
+
+    print("\n=== Summary ===")
+    for key, value in result["summary"].items():
+        print(f"{key}: {value}")
+
+    print("\n=== Market Distribution ===")
+    for key, value in result["distributions"]["market"].items():
+        print(f"{key}: {value}")
+
+    print("\n=== Side Distribution ===")
+    for key, value in result["distributions"]["side"].items():
+        print(f"{key}: {value}")
+
+    print("\n=== Top Source Agents ===")
+    for row in result["source_agent_rankings"][:10]:
+        print(
+            row["agent_name"],
+            row["symbol"],
+            "original:",
+            row["original_signal_count"],
+            "copied:",
+            row["copy_count"],
+            "total:",
+            row["total_influence"],
+            "multiplier:",
+            round(row["copy_multiplier"], 2),
+            "avg_quality:",
+            row["avg_quality"],
+        )
+
+    print("\n=== Crowded Trade Alerts ===")
+    for row in result["crowded_trade_alerts"][:10]:
+        print(
+            row["agent_name"],
+            row["symbol"],
+            "copy_count:",
+            row["copy_count"],
+            "copy_multiplier:",
+            round(row["copy_multiplier"], 2),
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/service/server/routes.py
+++ b/service/server/routes.py
@@ -21,7 +21,7 @@ from routes_signals import register_signal_routes
 from routes_team_missions import register_team_mission_routes
 from routes_trading import register_trading_routes
 from routes_users import register_user_routes
-
+from routes_signal_intelligence import register_signal_intelligence_routes
 
 def create_app() -> FastAPI:
     app = FastAPI(title='AI-Trader API')
@@ -45,6 +45,7 @@ def create_app() -> FastAPI:
     register_market_routes(app, ctx)
     register_agent_routes(app, ctx)
     register_signal_routes(app, ctx)
+    register_signal_intelligence_routes(app)
     register_trading_routes(app, ctx)
     register_experiment_routes(app, ctx)
     register_research_routes(app, ctx)

--- a/service/server/routes_signal_intelligence.py
+++ b/service/server/routes_signal_intelligence.py
@@ -1,0 +1,70 @@
+import time
+from typing import Any, Dict, List
+
+import requests
+from fastapi import FastAPI, HTTPException, Query
+
+from signal_intelligence import analyze_signal_intelligence
+
+
+AI4TRADE_API_BASE = "https://ai4trade.ai/api"
+
+
+def fetch_public_signals(limit: int = 1000, page_size: int = 100) -> List[Dict[str, Any]]:
+    """
+    Fetch recent public AI-Trader signals from the public signal feed.
+    """
+
+    all_signals = []
+
+    for offset in range(0, limit, page_size):
+        url = f"{AI4TRADE_API_BASE}/signals/feed?limit={page_size}&offset={offset}"
+
+        try:
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+        except requests.RequestException as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"Failed to fetch public AI-Trader signals: {exc}",
+            )
+
+        data = response.json()
+        signals = data.get("signals", [])
+
+        if not signals:
+            break
+
+        all_signals.extend(signals)
+
+        if len(signals) < page_size:
+            break
+
+        time.sleep(0.2)
+
+    return all_signals[:limit]
+
+
+def register_signal_intelligence_routes(app: FastAPI):
+    """
+    Register Signal Intelligence analytics endpoints.
+    """
+
+    @app.get("/api/analytics/signal-intelligence")
+    def get_signal_intelligence(
+        limit: int = Query(default=1000, ge=100, le=3000)
+    ):
+        """
+        Analyze recent AI-Trader signals.
+
+        Returns:
+        - original vs copied signal summary
+        - market / side / symbol distributions
+        - source-agent influence ranking
+        - crowded trade alerts
+        """
+
+        signals = fetch_public_signals(limit=limit)
+        result = analyze_signal_intelligence(signals)
+
+        return result

--- a/service/server/signal_intelligence.py
+++ b/service/server/signal_intelligence.py
@@ -1,0 +1,214 @@
+import re
+from collections import Counter, defaultdict
+from typing import Any, Dict, List, Optional
+
+
+COPY_PATTERN = re.compile(r"Copied from\s+([^\]\[]+)", re.IGNORECASE)
+
+
+def is_copied_signal(content: Any) -> bool:
+    """
+    Return True if the signal content indicates that it was copied
+    from another agent.
+    """
+    if not content:
+        return False
+
+    return bool(COPY_PATTERN.search(str(content)))
+
+
+def extract_copied_from(content: Any) -> Optional[str]:
+    """
+    Extract the source agent name from copied signal content.
+
+    Example:
+    "[Copied from byonce_aiai] [BUY] ..."
+    -> "byonce_aiai"
+    """
+    if not content:
+        return None
+
+    match = COPY_PATTERN.search(str(content))
+
+    if not match:
+        return None
+
+    return match.group(1).strip()
+
+
+def safe_float(value: Any) -> Optional[float]:
+    """
+    Convert a value to float safely.
+    Return None if conversion fails.
+    """
+    try:
+        if value is None:
+            return None
+
+        return float(value)
+
+    except (TypeError, ValueError):
+        return None
+
+
+def analyze_signal_intelligence(signals: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Analyze AI-Trader signal data.
+
+    This function separates original and copied operation signals,
+    calculates source-agent influence metrics, and detects crowded
+    copy-trading risks.
+
+    Parameters
+    ----------
+    signals:
+        A list of signal dictionaries returned by the AI-Trader API.
+
+    Returns
+    -------
+    dict:
+        A structured analytics result containing summary statistics,
+        distributions, source-agent rankings, and crowded trade alerts.
+    """
+
+    operation_signals = [
+        signal for signal in signals
+        if signal.get("message_type") == "operation"
+    ]
+
+    total_signals = len(signals)
+    total_operations = len(operation_signals)
+
+    message_type_counts = Counter(
+        signal.get("message_type") or "unknown"
+        for signal in signals
+    )
+
+    market_counts = Counter(
+        signal.get("market") or "unknown"
+        for signal in operation_signals
+    )
+
+    side_counts = Counter(
+        signal.get("side") or "unknown"
+        for signal in operation_signals
+    )
+
+    symbol_counts = Counter(
+        signal.get("symbol") or "unknown"
+        for signal in operation_signals
+    )
+
+    original_signals = []
+    copied_signals = []
+
+    for signal in operation_signals:
+        content = signal.get("content")
+        copied_from = extract_copied_from(content)
+
+        enriched_signal = dict(signal)
+        enriched_signal["is_copied"] = copied_from is not None
+        enriched_signal["copied_from"] = copied_from
+
+        if copied_from:
+            copied_signals.append(enriched_signal)
+        else:
+            original_signals.append(enriched_signal)
+
+    original_count = len(original_signals)
+    copied_count = len(copied_signals)
+
+    copied_by_source_symbol = Counter()
+
+    for signal in copied_signals:
+        copied_from = signal.get("copied_from")
+        symbol = signal.get("symbol") or "unknown"
+
+        if copied_from:
+            copied_by_source_symbol[(copied_from, symbol)] += 1
+
+    original_by_source_symbol = defaultdict(list)
+
+    for signal in original_signals:
+        agent_name = signal.get("agent_name") or "unknown"
+        symbol = signal.get("symbol") or "unknown"
+
+        original_by_source_symbol[(agent_name, symbol)].append(signal)
+
+    source_agent_rankings = []
+
+    for key, original_group in original_by_source_symbol.items():
+        agent_name, symbol = key
+
+        original_signal_count = len(original_group)
+        copy_count = copied_by_source_symbol.get((agent_name, symbol), 0)
+
+        quality_scores = []
+
+        for signal in original_group:
+            score = safe_float(signal.get("quality_score"))
+
+            if score is not None:
+                quality_scores.append(score)
+
+        avg_quality = (
+            sum(quality_scores) / len(quality_scores)
+            if quality_scores
+            else None
+        )
+
+        max_quality = max(quality_scores) if quality_scores else None
+
+        sides = sorted({
+            signal.get("side") or "unknown"
+            for signal in original_group
+        })
+
+        total_influence = original_signal_count + copy_count
+
+        copy_multiplier = (
+            copy_count / original_signal_count
+            if original_signal_count > 0
+            else 0
+        )
+
+        source_agent_rankings.append({
+            "agent_name": agent_name,
+            "symbol": symbol,
+            "original_signal_count": original_signal_count,
+            "copy_count": copy_count,
+            "total_influence": total_influence,
+            "copy_multiplier": copy_multiplier,
+            "avg_quality": avg_quality,
+            "max_quality": max_quality,
+            "sides": sides,
+        })
+
+    source_agent_rankings = sorted(
+        source_agent_rankings,
+        key=lambda row: row["total_influence"],
+        reverse=True
+    )
+
+    crowded_trade_alerts = [
+        row for row in source_agent_rankings
+        if row["copy_count"] >= 30 or row["copy_multiplier"] >= 10
+    ]
+
+    return {
+        "summary": {
+            "total_signals": total_signals,
+            "operation_signals": total_operations,
+            "original_operation_signals": original_count,
+            "copied_operation_signals": copied_count,
+            "copied_ratio": copied_count / total_operations if total_operations else 0,
+        },
+        "distributions": {
+            "message_type": dict(message_type_counts),
+            "market": dict(market_counts),
+            "side": dict(side_counts),
+            "symbol_top": dict(symbol_counts.most_common(20)),
+        },
+        "source_agent_rankings": source_agent_rankings[:50],
+        "crowded_trade_alerts": crowded_trade_alerts[:30],
+    }

--- a/service/server/tests/test_signal_intelligence.py
+++ b/service/server/tests/test_signal_intelligence.py
@@ -1,0 +1,75 @@
+from signal_intelligence import (
+    is_copied_signal,
+    extract_copied_from,
+    analyze_signal_intelligence,
+)
+
+
+def test_extract_copied_from():
+    content = "[Copied from byonce_aiai] [BUY] conf=95%"
+
+    assert is_copied_signal(content) is True
+    assert extract_copied_from(content) == "byonce_aiai"
+
+
+def test_non_copied_signal():
+    content = "[BUY] BTC momentum signal"
+
+    assert is_copied_signal(content) is False
+    assert extract_copied_from(content) is None
+
+
+def test_empty_content():
+    assert is_copied_signal(None) is False
+    assert extract_copied_from(None) is None
+
+
+def test_analyze_signal_intelligence_basic():
+    signals = [
+        {
+            "id": 1,
+            "message_type": "operation",
+            "market": "crypto",
+            "symbol": "HYPE",
+            "side": "buy",
+            "agent_name": "byonce_aiai",
+            "quality_score": 2.5,
+            "content": "[BUY] HYPE signal",
+        },
+        {
+            "id": 2,
+            "message_type": "operation",
+            "market": "crypto",
+            "symbol": "HYPE",
+            "side": "buy",
+            "agent_name": "CopyBotA",
+            "quality_score": 2.1,
+            "content": "[Copied from byonce_aiai] [BUY] HYPE signal",
+        },
+        {
+            "id": 3,
+            "message_type": "operation",
+            "market": "crypto",
+            "symbol": "HYPE",
+            "side": "buy",
+            "agent_name": "CopyBotB",
+            "quality_score": 2.2,
+            "content": "[Copied from byonce_aiai] [BUY] HYPE signal",
+        },
+    ]
+
+    result = analyze_signal_intelligence(signals)
+
+    assert result["summary"]["total_signals"] == 3
+    assert result["summary"]["operation_signals"] == 3
+    assert result["summary"]["original_operation_signals"] == 1
+    assert result["summary"]["copied_operation_signals"] == 2
+
+    top_agent = result["source_agent_rankings"][0]
+
+    assert top_agent["agent_name"] == "byonce_aiai"
+    assert top_agent["symbol"] == "HYPE"
+    assert top_agent["original_signal_count"] == 1
+    assert top_agent["copy_count"] == 2
+    assert top_agent["total_influence"] == 3
+    assert top_agent["copy_multiplier"] == 2


### PR DESCRIPTION
Summary

This PR adds a Signal Intelligence module to AI-Trader.
The module analyzes AI-generated trading signals and identifies original signals, copied signals, source-agent influence, and crowded copy-trading risks.

 Changes
- Added signal intelligence analysis logic
- Added demo script for public signal feed analysis
- Added analytics API endpoint
- Added unit tests
- Added documentation

New API
GET /api/analytics/signal-intelligence?limit=1000

Test
```bash
python -m pytest service/server/tests/test_signal_intelligence.py -q

Expected result:
4 passed