### PR TITLE
fix(agent): suppress internal exception details in selfRegister error responses

### DIFF
--- a/service/server/routes_agent.py
+++ b/service/server/routes_agent.py
@@ -722,7 +722,8 @@ def register_agent_routes(app: FastAPI, ctx: RouteContext) -> None:
             raise
         except Exception as exc:
             conn.close()
-            raise HTTPException(status_code=500, detail=str(exc))
+            print(f'[Agent Registration Error] {exc}')
+            raise HTTPException(status_code=500, detail='Agent registration failed')
 
     @app.post('/api/claw/agents/login')
     async def agent_login(data: AgentLogin):

--- a/service/server/tests/test_cwe209_agent_registration.py
+++ b/service/server/tests/test_cwe209_agent_registration.py
@@ -1,0 +1,119 @@
+"""Tests verifying CWE-209 fix: error responses on /api/claw/agents/selfRegister
+must not leak internal exception details."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+import database
+from routes import create_app
+
+
+class CWE209AgentRegistrationTests(unittest.TestCase):
+    """Ensure 500 responses on selfRegister do not leak exception details."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        database.DATABASE_URL = ""
+        database._SQLITE_DB_PATH = os.path.join(self.tmp.name, "test.db")
+        database.init_database()
+        self.client = TestClient(create_app())
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_successful_registration_still_works(self):
+        """Normal registration should succeed and return expected fields."""
+        response = self.client.post(
+            "/api/claw/agents/selfRegister",
+            json={"name": "test-agent", "password": "password123", "initial_balance": 100000},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["name"], "test-agent")
+        self.assertIn("token", data)
+        self.assertIn("agent_id", data)
+
+    def test_duplicate_registration_returns_409_not_internal_details(self):
+        """Registering the same agent twice should return a clear 409 error."""
+        self.client.post(
+            "/api/claw/agents/selfRegister",
+            json={"name": "dup-agent", "password": "password123", "initial_balance": 100000},
+        )
+        response = self.client.post(
+            "/api/claw/agents/selfRegister",
+            json={"name": "dup-agent", "password": "password123", "initial_balance": 100000},
+        )
+        # Should get a specific error code, not a 500
+        self.assertIn(response.status_code, (400, 409))
+
+    def test_internal_error_returns_generic_message(self):
+        """When an unexpected exception occurs inside the registration try
+        block, the 500 response must contain only a generic message, not the
+        raw exception string.
+
+        We patch ``hash_password`` (called inside the try block at line ~571)
+        rather than ``get_db_connection`` (which is called *before* the try
+        block at line 563 and therefore is not covered by the fix's
+        except-clause).
+        """
+        secret_message = "SECRET_DB_CONNECTION_STRING_12345"
+        with patch(
+            "routes_agent.hash_password",
+            side_effect=RuntimeError(secret_message),
+        ):
+            response = self.client.post(
+                "/api/claw/agents/selfRegister",
+                json={"name": "fail-agent", "password": "password123", "initial_balance": 100000},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        detail = response.json().get("detail", "")
+
+        # The critical assertion: internal exception details must NOT leak
+        self.assertNotIn(secret_message, detail)
+        self.assertNotIn("SECRET_DB_CONNECTION_STRING", detail)
+        self.assertNotIn("RuntimeError", detail)
+
+        # The response should contain only the generic message
+        self.assertEqual(detail, "Agent registration failed")
+
+    def test_internal_error_does_not_leak_traceback(self):
+        """Ensure no traceback or Python-internal info leaks in error response.
+
+        Like the test above, we patch a function that is called *inside* the
+        try block so the fix's generic-error handler is exercised.
+        """
+        with patch(
+            "routes_agent.hash_password",
+            side_effect=ValueError("sqlite3.OperationalError: table agents has no column named secret"),
+        ):
+            response = self.client.post(
+                "/api/claw/agents/selfRegister",
+                json={"name": "trace-agent", "password": "password123", "initial_balance": 100000},
+            )
+
+        self.assertEqual(response.status_code, 500)
+        body = response.text
+
+        # None of these internal details should appear in the response
+        self.assertNotIn("sqlite3", body)
+        self.assertNotIn("OperationalError", body)
+        self.assertNotIn("Traceback", body)
+        self.assertNotIn("File ", body)
+
+        detail = response.json().get("detail", "")
+        self.assertEqual(detail, "Agent registration failed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The `/api/claw/agents/selfRegister` endpoint in `service/server/routes_agent.py` returns raw Python exception messages to HTTP clients on internal errors. When an unexpected exception occurs during agent registration, the handler at line 724 passes `str(exc)` directly into the `HTTPException` detail field:

```python
except Exception as exc:
    conn.close()
    raise HTTPException(status_code=500, detail=str(exc))
```

This is an instance of [CWE-209: Generation of Error Message Containing Sensitive Information](https://cwe.mitre.org/data/definitions/209.html). Depending on the exception type, the leaked message can include database file paths, SQLite schema details, connection strings, internal hostnames, or Python tracebacks — all useful for reconnaissance.

This endpoint is particularly sensitive because it requires **no authentication**. Unlike similar patterns in `routes_signals.py`, `routes_experiments.py`, `routes_challenges.py`, and `routes_team_missions.py` (which are behind auth), `selfRegister` is publicly accessible and deployed at ai4trade.ai.

## Proof of Concept

An attacker can trigger internal errors and read the exception details from the response. For example, if the database is temporarily unavailable or a schema migration leaves a column missing:

```bash
# Send a registration request that triggers an internal error
# (e.g., database constraint violation, missing column, disk full)
curl -X POST https://ai4trade.ai/api/claw/agents/selfRegister \
  -H "Content-Type: application/json" \
  -d '{"name": "test-agent", "password": "pass123", "initial_balance": 100000}'
```

If any `Exception` is raised inside the try block (lines 566–724 of `routes_agent.py`), the current code returns the raw exception string in the JSON response body:

```json
{"detail": "sqlite3.OperationalError: no such table: agents"}
```

or:

```json
{"detail": "OperationalError: (psycopg2.OperationalError) could not connect to server: Connection refused\n\tIs the server running on host \"internal-db.cluster.local\" ..."}
```

This reveals database technology, internal hostnames, table names, and schema details to unauthenticated users.

## Fix

The fix replaces `str(exc)` with a static generic message `'Agent registration failed'` and logs the actual exception server-side via `print()` so developers can still diagnose issues:

```python
except Exception as exc:
    conn.close()
    print(f'[Agent Registration Error] {exc}')
    raise HTTPException(status_code=500, detail='Agent registration failed')
```

This preserves the existing error handling flow (connection cleanup, 500 status code) while preventing information leakage. The `HTTPException` re-raise for known errors (e.g., 400 for duplicate names) is unaffected — that handler is in a separate `except HTTPException` block above.

## Testing

The PR includes a test file (`service/server/tests/test_cwe209_agent_registration.py`) with four tests:

1. **`test_successful_registration_still_works`** — Verifies normal registration is unaffected by the fix.
2. **`test_duplicate_registration_returns_409_not_internal_details`** — Confirms duplicate agent names still return proper 400/409 errors.
3. **`test_internal_error_returns_generic_message`** — Patches `hash_password` to raise a `RuntimeError` containing a simulated secret (`SECRET_DB_CONNECTION_STRING_12345`) and asserts the 500 response contains only the generic message, not the secret.
4. **`test_internal_error_does_not_leak_traceback`** — Patches `hash_password` to raise an exception mimicking a SQLite error and asserts no database internals (`sqlite3`, `OperationalError`, `Traceback`) appear in the response.

All four tests pass.

## Security Analysis

The vulnerability is exploitable because:

- The endpoint requires no authentication — any internet user can reach it.
- The `except Exception` handler is a catch-all covering ~160 lines of code (lines 566–724), meaning many different failure modes can produce varied and informative exception messages.
- FastAPI serializes the `detail` field directly into the JSON response body with no sanitization.
- The service is publicly deployed at ai4trade.ai.

Before submitting, we considered whether existing protections mitigate this. The CORS middleware is permissive (`allow_origins=CORS_ORIGINS`, `allow_methods=['*']`), and there is no global error handler or middleware that sanitizes 500 responses. The endpoint has no rate limiting or authentication gate. The information disclosure is real and reachable from the public internet.

Severity is low-to-medium: the leaked information aids reconnaissance (revealing database technology, internal network topology, table schemas) but is not directly exploitable for data theft or code execution on its own.

**Note:** Similar `str(exc)` patterns exist in other route files (`routes_signals.py`, `routes_experiments.py`, `routes_challenges.py`, `routes_team_missions.py`), but those endpoints are behind authentication. This PR targets the single unauthenticated instance as the highest-priority fix.