### PR TITLE
fix: count PnL for positions priced at exactly 0.0

### DIFF
--- a/service/server/routes_signals.py
+++ b/service/server/routes_signals.py
@@ -958,12 +958,12 @@ def register_signal_routes(app: FastAPI, ctx: RouteContext) -> None:
             for pos_row in position_rows:
                 current_price = pos_row['current_price']
                 pnl = None
-                if current_price and pos_row['entry_price']:
+                if current_price is not None and pos_row['entry_price'] is not None:
                     if pos_row['side'] == 'long':
                         pnl = (current_price - pos_row['entry_price']) * abs(pos_row['quantity'])
                     else:
                         pnl = (pos_row['entry_price'] - current_price) * abs(pos_row['quantity'])
-                if pnl:
+                if pnl is not None:
                     total_position_pnl += pnl
                 position_summary.append({
                     'symbol': pos_row['symbol'],

--- a/service/server/routes_trading.py
+++ b/service/server/routes_trading.py
@@ -406,7 +406,7 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
             total_position_pnl = 0
             for pos in positions:
                 current_price = pos['current_price']
-                if current_price and pos['entry_price']:
+                if current_price is not None and pos['entry_price'] is not None:
                     if pos['side'] == 'long':
                         pnl = (current_price - pos['entry_price']) * abs(pos['quantity'])
                     else:
@@ -605,7 +605,7 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
         for row in rows:
             current_price = resolved_prices.get(position_price_cache_key(row))
             pnl = None
-            if current_price and row['entry_price']:
+            if current_price is not None and row['entry_price'] is not None:
                 if row['side'] == 'long':
                     pnl = (current_price - row['entry_price']) * abs(row['quantity'])
                 else:
@@ -667,12 +667,12 @@ def register_trading_routes(app: FastAPI, ctx: RouteContext) -> None:
         for row in rows:
             current_price = resolved_prices.get(position_price_cache_key(row))
             pnl = None
-            if current_price and row['entry_price']:
+            if current_price is not None and row['entry_price'] is not None:
                 if row['side'] == 'long':
                     pnl = (current_price - row['entry_price']) * abs(row['quantity'])
                 else:
                     pnl = (row['entry_price'] - current_price) * abs(row['quantity'])
-            if pnl:
+            if pnl is not None:
                 total_pnl += pnl
 
             positions.append({

--- a/service/server/tests/test_position_pnl_zero_price.py
+++ b/service/server/tests/test_position_pnl_zero_price.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+import database
+from routes import create_app
+from routes_shared import utc_now_iso_z
+
+
+class ZeroPricePnlTests(unittest.TestCase):
+    """Regression: a valid current_price of 0.0 must not be treated as 'no price'.
+
+    Polymarket outcome tokens resolve to exactly 0.0 when the outcome loses.
+    The PnL endpoints previously guarded with `if current_price and ...`, so a
+    0.0 price was falsy and the position's (fully realized) loss was silently
+    dropped, overstating position PnL and leaderboard rank. The authoritative
+    leaderboard SQL distinguishes NULL from 0.0, so the Python endpoints must too.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        database.DATABASE_URL = ""
+        database._SQLITE_DB_PATH = os.path.join(self.tmp.name, "test.db")
+        database.init_database()
+        self.client = TestClient(create_app())
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _create_agent(self, name: str, cash: float = 100000.0) -> int:
+        now = utc_now_iso_z()
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO agents (name, token, points, cash, created_at, updated_at)
+            VALUES (?, ?, 0, ?, ?, ?)
+            """,
+            (name, f"token-{name}", cash, now, now),
+        )
+        agent_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+        return agent_id
+
+    def _insert_position(self, agent_id, *, entry_price, current_price, quantity, side="long"):
+        now = utc_now_iso_z()
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO positions
+            (agent_id, symbol, market, token_id, outcome, side, quantity, entry_price, current_price, opened_at)
+            VALUES (?, 'WINYES', 'polymarket', 'tok-1', 'Yes', ?, ?, ?, ?, ?)
+            """,
+            (agent_id, side, quantity, entry_price, current_price, now),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_zero_current_price_loss_is_counted(self):
+        # Long 100 tokens bought at 0.60; outcome lost so the token now trades at 0.0.
+        # Expected PnL = (0.0 - 0.60) * 100 = -60.0 (a full loss), not 0.
+        agent_id = self._create_agent("loser")
+        self._insert_position(agent_id, entry_price=0.60, current_price=0.0, quantity=100)
+
+        resp = self.client.get("/api/leaderboard/position-pnl")
+        self.assertEqual(resp.status_code, 200)
+        rows = {r["agent_id"]: r for r in resp.json()["top_agents"]}
+        self.assertAlmostEqual(rows[agent_id]["position_pnl"], -60.0, places=6)
+
+        resp = self.client.get(f"/api/agents/{agent_id}/positions")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertAlmostEqual(body["total_pnl"], -60.0, places=6)
+        self.assertAlmostEqual(body["positions"][0]["pnl"], -60.0, places=6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Problem

The position-PnL endpoints compute profit only when `if current_price and entry_price:`. In Python a price of **exactly `0.0` is falsy**, so any position whose current price is `0.0` is silently skipped and its PnL is treated as non-existent.

Polymarket outcome tokens resolve to **exactly `0.0`** when the outcome loses. As a result a fully-realized loss is dropped from:

- `GET /api/leaderboard/position-pnl`
- `GET /api/positions`
- `GET /api/agents/{agent_id}/positions`
- the signal leaderboard position summary (`routes_signals.py`)

This **overstates position PnL and inflates leaderboard ranking** for agents holding worthless resolved positions.

### Why it's a real inconsistency

The authoritative leaderboard SQL in `routes_trading.py` already distinguishes `NULL` from `0.0` (`WHEN p.current_price IS NULL ...`) and values a `0.0` price correctly. These Python endpoints were therefore inconsistent with the source-of-truth valuation.

### Fix

Use explicit `is not None` checks for `current_price`, `entry_price`, and the accumulated `pnl` instead of truthiness.

### Test

Adds `tests/test_position_pnl_zero_price.py`: a long Polymarket position bought at `0.60` that resolves to `0.0`.

- Expected PnL: `(0.0 - 0.60) * 100 = -60.0`
- Before fix: reported `0` (loss dropped) — test fails
- After fix: reported `-60.0` — test passes
