### PR TITLE
fix: allow background worker to start on Windows (fcntl ImportError, #89)

### DIFF
--- a/service/server/worker.py
+++ b/service/server/worker.py
@@ -6,12 +6,20 @@ with price refreshes, profit-history compaction, and market-intel snapshots.
 """
 
 import asyncio
-import fcntl
 import logging
 import os
 import signal
 import sys
 from contextlib import suppress
+
+try:  # POSIX single-instance file locking
+    import fcntl
+except ImportError:  # Windows has no fcntl; fall back to msvcrt
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:  # pragma: no cover - neither backend available
+        msvcrt = None
 
 from database import init_database, get_database_status
 from tasks import DEFAULT_BACKGROUND_TASKS, _prune_profit_history, start_background_tasks
@@ -39,8 +47,13 @@ def _acquire_file_lock():
     lock_path = os.getenv("AI_TRADER_WORKER_LOCK_FILE", "/tmp/ai-trader-worker.lock")
     handle = open(lock_path, "w", encoding="utf-8")
     try:
-        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except BlockingIOError:
+        if fcntl is not None:
+            fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        elif msvcrt is not None:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:  # pragma: no cover - no locking backend on this platform
+            logger.warning("No file-locking backend available; worker singleton not enforced.")
+    except (BlockingIOError, OSError):
         handle.close()
         logger.warning("Another AI-Trader worker is already running; lock_file=%s", lock_path)
         return None
@@ -55,7 +68,11 @@ def _release_file_lock(handle) -> None:
     if handle is None:
         return
     with suppress(Exception):
-        fcntl.flock(handle, fcntl.LOCK_UN)
+        if fcntl is not None:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+        elif msvcrt is not None:
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
     with suppress(Exception):
         handle.close()
 


### PR DESCRIPTION
### Problem (issue #89)

`service/server/worker.py` imports `fcntl` at module top level:

```python
import fcntl
```

`fcntl` is a **Unix-only** standard-library module. On Windows the import raises `ImportError` immediately, so the standalone background worker (`python worker.py`) cannot start at all. This matches the Windows `fcntl` failure reported in #89.

### Fix

Make the POSIX file-locking backend optional and fall back to `msvcrt` on Windows for the single-instance lock:

- `import fcntl` guarded by `try/except`; on failure fall back to `msvcrt`, else `None`
- `_acquire_file_lock` uses `fcntl.flock`, else `msvcrt.locking(LK_NBLCK)`, else logs a warning and continues without singleton enforcement
- `_release_file_lock` mirrors the same backends
- contention `except` broadened to `(BlockingIOError, OSError)` because `msvcrt.locking` raises `OSError` when the region is already locked

The other Windows-hostile calls in this file (`os.nice`, `loop.add_signal_handler`) are already wrapped in `try/except` and degrade cleanly, so no change is needed there.

### Verification

Reproduced and verified with the `fcntl` import blocked to simulate Windows:

| Scenario | Import | Locking |
|---|---|---|
| Native POSIX (real `fcntl`) | ok | acquire → second attempt blocked → release works |
| Windows (fcntl absent, `msvcrt` present) | **ok (previously ImportError)** | acquire via `msvcrt`, second blocked, unlock on release |
| No backend (fcntl + msvcrt absent) | ok | continues with a warning, no crash |

On the unmodified file the same simulation fails with `ImportError: No module named fcntl`, confirming the fix.

Closes #89
