### PR TITLE
fix: enforce cash constraint in challenge replay scoring (hidden leverage inflates challenge leaderboard)

### DIFF
--- a/service/server/challenge_scoring.py
+++ b/service/server/challenge_scoring.py
@@ -108,6 +108,13 @@ def score_agent_trades(
                 disqualified_reason = f'buy_used_while_short:{symbol}'
                 break
             cash -= price * quantity
+            if cash < -1e-9:
+                # Live trading rejects buys that exceed available cash; replaying
+                # with the challenge's starting cash must enforce the same rule,
+                # otherwise spreading buys across symbols yields hidden leverage
+                # that inflates return_pct against starting_cash.
+                disqualified_reason = f'insufficient_challenge_cash:{symbol}'
+                break
             new_qty = current_qty + quantity
             new_entry = (
                 ((current_qty * current_entry) + (quantity * price)) / new_qty
@@ -140,6 +147,11 @@ def score_agent_trades(
                 disqualified_reason = f'short_used_while_long:{symbol}'
                 break
             cash -= price * quantity
+            if cash < -1e-9:
+                # Shorts escrow price * quantity in the live model, so they are
+                # cash-bounded exactly like buys.
+                disqualified_reason = f'insufficient_challenge_cash:{symbol}'
+                break
             new_qty = current_qty - quantity
             current_short_qty = abs(current_qty)
             new_entry = (

--- a/service/server/challenges.py
+++ b/service/server/challenges.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -329,6 +330,8 @@ def join_challenge(challenge_key: str, agent_id: int, data: Any = None) -> dict[
 
         variant_key = _resolve_variant(cursor, challenge.get('experiment_key'), agent_id, payload.get('variant_key'))
         starting_cash = float(payload.get('starting_cash') or challenge.get('initial_capital') or 100000.0)
+        if not math.isfinite(starting_cash) or starting_cash <= 0:
+            raise ChallengeError('starting_cash must be a positive finite number')
         cursor.execute(
             """
             INSERT INTO challenge_participants

--- a/service/server/tests/test_challenge_scoring_leverage.py
+++ b/service/server/tests/test_challenge_scoring_leverage.py
@@ -1,0 +1,97 @@
+import sys
+import unittest
+from pathlib import Path
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from challenge_scoring import score_agent_trades
+
+
+def _challenge(**overrides):
+    challenge = {
+        'initial_capital': 10000.0,
+        'max_position_pct': 100.0,
+        'max_drawdown_pct': 100.0,
+        'scoring_method': 'return-only',
+        'rules_json': None,
+    }
+    challenge.update(overrides)
+    return challenge
+
+
+def _participant(starting_cash=10000.0):
+    return {'agent_id': 1, 'starting_cash': starting_cash, 'status': 'joined'}
+
+
+def _trade(trade_id, side, symbol, price, quantity, executed_at):
+    return {
+        'id': trade_id,
+        'side': side,
+        'market': 'us-stock',
+        'symbol': symbol,
+        'price': price,
+        'quantity': quantity,
+        'executed_at': executed_at,
+    }
+
+
+class ChallengeScoringLeverageTests(unittest.TestCase):
+    """Regression: challenge replay must enforce the cash constraint.
+
+    Live trading rejects buys/shorts whose value exceeds available cash, but
+    the challenge replay applied them with no cash check, letting cash go
+    negative silently. The per-symbol max_position_pct guard does not catch
+    exposure spread across several symbols, so a participant trading a larger
+    live account inside a smaller-capital challenge gained hidden leverage
+    that inflated return_pct against starting_cash.
+    """
+
+    def test_overspending_across_symbols_is_disqualified(self):
+        # 10k starting cash; two 6k buys = 12k deployed, cash -2k.
+        # Each position is only 60% of equity so max_position_pct passes;
+        # before the fix this scored return_pct on 1.2x hidden leverage.
+        trades = [
+            _trade(1, 'buy', 'AAA', 100.0, 60, '2026-01-02T15:00:00Z'),
+            _trade(2, 'buy', 'BBB', 100.0, 60, '2026-01-02T15:05:00Z'),
+        ]
+        result = score_agent_trades(_challenge(), _participant(), trades)
+        self.assertEqual(result['disqualified_reason'], 'insufficient_challenge_cash:BBB')
+        self.assertIsNone(result['final_score'])
+
+    def test_short_escrow_is_cash_bounded(self):
+        # Shorts escrow price * quantity in the live model, so they are
+        # bounded by cash exactly like buys.
+        trades = [
+            _trade(1, 'short', 'AAA', 100.0, 60, '2026-01-02T15:00:00Z'),
+            _trade(2, 'short', 'BBB', 100.0, 60, '2026-01-02T15:05:00Z'),
+        ]
+        result = score_agent_trades(_challenge(), _participant(), trades)
+        self.assertEqual(result['disqualified_reason'], 'insufficient_challenge_cash:BBB')
+        self.assertIsNone(result['final_score'])
+
+    def test_full_deployment_without_overspend_is_allowed(self):
+        # Spending exactly the starting cash must not trip the guard.
+        trades = [
+            _trade(1, 'buy', 'AAA', 100.0, 100, '2026-01-02T15:00:00Z'),
+            _trade(2, 'sell', 'AAA', 110.0, 100, '2026-01-03T15:00:00Z'),
+        ]
+        result = score_agent_trades(_challenge(), _participant(), trades)
+        self.assertIsNone(result['disqualified_reason'])
+        self.assertAlmostEqual(result['return_pct'], 10.0, places=6)
+        self.assertAlmostEqual(result['final_score'], 10.0, places=6)
+
+    def test_honest_partial_deployment_unchanged(self):
+        trades = [
+            _trade(1, 'buy', 'AAA', 100.0, 60, '2026-01-02T15:00:00Z'),
+            _trade(2, 'sell', 'AAA', 120.0, 60, '2026-01-03T15:00:00Z'),
+        ]
+        result = score_agent_trades(_challenge(), _participant(), trades)
+        self.assertIsNone(result['disqualified_reason'])
+        self.assertAlmostEqual(result['return_pct'], 12.0, places=6)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Problem

`score_agent_trades` (challenge replay scoring) applies `buy` and `short` trades **without any cash check**, so replay cash can go negative silently. Live trading rejects exactly this (`Insufficient cash. Required: ...` in `routes_signals.py`), so the replay is inconsistent with the platform's own no-leverage rule.

The only guard, `max_position_pct`, is **per-symbol**. Spreading buys across N symbols keeps every position at/under 100% of equity while total exposure reaches ~N× the challenge capital:

> 10k challenge capital → ten 10k buys in ten symbols → cash −90k, equity 10k, each position exactly 100% → **passes all checks, scores with ~10× leverage**.

Because challenge trades are mirrored from live signals, a participant trading a larger live account inside a smaller-capital challenge gains hidden leverage and an inflated `return_pct` on the challenge leaderboard. On top of that, `starting_cash` at join time is **client-supplied and entirely unvalidated** (`ChallengeJoinRequest.starting_cash`), including negative, zero, NaN, or Infinity.

### Fix

- `challenge_scoring.py`: disqualify with `insufficient_challenge_cash:SYMBOL` when a `buy` or `short` pushes replay cash below zero (tolerance `-1e-9`, matching the file's existing epsilons). Shorts escrow `price * quantity` in the live model, so they are cash-bounded exactly like buys. Disqualification matches how the scorer already treats other rule breaches (`sell_exceeds_challenge_long`, `max_position_pct_exceeded`).
- `challenges.py`: reject non-finite or non-positive `starting_cash` on join.

### Tests

`tests/test_challenge_scoring_leverage.py` (pure-function tests against `score_agent_trades`):

| Case | Before fix | After fix |
|---|---|---|
| Two 6k buys on 10k capital (60% per symbol, cash −2k) | scored normally (`disqualified_reason=None`) | disqualified `insufficient_challenge_cash:BBB` |
| Two 6k shorts on 10k capital | scored normally | disqualified |
| Exact full deployment (buy 10k, sell at +10%) | 10% return | unchanged, 10% return |
| Partial deployment (buy 6k, sell at +20%) | 12% return | unchanged, 12% return |

Full server suite: **93 tests pass** (2 skipped), no regressions.
