### PR TITLE
Add per-model, per-day token usage tracking (#74)

### DIFF
--- a/TOKEN_USAGE_WORK_NOTE.md
+++ b/TOKEN_USAGE_WORK_NOTE.md
@@ -1,0 +1,66 @@
+# Work Note — Token Usage Tracking (issue #74)
+
+## Goal
+Issue #74 asks for LLM **token usage per model and per day**. This adds that to
+the backend, adapting the token accounting from the RadSim project.
+
+## Key constraint
+The AI-Trader backend makes **no LLM calls itself** — no LLM SDKs, no model API
+keys. The token-generating calls happen inside the external agents (Claude Code,
+Codex, Cursor, etc.). So the server cannot observe tokens directly; agents must
+**self-report** usage, and the platform stores and aggregates it.
+
+## What was added
+| File | Change |
+|------|--------|
+| `service/server/config.py` | Ported RadSim's `MODEL_PRICING` table + `get_model_pricing` (unknown model → `None`, never "free") |
+| `service/server/token_usage.py` *(new)* | Service layer adapted from RadSim's `task_logger`: `estimate_tokens`, `compute_cost_usd`, `record_token_usage`, `get_usage_by_model_and_day`, `summarize_usage` |
+| `service/server/database.py` | New `token_usage` table + two indexes in `init_database()` (dual-backend SQLite/PostgreSQL) |
+| `service/server/routes_models.py` | `TokenUsageReport` request model with trimming + abuse bounds |
+| `service/server/routes_token_usage.py` *(new)* | Endpoints, registered in `routes.py` before the SPA catch-all |
+| `service/server/tests/test_token_usage.py` *(new)* | 15 end-to-end tests |
+
+## API
+- `POST /api/claw/usage` — agent self-reports `{model, provider, input_tokens, output_tokens}` (auth-scoped to the caller)
+- `GET  /api/claw/usage?start_date&end_date` — the caller's own usage grouped by model + day
+- `GET  /api/usage/models?start_date&end_date` — public, agent-anonymous rollup by model + day
+
+## Data model
+`token_usage(id, agent_id, model, provider, input_tokens, output_tokens, cost_usd, created_at)`.
+Per-model/per-day aggregation is `GROUP BY substr(created_at,1,10), model`
+(`substr` keeps the day bucket backend-agnostic across SQLite and PostgreSQL).
+
+## RadSim reuse
+- **Verbatim:** pricing table + cost math (from RadSim `config.py` / `output.py`).
+- **Adapted:** token estimator (`len/4`) and the record/aggregate/estimate structure from `task_logger.py`.
+- **Deliberately not ported:** RadSim's private-SQLite-file singleton writer — not multi-tenant, async-safe, or Postgres-capable. The write path uses AI-Trader's own `DatabaseCursor` layer instead.
+
+## Security / standards check
+- Untrusted input: model/provider strings are trimmed; blank models are rejected; counts bounded (`ge=0`, `le=20_000_000`); date filters are calendar-validated, chronological, and **fail closed** (400).
+- AuthZ: every write and personal read requires a valid Bearer token, scoped to `agent['id']`; bad token → 401.
+- Abuse control: self-report writes are rate-limited per agent in the shared route context; excess reports → 429.
+- Injection: all SQL parameterized; the only interpolated fragment is a constant `WHERE` built from fixed strings.
+- Integrity: cost computed **server-side** (never trusted from client); day bucket uses the **server** timestamp; unknown model → `NULL` cost.
+- No prompt/response **content** is accepted or stored — only counts. No secrets introduced.
+
+## Open caveat (for reviewers)
+Self-reported usage is **untrusted**. Treat it as informational; do **not** feed
+it into rewards/leaderboard scoring without a verification story.
+
+## Follow-up review fixes (adversarial pass)
+Addressed all six findings from the cross-review:
+1. **Silent undercounting from the write rate limit** — added `POST /api/claw/usage/batch` (up to `MAX_REPORTS_PER_BATCH=500` records) that counts as **one** write, so a busy agent reports many calls without dropping usage.
+2. **Public overview uncached / full-scan** — `GET /api/usage/models` now uses the repo's short cache (`token_usage_overview_cache`, 60s TTL, Redis + in-process).
+3. **No idempotency** — optional `client_event_id` per report + a `UNIQUE(agent_id, client_event_id)` index; a repeated key returns the stored row (`deduplicated: true`) instead of double-counting.
+4. **Rate-limit state leak** — idle agents are pruned from `token_usage_rate_limit_state` once it exceeds `TOKEN_USAGE_RATE_LIMIT_MAX_AGENTS=10000`.
+5. **Non-sargable date filter** — bounds now compare the raw `created_at` column (`>= start`, `< day_after(end)`) so the `(agent_id, created_at)` / `(model, created_at)` indexes serve the range; the day bucket still uses `substr`.
+6. **Day timezone** — documented as **UTC**; responses now include `"timezone": "UTC"`.
+
+Standards check: ruff clean on all changed files (pre-existing `config.py` E402 untouched); no dependencies added (no `pip-audit` needed).
+
+## Tests
+```
+tests/test_token_usage.py ......................  22 passed
+tests/  (full server suite)                       143 passed, 2 skipped — 0 regressions
+```
+Run: `cd service/server && python3 -m pytest tests/test_token_usage.py -v`

--- a/service/server/config.py
+++ b/service/server/config.py
@@ -43,3 +43,47 @@ REPLY_PUBLISH_REWARD = 2       # Points for replying to a strategy/discussion
 
 # Environment
 ENVIRONMENT = os.getenv("ENVIRONMENT", "development")
+
+# ==================== LLM Token Pricing ====================
+# USD per 1,000,000 tokens as (input_price, output_price).
+# Ported from RadSim's MODEL_PRICING table (verified Jul 2026). Used to turn
+# reported token counts into a cost estimate. Unknown models return None so
+# callers can distinguish "unknown cost" from "genuinely free" — an unknown
+# model must never be displayed as free.
+MODEL_PRICING = {
+    # Claude Series
+    "claude-opus-4-8": (5.00, 25.00),
+    "claude-opus-4-6": (5.00, 25.00),
+    "claude-sonnet-4-6": (3.00, 15.00),
+    "claude-sonnet-4-5": (3.00, 15.00),
+    "claude-haiku-4-5": (1.00, 5.00),
+    # OpenAI GPT-5 Series
+    "gpt-5.4": (5.00, 15.00),
+    "gpt-5.3-codex": (5.00, 15.00),
+    "gpt-5.2": (2.50, 10.00),
+    "gpt-5.2-codex": (2.50, 10.00),
+    "gpt-5-mini": (1.00, 4.00),
+    # OpenRouter models (live pricing, verified Jul 2026)
+    "minimax/minimax-m3": (0.30, 1.20),
+    "deepseek/deepseek-v4-flash": (0.09, 0.18),
+    "moonshotai/kimi-k2.5": (0.38, 2.02),
+    "anthropic/claude-opus-4.8": (5.00, 25.00),
+    "anthropic/claude-opus-4.6": (5.00, 25.00),
+    "anthropic/claude-sonnet-4.6": (3.00, 15.00),
+    "anthropic/claude-haiku-4.5": (1.00, 5.00),
+    "openai/gpt-5.4": (2.50, 15.00),
+    "openai/gpt-5.3-codex": (1.75, 14.00),
+    "openai/gpt-5.2-codex": (1.75, 14.00),
+    "minimax/minimax-m2.1": (0.30, 1.20),
+    "z-ai/glm-5.2": (0.77, 2.42),
+    "z-ai/glm-4.7": (0.40, 1.75),
+}
+
+
+def get_model_pricing(model):
+    """Return (input, output) USD per 1M tokens for a model, or None when unknown.
+
+    Returning None instead of zeros lets callers distinguish "unknown cost"
+    from "genuinely free" — an unknown model must never display as free.
+    """
+    return MODEL_PRICING.get(model)

--- a/service/server/database.py
+++ b/service/server/database.py
@@ -1687,6 +1687,39 @@ def init_database():
         ON stock_analysis_snapshots(market, symbol)
     """)
 
+    # Token usage table - per-call LLM token usage reported by agents (issue #74)
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS token_usage (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            agent_id INTEGER NOT NULL,
+            model TEXT NOT NULL,
+            provider TEXT,
+            input_tokens INTEGER NOT NULL DEFAULT 0,
+            output_tokens INTEGER NOT NULL DEFAULT 0,
+            cost_usd REAL,
+            client_event_id TEXT,
+            created_at TEXT DEFAULT (datetime('now')),
+            FOREIGN KEY (agent_id) REFERENCES agents(id)
+        )
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_token_usage_agent_created
+        ON token_usage(agent_id, created_at)
+    """)
+
+    cursor.execute("""
+        CREATE INDEX IF NOT EXISTS idx_token_usage_model_created
+        ON token_usage(model, created_at)
+    """)
+
+    # Deduplicate retried reports. Multiple NULL client_event_id rows stay
+    # distinct in both SQLite and PostgreSQL, so unkeyed reports are unaffected.
+    cursor.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_token_usage_agent_event
+        ON token_usage(agent_id, client_event_id)
+    """)
+
     if not using_postgres():
         conn.commit()
     elif previous_autocommit is not None:

--- a/service/server/routes.py
+++ b/service/server/routes.py
@@ -19,6 +19,7 @@ from routes_research import register_research_routes
 from routes_shared import RouteContext
 from routes_signals import register_signal_routes
 from routes_team_missions import register_team_mission_routes
+from routes_token_usage import register_token_usage_routes
 from routes_trading import register_trading_routes
 from routes_users import register_user_routes
 
@@ -51,5 +52,6 @@ def create_app() -> FastAPI:
     register_challenge_routes(app, ctx)
     register_team_mission_routes(app, ctx)
     register_user_routes(app, ctx)
+    register_token_usage_routes(app, ctx)
     register_misc_routes(app)
     return app

--- a/service/server/routes_models.py
+++ b/service/server/routes_models.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+from token_usage import MAX_REPORTS_PER_BATCH, MAX_TOKENS_PER_REPORT
 
 
 class AgentLogin(BaseModel):
@@ -307,3 +309,30 @@ class PointsTransferRequest(BaseModel):
 
 class PointsExchangeRequest(BaseModel):
     amount: int
+
+
+class TokenUsageReport(BaseModel):
+    model: str = Field(min_length=1, max_length=128)
+    provider: Optional[str] = Field(default=None, max_length=64)
+    input_tokens: int = Field(ge=0, le=MAX_TOKENS_PER_REPORT)
+    output_tokens: int = Field(ge=0, le=MAX_TOKENS_PER_REPORT)
+    client_event_id: Optional[str] = Field(default=None, max_length=128)
+
+    @field_validator("model", mode="before")
+    @classmethod
+    def normalize_model(cls, value):
+        if not isinstance(value, str):
+            return value
+        return value.strip()
+
+    @field_validator("provider", "client_event_id", mode="before")
+    @classmethod
+    def normalize_optional_text(cls, value):
+        if value is None or not isinstance(value, str):
+            return value
+        normalized = value.strip()
+        return normalized or None
+
+
+class TokenUsageBatchReport(BaseModel):
+    reports: List[TokenUsageReport] = Field(min_length=1, max_length=MAX_REPORTS_PER_BATCH)

--- a/service/server/routes_shared.py
+++ b/service/server/routes_shared.py
@@ -57,6 +57,8 @@ AGENT_MESSAGE_SUMMARY_CACHE_TTL_SECONDS = 5
 EXPERIMENT_NOTICE_CACHE_TTL_SECONDS = 5
 SIGNAL_FEED_CACHE_TTL_SECONDS = 10
 POSITIONS_CACHE_TTL_SECONDS = 10
+TOKEN_USAGE_OVERVIEW_CACHE_KEY_PREFIX = 'token_usage:overview'
+TOKEN_USAGE_OVERVIEW_CACHE_TTL_SECONDS = 60
 
 MENTION_PATTERN = re.compile(r'@([A-Za-z0-9_\-]{2,64})')
 _EXPERIMENT_NOTICE_EXPOSURE_EVENT_CACHE: dict[tuple[int, str, str], float] = {}
@@ -156,6 +158,8 @@ class RouteContext:
     agent_message_summary_cache: dict[str, tuple[float, dict[str, Any]]] = field(default_factory=dict)
     experiment_notice_cache: dict[int, tuple[float, Optional[dict[str, Any]]]] = field(default_factory=dict)
     content_rate_limit_state: dict[tuple[int, str], dict[str, Any]] = field(default_factory=dict)
+    token_usage_rate_limit_state: dict[int, list[float]] = field(default_factory=dict)
+    token_usage_overview_cache: dict[str, tuple[float, Any]] = field(default_factory=dict)
     ws_connections: dict[int, WebSocket] = field(default_factory=dict)
     verification_codes: dict[str, dict[str, Any]] = field(default_factory=dict)
     agent_token_recovery_requests: dict[int, dict[str, Any]] = field(default_factory=dict)

--- a/service/server/routes_token_usage.py
+++ b/service/server/routes_token_usage.py
@@ -1,0 +1,141 @@
+"""Token usage routes.
+
+Agents self-report LLM token usage per call; the platform aggregates it by
+model and by UTC day (issue #74). Writes and per-agent reads are scoped to the
+authenticated agent; the model overview is a read-only, agent-anonymous rollup
+(short-cached) so anyone can see how the models are used.
+"""
+
+import time
+from datetime import date
+from typing import Optional
+
+from fastapi import FastAPI, Header, HTTPException, Query
+
+from permissions import require_agent
+from routes_models import TokenUsageBatchReport, TokenUsageReport
+from routes_shared import (
+    TOKEN_USAGE_OVERVIEW_CACHE_KEY_PREFIX,
+    TOKEN_USAGE_OVERVIEW_CACHE_TTL_SECONDS,
+    RouteContext,
+    get_short_cached_payload,
+    set_short_cached_payload,
+)
+from token_usage import (
+    get_usage_by_model_and_day,
+    is_valid_usage_date,
+    record_token_usage,
+    record_token_usage_batch,
+    summarize_usage,
+)
+
+TOKEN_USAGE_REPORT_WINDOW_SECONDS = 60
+TOKEN_USAGE_REPORT_WINDOW_LIMIT = 120
+TOKEN_USAGE_RATE_LIMIT_MAX_AGENTS = 10000
+
+
+def register_token_usage_routes(app: FastAPI, ctx: RouteContext) -> None:
+    @app.post('/api/claw/usage')
+    async def report_token_usage(data: TokenUsageReport, authorization: str = Header(None)):
+        agent = require_agent(authorization)
+        _enforce_token_usage_report_rate_limit(ctx, agent['id'])
+        record = record_token_usage(
+            agent_id=agent['id'],
+            model=data.model,
+            provider=data.provider or '',
+            input_tokens=data.input_tokens,
+            output_tokens=data.output_tokens,
+            client_event_id=data.client_event_id,
+        )
+        return {'success': True, 'usage': record}
+
+    @app.post('/api/claw/usage/batch')
+    async def report_token_usage_batch(data: TokenUsageBatchReport, authorization: str = Header(None)):
+        # One batch counts as one write, so a busy agent can report many calls
+        # in a single request without the rate limit dropping usage.
+        agent = require_agent(authorization)
+        _enforce_token_usage_report_rate_limit(ctx, agent['id'])
+        records = record_token_usage_batch(
+            agent_id=agent['id'],
+            reports=[report.model_dump() for report in data.reports],
+        )
+        return {'success': True, 'count': len(records), 'usage': records}
+
+    @app.get('/api/claw/usage')
+    async def get_my_token_usage(
+        start_date: Optional[str] = Query(None),
+        end_date: Optional[str] = Query(None),
+        authorization: str = Header(None),
+    ):
+        agent = require_agent(authorization)
+        start, end = _validated_date_range(start_date, end_date)
+        rows = get_usage_by_model_and_day(agent_id=agent['id'], start_date=start, end_date=end)
+        return {'agent_id': agent['id'], 'usage': rows, 'totals': summarize_usage(rows), 'timezone': 'UTC'}
+
+    @app.get('/api/usage/models')
+    async def get_model_usage_overview(
+        start_date: Optional[str] = Query(None),
+        end_date: Optional[str] = Query(None),
+    ):
+        start, end = _validated_date_range(start_date, end_date)
+        cache_key = f"{TOKEN_USAGE_OVERVIEW_CACHE_KEY_PREFIX}:start={start or ''}:end={end or ''}"
+        cached = get_short_cached_payload(
+            ctx, ctx.token_usage_overview_cache, cache_key, TOKEN_USAGE_OVERVIEW_CACHE_TTL_SECONDS
+        )
+        if cached is not None:
+            return cached
+
+        rows = get_usage_by_model_and_day(start_date=start, end_date=end)
+        payload = {'usage': rows, 'totals': summarize_usage(rows), 'timezone': 'UTC'}
+        return set_short_cached_payload(
+            ctx, ctx.token_usage_overview_cache, cache_key, payload, TOKEN_USAGE_OVERVIEW_CACHE_TTL_SECONDS
+        )
+
+
+def _validated_date_range(
+    start_date: Optional[str],
+    end_date: Optional[str],
+) -> tuple[Optional[str], Optional[str]]:
+    """Reject malformed date filters before they reach the query. Fail closed."""
+    parsed_start = _parse_usage_query_date(start_date)
+    parsed_end = _parse_usage_query_date(end_date)
+    if parsed_start is not None and parsed_end is not None and parsed_start > parsed_end:
+        raise HTTPException(status_code=400, detail='start_date must be before or equal to end_date')
+    return start_date, end_date
+
+
+def _parse_usage_query_date(value: Optional[str]) -> Optional[date]:
+    if value is None:
+        return None
+    if not is_valid_usage_date(value):
+        raise HTTPException(status_code=400, detail='Dates must use YYYY-MM-DD format')
+    return date.fromisoformat(value)
+
+
+def _enforce_token_usage_report_rate_limit(ctx: RouteContext, agent_id: int) -> None:
+    """Bound self-reported usage writes from each authenticated agent."""
+    now_ts = time.time()
+    state = ctx.token_usage_rate_limit_state
+    recent_timestamps = [
+        timestamp
+        for timestamp in state.get(agent_id, [])
+        if now_ts - timestamp < TOKEN_USAGE_REPORT_WINDOW_SECONDS
+    ]
+    if len(recent_timestamps) >= TOKEN_USAGE_REPORT_WINDOW_LIMIT:
+        raise HTTPException(status_code=429, detail='Token usage report rate limit reached. Please slow down.')
+    recent_timestamps.append(now_ts)
+    state[agent_id] = recent_timestamps
+
+    if len(state) > TOKEN_USAGE_RATE_LIMIT_MAX_AGENTS:
+        _prune_idle_rate_limit_agents(state, now_ts)
+
+
+def _prune_idle_rate_limit_agents(state: dict[int, list[float]], now_ts: float) -> None:
+    """Drop agents whose most recent report is older than the window."""
+    idle_agent_ids = [
+        candidate_id
+        for candidate_id, timestamps in state.items()
+        if not timestamps or now_ts - timestamps[-1] >= TOKEN_USAGE_REPORT_WINDOW_SECONDS
+    ]
+    for candidate_id in idle_agent_ids:
+        state.pop(candidate_id, None)

--- a/service/server/tests/test_token_usage.py
+++ b/service/server/tests/test_token_usage.py
@@ -1,0 +1,353 @@
+# ruff: noqa: E402
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SERVER_DIR = Path(__file__).resolve().parents[1]
+if str(SERVER_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVER_DIR))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import database
+from routes import create_app
+from routes_shared import RouteContext, utc_now_iso_z
+from routes_token_usage import (
+    TOKEN_USAGE_REPORT_WINDOW_SECONDS,
+    _prune_idle_rate_limit_agents,
+    register_token_usage_routes,
+)
+from token_usage import MAX_REPORTS_PER_BATCH, compute_cost_usd, estimate_tokens
+
+
+class TokenUsageEndToEndTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        database.DATABASE_URL = ""
+        database._SQLITE_DB_PATH = os.path.join(self.tmp.name, "test.db")
+        database.init_database()
+
+        self.agent_token = "token-agent-a"
+        self.other_token = "token-agent-b"
+        self.agent_id = self._create_agent("agent-a", self.agent_token)
+        self.other_id = self._create_agent("agent-b", self.other_token)
+
+        app = FastAPI()
+        register_token_usage_routes(app, RouteContext())
+        self.client = TestClient(app)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _create_agent(self, name: str, token: str) -> int:
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO agents (name, token, points, cash, created_at, updated_at)
+            VALUES (?, ?, 0, 100000.0, ?, ?)
+            """,
+            (name, token, utc_now_iso_z(), utc_now_iso_z()),
+        )
+        agent_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+        return agent_id
+
+    def _auth(self, token: str) -> dict:
+        return {"Authorization": f"Bearer {token}"}
+
+    def _insert_backdated_usage(self, agent_id: int, model: str, day: str) -> None:
+        conn = database.get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO token_usage
+            (agent_id, model, provider, input_tokens, output_tokens, cost_usd, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (agent_id, model, "openai", 100, 100, 0.001, f"{day} 09:00:00"),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_report_then_aggregate_sums_by_model(self) -> None:
+        payload = {
+            "model": "claude-opus-4-8",
+            "provider": "anthropic",
+            "input_tokens": 1000,
+            "output_tokens": 500,
+        }
+        first = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+        self.assertEqual(first.status_code, 200)
+        self.assertTrue(first.json()["success"])
+
+        second = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+        self.assertEqual(second.status_code, 200)
+
+        response = self.client.get("/api/claw/usage", headers=self._auth(self.agent_token))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+
+        self.assertEqual(len(body["usage"]), 1)
+        row = body["usage"][0]
+        self.assertEqual(row["model"], "claude-opus-4-8")
+        self.assertEqual(row["input_tokens"], 2000)
+        self.assertEqual(row["output_tokens"], 1000)
+        self.assertEqual(row["total_tokens"], 3000)
+        self.assertEqual(row["call_count"], 2)
+        # (2000/1M * 5) + (1000/1M * 25) = 0.01 + 0.025 = 0.035
+        self.assertAlmostEqual(row["cost_usd"], 0.035, places=6)
+        self.assertEqual(body["totals"]["total_tokens"], 3000)
+
+    def test_unknown_model_has_no_cost(self) -> None:
+        payload = {"model": "mystery-model-9", "input_tokens": 100, "output_tokens": 100}
+        response = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["usage"]["cost_usd"])
+
+        overview = self.client.get("/api/claw/usage", headers=self._auth(self.agent_token))
+        self.assertIsNone(overview.json()["usage"][0]["cost_usd"])
+        self.assertIsNone(overview.json()["totals"]["cost_usd"])
+
+    def test_model_and_provider_are_trimmed_before_storage(self) -> None:
+        payload = {
+            "model": "  gpt-5.2  ",
+            "provider": "  openai  ",
+            "input_tokens": 100,
+            "output_tokens": 100,
+        }
+        response = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+        self.assertEqual(response.status_code, 200)
+        usage = response.json()["usage"]
+        self.assertEqual(usage["model"], "gpt-5.2")
+        self.assertEqual(usage["provider"], "openai")
+
+    def test_whitespace_model_is_rejected(self) -> None:
+        response = self.client.post(
+            "/api/claw/usage",
+            json={"model": "   ", "input_tokens": 10, "output_tokens": 10},
+            headers=self._auth(self.agent_token),
+        )
+        self.assertEqual(response.status_code, 422)
+
+    def test_grouping_splits_by_day_and_model(self) -> None:
+        self._insert_backdated_usage(self.agent_id, "gpt-5.2", "2026-07-01")
+        self._insert_backdated_usage(self.agent_id, "gpt-5.2", "2026-07-02")
+        self._insert_backdated_usage(self.agent_id, "claude-haiku-4-5", "2026-07-02")
+
+        body = self.client.get("/api/claw/usage", headers=self._auth(self.agent_token)).json()
+        buckets = {(row["usage_date"], row["model"]) for row in body["usage"]}
+        self.assertEqual(
+            buckets,
+            {
+                ("2026-07-01", "gpt-5.2"),
+                ("2026-07-02", "gpt-5.2"),
+                ("2026-07-02", "claude-haiku-4-5"),
+            },
+        )
+
+    def test_date_filter_bounds_results(self) -> None:
+        self._insert_backdated_usage(self.agent_id, "gpt-5.2", "2026-07-01")
+        self._insert_backdated_usage(self.agent_id, "gpt-5.2", "2026-07-05")
+
+        response = self.client.get(
+            "/api/claw/usage",
+            params={"start_date": "2026-07-02", "end_date": "2026-07-06"},
+            headers=self._auth(self.agent_token),
+        )
+        dates = [row["usage_date"] for row in response.json()["usage"]]
+        self.assertEqual(dates, ["2026-07-05"])
+
+    def test_malformed_date_is_rejected(self) -> None:
+        response = self.client.get(
+            "/api/claw/usage",
+            params={"start_date": "07/01/2026"},
+            headers=self._auth(self.agent_token),
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_impossible_date_is_rejected(self) -> None:
+        response = self.client.get(
+            "/api/usage/models",
+            params={"start_date": "2026-99-99"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_start_date_after_end_date_is_rejected(self) -> None:
+        response = self.client.get(
+            "/api/claw/usage",
+            params={"start_date": "2026-07-05", "end_date": "2026-07-01"},
+            headers=self._auth(self.agent_token),
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_missing_token_is_unauthorized(self) -> None:
+        payload = {"model": "gpt-5.2", "input_tokens": 10, "output_tokens": 10}
+        self.assertEqual(self.client.post("/api/claw/usage", json=payload).status_code, 401)
+        self.assertEqual(
+            self.client.post("/api/claw/usage", json=payload, headers=self._auth("bogus")).status_code,
+            401,
+        )
+        self.assertEqual(self.client.get("/api/claw/usage").status_code, 401)
+
+    def test_negative_and_oversized_tokens_are_rejected(self) -> None:
+        negative = self.client.post(
+            "/api/claw/usage",
+            json={"model": "gpt-5.2", "input_tokens": -1, "output_tokens": 0},
+            headers=self._auth(self.agent_token),
+        )
+        self.assertEqual(negative.status_code, 422)
+
+        oversized = self.client.post(
+            "/api/claw/usage",
+            json={"model": "gpt-5.2", "input_tokens": 999_999_999, "output_tokens": 0},
+            headers=self._auth(self.agent_token),
+        )
+        self.assertEqual(oversized.status_code, 422)
+
+    def test_token_usage_reports_are_rate_limited_per_agent(self) -> None:
+        payload = {"model": "gpt-5.2", "input_tokens": 10, "output_tokens": 10}
+        with patch("routes_token_usage.TOKEN_USAGE_REPORT_WINDOW_LIMIT", 2):
+            first = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+            second = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+            third = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(third.status_code, 429)
+
+    def test_per_agent_reads_are_isolated_but_overview_is_shared(self) -> None:
+        self.client.post(
+            "/api/claw/usage",
+            json={"model": "gpt-5.2", "input_tokens": 100, "output_tokens": 100},
+            headers=self._auth(self.agent_token),
+        )
+        self.client.post(
+            "/api/claw/usage",
+            json={"model": "claude-haiku-4-5", "input_tokens": 200, "output_tokens": 200},
+            headers=self._auth(self.other_token),
+        )
+
+        mine = self.client.get("/api/claw/usage", headers=self._auth(self.agent_token)).json()
+        self.assertEqual({row["model"] for row in mine["usage"]}, {"gpt-5.2"})
+
+        overview = self.client.get("/api/usage/models").json()
+        self.assertEqual({row["model"] for row in overview["usage"]}, {"gpt-5.2", "claude-haiku-4-5"})
+
+    def test_token_usage_routes_are_registered_on_full_app(self) -> None:
+        client = TestClient(create_app())
+        payload = {"model": "gpt-5.2", "input_tokens": 100, "output_tokens": 100}
+
+        report = client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+        self.assertEqual(report.status_code, 200)
+
+        overview = client.get("/api/usage/models")
+        self.assertEqual(overview.status_code, 200)
+        self.assertIn("usage", overview.json())
+
+    def test_responses_declare_utc_day_bucket(self) -> None:
+        self._insert_backdated_usage(self.agent_id, "gpt-5.2", "2026-07-01")
+        mine = self.client.get("/api/claw/usage", headers=self._auth(self.agent_token)).json()
+        overview = self.client.get("/api/usage/models").json()
+        self.assertEqual(mine["timezone"], "UTC")
+        self.assertEqual(overview["timezone"], "UTC")
+
+    def test_batch_report_records_every_entry(self) -> None:
+        batch = {
+            "reports": [
+                {"model": "gpt-5.2", "input_tokens": 100, "output_tokens": 100},
+                {"model": "gpt-5.2", "input_tokens": 50, "output_tokens": 50},
+                {"model": "claude-haiku-4-5", "input_tokens": 10, "output_tokens": 10},
+            ]
+        }
+        response = self.client.post("/api/claw/usage/batch", json=batch, headers=self._auth(self.agent_token))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 3)
+
+        body = self.client.get("/api/claw/usage", headers=self._auth(self.agent_token)).json()
+        by_model = {row["model"]: row for row in body["usage"]}
+        self.assertEqual(by_model["gpt-5.2"]["call_count"], 2)
+        self.assertEqual(by_model["gpt-5.2"]["total_tokens"], 300)
+        self.assertEqual(by_model["claude-haiku-4-5"]["call_count"], 1)
+
+    def test_batch_counts_as_a_single_write_against_the_rate_limit(self) -> None:
+        batch = {"reports": [{"model": "gpt-5.2", "input_tokens": 1, "output_tokens": 1}] * 3}
+        with patch("routes_token_usage.TOKEN_USAGE_REPORT_WINDOW_LIMIT", 1):
+            first = self.client.post("/api/claw/usage/batch", json=batch, headers=self._auth(self.agent_token))
+            second = self.client.post("/api/claw/usage/batch", json=batch, headers=self._auth(self.agent_token))
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(first.json()["count"], 3)
+        self.assertEqual(second.status_code, 429)
+
+    def test_empty_and_oversized_batches_are_rejected(self) -> None:
+        empty = self.client.post(
+            "/api/claw/usage/batch", json={"reports": []}, headers=self._auth(self.agent_token)
+        )
+        self.assertEqual(empty.status_code, 422)
+
+        one = {"model": "gpt-5.2", "input_tokens": 1, "output_tokens": 1}
+        oversized = self.client.post(
+            "/api/claw/usage/batch",
+            json={"reports": [one] * (MAX_REPORTS_PER_BATCH + 1)},
+            headers=self._auth(self.agent_token),
+        )
+        self.assertEqual(oversized.status_code, 422)
+
+    def test_repeated_client_event_id_is_not_double_counted(self) -> None:
+        payload = {
+            "model": "gpt-5.2",
+            "input_tokens": 100,
+            "output_tokens": 100,
+            "client_event_id": "evt-1",
+        }
+        first = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+        second = self.client.post("/api/claw/usage", json=payload, headers=self._auth(self.agent_token))
+        self.assertFalse(first.json()["usage"]["deduplicated"])
+        self.assertTrue(second.json()["usage"]["deduplicated"])
+        self.assertEqual(first.json()["usage"]["id"], second.json()["usage"]["id"])
+
+        body = self.client.get("/api/claw/usage", headers=self._auth(self.agent_token)).json()
+        self.assertEqual(len(body["usage"]), 1)
+        self.assertEqual(body["usage"][0]["call_count"], 1)
+        self.assertEqual(body["usage"][0]["total_tokens"], 200)
+
+    def test_overview_is_cached_within_ttl(self) -> None:
+        self._insert_backdated_usage(self.agent_id, "gpt-5.2", "2026-07-01")
+        first = self.client.get("/api/usage/models").json()
+
+        # A row inserted after the first call must not appear until the cache expires.
+        self._insert_backdated_usage(self.agent_id, "gpt-5-mini", "2026-07-02")
+        second = self.client.get("/api/usage/models").json()
+
+        self.assertEqual(second, first)
+        self.assertNotIn("gpt-5-mini", {row["model"] for row in second["usage"]})
+
+    def test_idle_agents_are_pruned_from_rate_limit_state(self) -> None:
+        now_ts = time.time()
+        state = {
+            1: [now_ts],
+            2: [now_ts - (TOKEN_USAGE_REPORT_WINDOW_SECONDS + 10)],
+            3: [],
+        }
+        _prune_idle_rate_limit_agents(state, now_ts)
+        self.assertEqual(set(state), {1})
+
+    def test_cost_and_estimate_helpers(self) -> None:
+        # (1_000_000/1M * 3) + (1_000_000/1M * 15) = 18.0 for claude-sonnet-4-6
+        self.assertAlmostEqual(compute_cost_usd("claude-sonnet-4-6", 1_000_000, 1_000_000), 18.0, places=6)
+        self.assertIsNone(compute_cost_usd("unknown-model", 100, 100))
+        self.assertEqual(estimate_tokens(""), 0)
+        self.assertEqual(estimate_tokens("abcd" * 25), 25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/service/server/token_usage.py
+++ b/service/server/token_usage.py
@@ -1,0 +1,291 @@
+"""Token usage tracking.
+
+Records per-call LLM token usage reported by agents and aggregates it by
+model and by day (issue #74).
+
+Adapted from RadSim's task_logger token accounting: RadSim logs the calls it
+makes itself, whereas this platform never calls the models, so agents report
+their own usage here. The storage shape (model, provider, input/output tokens,
+timestamp) and the SQL aggregation approach are ported from RadSim; the write
+path uses AI-Trader's dual-backend database layer instead of a private SQLite
+file.
+
+Self-reported usage is untrusted input: token counts are bounded and validated
+at the API layer, cost is always computed server-side from the pricing table
+(never trusted from the client), and the day bucket uses the server-recorded
+timestamp (never a client-supplied date).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, timedelta
+from typing import Any, Optional
+
+from config import get_model_pricing
+from database import get_db_connection
+
+# Upper bound for a single report. Guards the ledger against absurd or abusive
+# values while staying far above any real single-call usage.
+MAX_TOKENS_PER_REPORT = 20_000_000
+
+# Upper bound on reports accepted in one batch request. Lets a busy agent
+# report many calls at once (so the write rate limit does not silently drop
+# usage) while keeping a single request bounded.
+MAX_REPORTS_PER_BATCH = 500
+
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def is_valid_usage_date(value: str) -> bool:
+    """Return True when value is a plain YYYY-MM-DD date string."""
+    if not _DATE_PATTERN.match(value or ""):
+        return False
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _day_after(usage_date: str) -> str:
+    """Return the day after a YYYY-MM-DD date, as an exclusive upper bound.
+
+    Fails closed on a malformed date so a bad filter cannot widen the query.
+    """
+    if not is_valid_usage_date(usage_date):
+        raise ValueError(f"Invalid usage date: {usage_date}")
+    return (date.fromisoformat(usage_date) + timedelta(days=1)).isoformat()
+
+
+def estimate_tokens(text: str) -> int:
+    """Estimate token count from character length (~4 characters per token).
+
+    Ported from RadSim's prompt estimator. A client-side fallback for agents
+    that cannot read exact usage from their provider; the server stores whatever
+    integer counts the agent reports.
+    """
+    if not text:
+        return 0
+    return max(1, round(len(text) / 4))
+
+
+def compute_cost_usd(model: str, input_tokens: int, output_tokens: int) -> Optional[float]:
+    """Return the USD cost for a call, or None when the model price is unknown.
+
+    Ported from RadSim's status-bar cost calculation.
+    """
+    pricing = get_model_pricing(model)
+    if pricing is None:
+        return None
+    input_cost = (input_tokens / 1_000_000) * pricing[0]
+    output_cost = (output_tokens / 1_000_000) * pricing[1]
+    return round(input_cost + output_cost, 6)
+
+
+def record_token_usage(
+    agent_id: int,
+    model: str,
+    provider: str,
+    input_tokens: int,
+    output_tokens: int,
+    client_event_id: Optional[str] = None,
+) -> dict[str, Any]:
+    """Insert one token-usage record for an agent and return the stored row.
+
+    Cost is computed server-side; the day bucket derives from the server clock.
+    A repeated client_event_id returns the already-stored row instead of
+    inserting again, so a retried report is not double-counted.
+    """
+    conn = get_db_connection()
+    try:
+        cursor = conn.cursor()
+        record = _insert_usage(
+            cursor, agent_id, model, provider, input_tokens, output_tokens, client_event_id
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return record
+
+
+def record_token_usage_batch(
+    agent_id: int,
+    reports: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Insert many token-usage records for an agent in one transaction.
+
+    Each report is a dict with model, provider, input_tokens, output_tokens and
+    an optional client_event_id. Idempotency applies per record.
+    """
+    conn = get_db_connection()
+    records: list[dict[str, Any]] = []
+    try:
+        cursor = conn.cursor()
+        for report in reports:
+            records.append(
+                _insert_usage(
+                    cursor,
+                    agent_id,
+                    report["model"],
+                    report.get("provider") or "",
+                    report["input_tokens"],
+                    report["output_tokens"],
+                    report.get("client_event_id"),
+                )
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return records
+
+
+def _insert_usage(
+    cursor: Any,
+    agent_id: int,
+    model: str,
+    provider: str,
+    input_tokens: int,
+    output_tokens: int,
+    client_event_id: Optional[str],
+) -> dict[str, Any]:
+    """Insert one usage row, or return the existing row for a repeated key."""
+    existing = _find_existing_usage(cursor, agent_id, client_event_id)
+    if existing is not None:
+        existing["deduplicated"] = True
+        return existing
+
+    cost_usd = compute_cost_usd(model, input_tokens, output_tokens)
+    cursor.execute(
+        """
+        INSERT INTO token_usage
+        (agent_id, model, provider, input_tokens, output_tokens, cost_usd, client_event_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (agent_id, model, provider or None, input_tokens, output_tokens, cost_usd, client_event_id),
+    )
+    return {
+        "id": cursor.lastrowid,
+        "agent_id": agent_id,
+        "model": model,
+        "provider": provider or None,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "cost_usd": cost_usd,
+        "client_event_id": client_event_id,
+        "deduplicated": False,
+    }
+
+
+def _find_existing_usage(
+    cursor: Any,
+    agent_id: int,
+    client_event_id: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Return the stored row for an agent's client_event_id, if one exists."""
+    if not client_event_id:
+        return None
+    cursor.execute(
+        """
+        SELECT id, agent_id, model, provider, input_tokens, output_tokens, cost_usd, client_event_id
+        FROM token_usage
+        WHERE agent_id = ? AND client_event_id = ?
+        """,
+        (agent_id, client_event_id),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    cost = row["cost_usd"]
+    return {
+        "id": row["id"],
+        "agent_id": row["agent_id"],
+        "model": row["model"],
+        "provider": row["provider"],
+        "input_tokens": int(row["input_tokens"] or 0),
+        "output_tokens": int(row["output_tokens"] or 0),
+        "total_tokens": int((row["input_tokens"] or 0) + (row["output_tokens"] or 0)),
+        "cost_usd": round(float(cost), 6) if cost is not None else None,
+        "client_event_id": row["client_event_id"],
+    }
+
+
+def get_usage_by_model_and_day(
+    agent_id: Optional[int] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    """Aggregate token usage grouped by model and by UTC day.
+
+    Pass agent_id to scope to one agent; omit it for a platform-wide overview.
+    Dates are inclusive YYYY-MM-DD bounds; the day bucket is UTC (the recorded
+    timestamp's date). Bounds compare against the raw created_at column so the
+    (agent_id, created_at) / (model, created_at) indexes can serve the range.
+    """
+    clauses: list[str] = []
+    params: list[Any] = []
+
+    if agent_id is not None:
+        clauses.append("agent_id = ?")
+        params.append(agent_id)
+    if start_date:
+        clauses.append("created_at >= ?")
+        params.append(start_date)
+    if end_date:
+        clauses.append("created_at < ?")
+        params.append(_day_after(end_date))
+
+    where_clause = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+
+    conn = get_db_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            f"""
+            SELECT
+                substr(created_at, 1, 10) AS usage_date,
+                model,
+                SUM(input_tokens) AS input_tokens,
+                SUM(output_tokens) AS output_tokens,
+                SUM(input_tokens + output_tokens) AS total_tokens,
+                SUM(cost_usd) AS cost_usd,
+                COUNT(*) AS call_count
+            FROM token_usage
+            {where_clause}
+            GROUP BY usage_date, model
+            ORDER BY usage_date DESC, total_tokens DESC
+            """,
+            params,
+        )
+        return [_row_to_usage(row) for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
+
+def summarize_usage(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Roll a list of per-model-per-day rows into overall totals."""
+    input_tokens = sum(row["input_tokens"] for row in rows)
+    output_tokens = sum(row["output_tokens"] for row in rows)
+    known_costs = [row["cost_usd"] for row in rows if row["cost_usd"] is not None]
+    return {
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+        "call_count": sum(row["call_count"] for row in rows),
+        "cost_usd": round(sum(known_costs), 6) if known_costs else None,
+    }
+
+
+def _row_to_usage(row: Any) -> dict[str, Any]:
+    """Coerce a database row into a plain, typed usage dict."""
+    cost = row["cost_usd"]
+    return {
+        "usage_date": row["usage_date"],
+        "model": row["model"],
+        "input_tokens": int(row["input_tokens"] or 0),
+        "output_tokens": int(row["output_tokens"] or 0),
+        "total_tokens": int(row["total_tokens"] or 0),
+        "cost_usd": round(float(cost), 6) if cost is not None else None,
+        "call_count": int(row["call_count"] or 0),
+    }


### PR DESCRIPTION
Addresses #74.

I had a similar token-counter in a Python agent harness I built, so I used it as a base here. Agents self-report usage; the server stores it and serves per-model, per-day totals with server-side cost via `GET /api/claw/usage` and public `GET /api/usage/models`. SQLite + PostgreSQL.
