### PR TITLE
Fix intraday-timestamp crash in trading-date scheduling (#69)

### DIFF
--- a/agent/base_agent/base_agent.py
+++ b/agent/base_agent/base_agent.py
@@ -571,46 +571,14 @@ class BaseAgent:
         Returns:
             List of trading dates (excluding weekends and holidays)
         """
-        from tools.price_tools import is_trading_day
+        from tools.price_tools import compute_trading_dates
 
-        dates = []
-        max_date = None
-
-        if not os.path.exists(self.position_file):
+        position_file = self.position_file
+        if not os.path.exists(position_file):
             self.register_agent()
-            max_date = init_date
-        else:
-            # Read existing position file, find latest date
-            with open(self.position_file, "r") as f:
-                for line in f:
-                    doc = json.loads(line)
-                    current_date = doc["date"]
-                    if max_date is None:
-                        max_date = current_date
-                    else:
-                        current_date_obj = datetime.strptime(current_date.split(' ')[0], "%Y-%m-%d")
-                        max_date_obj = datetime.strptime(max_date.split(' ')[0], "%Y-%m-%d")
-                        if current_date_obj > max_date_obj:
-                            max_date = current_date
+            position_file = None
 
-        # Check if new dates need to be processed
-        max_date_obj = datetime.strptime(max_date.split(' ')[0], "%Y-%m-%d")
-        end_date_obj = datetime.strptime(end_date.split(' ')[0], "%Y-%m-%d")
-
-        if end_date_obj <= max_date_obj:
-            return []
-
-        # Generate trading date list, filtered by actual trading days
-        trading_dates = []
-        current_date = max_date_obj + timedelta(days=1)
-        from tools.price_tools import is_trading_day
-        while current_date <= end_date_obj:
-            date_str = current_date.strftime("%Y-%m-%d")
-            # Check if this is an actual trading day in merged.jsonl
-            if is_trading_day(date_str, market=self.market):
-                trading_dates.append(date_str)
-            current_date += timedelta(days=1)
-        return trading_dates
+        return compute_trading_dates(position_file, init_date, end_date, self.market)
 
     async def run_with_retry(self, today_date: str) -> None:
         """Run method with retry"""

--- a/agent/base_agent_astock/base_agent_astock.py
+++ b/agent/base_agent_astock/base_agent_astock.py
@@ -474,47 +474,14 @@ class BaseAgentAStock:
         Returns:
             List of trading dates (excluding weekends and holidays)
         """
-        from tools.price_tools import is_trading_day
+        from tools.price_tools import compute_trading_dates
 
-        dates = []
-        max_date = None
-
-        if not os.path.exists(self.position_file):
+        position_file = self.position_file
+        if not os.path.exists(position_file):
             self.register_agent()
-            max_date = init_date
-        else:
-            # Read existing position file, find latest date
-            with open(self.position_file, "r") as f:
-                for line in f:
-                    doc = json.loads(line)
-                    current_date = doc["date"]
-                    if max_date is None:
-                        max_date = current_date
-                    else:
-                        current_date_obj = datetime.strptime(current_date, "%Y-%m-%d")
-                        max_date_obj = datetime.strptime(max_date, "%Y-%m-%d")
-                        if current_date_obj > max_date_obj:
-                            max_date = current_date
+            position_file = None
 
-        # Check if new dates need to be processed
-        max_date_obj = datetime.strptime(max_date, "%Y-%m-%d")
-        end_date_obj = datetime.strptime(end_date, "%Y-%m-%d")
-
-        if end_date_obj <= max_date_obj:
-            return []
-
-        # Generate trading date list, filtered by actual trading days (A-shares market)
-        trading_dates = []
-        current_date = max_date_obj + timedelta(days=1)
-
-        while current_date <= end_date_obj:
-            date_str = current_date.strftime("%Y-%m-%d")
-            # Check if this is an actual trading day in A-shares market
-            if is_trading_day(date_str, market="cn"):
-                trading_dates.append(date_str)
-            current_date += timedelta(days=1)
-
-        return trading_dates
+        return compute_trading_dates(position_file, init_date, end_date, market="cn")
 
     async def run_with_retry(self, today_date: str) -> None:
         """Run method with retry"""

--- a/agent/base_agent_crypto/base_agent_crypto.py
+++ b/agent/base_agent_crypto/base_agent_crypto.py
@@ -382,47 +382,14 @@ class BaseAgentCrypto:
         Returns:
             List of trading dates (crypto trades every day)
         """
-        from tools.price_tools import is_trading_day
+        from tools.price_tools import compute_trading_dates
 
-        dates = []
-        max_date = None
-
-        if not os.path.exists(self.position_file):
+        position_file = self.position_file
+        if not os.path.exists(position_file):
             self.register_agent()
-            max_date = init_date
-        else:
-            # Read existing position file, find latest date
-            with open(self.position_file, "r") as f:
-                for line in f:
-                    doc = json.loads(line)
-                    current_date = doc["date"]
-                    if max_date is None:
-                        max_date = current_date
-                    else:
-                        current_date_obj = datetime.strptime(current_date, "%Y-%m-%d")
-                        max_date_obj = datetime.strptime(max_date, "%Y-%m-%d")
-                        if current_date_obj > max_date_obj:
-                            max_date = current_date
+            position_file = None
 
-        # Check if new dates need to be processed
-        max_date_obj = datetime.strptime(max_date, "%Y-%m-%d")
-        end_date_obj = datetime.strptime(end_date, "%Y-%m-%d")
-
-        if end_date_obj <= max_date_obj:
-            return []
-
-        # Generate trading date list, filtered by actual trading days
-        trading_dates = []
-        current_date = max_date_obj + timedelta(days=1)
-
-        while current_date <= end_date_obj:
-            date_str = current_date.strftime("%Y-%m-%d")
-            # Check if this is an actual trading day in merged.jsonl
-            if is_trading_day(date_str, market=self.market):
-                trading_dates.append(date_str)
-            current_date += timedelta(days=1)
-
-        return trading_dates
+        return compute_trading_dates(position_file, init_date, end_date, self.market)
 
     async def run_with_retry(self, today_date: str) -> None:
         """Run method with retry"""

--- a/tests/issue69_date_parsing_test.py
+++ b/tests/issue69_date_parsing_test.py
@@ -1,0 +1,95 @@
+# ruff: noqa: E402
+"""End-to-end coverage for issue #69: intraday timestamps crashing date parsing.
+
+The shipped data stores position dates like "2025-10-01 10:00:00", which the
+date-only strptime in get_trading_dates could not parse. These tests exercise
+the real scheduling path (parse_date + compute_trading_dates + is_trading_day)
+against that exact format, over real temp files.
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import tools.price_tools as price_tools
+from tools.price_tools import compute_trading_dates
+from utils.date_utils import parse_date
+
+
+class ParseDateTests(unittest.TestCase):
+    def test_accepts_plain_date(self):
+        self.assertEqual(parse_date("2025-10-01"), datetime(2025, 10, 1))
+
+    def test_accepts_intraday_timestamp(self):
+        # The exact shipped format from data/agent_data/*/position/position.jsonl.
+        self.assertEqual(parse_date("2025-10-01 10:00:00"), datetime(2025, 10, 1, 10, 0, 0))
+
+    def test_rejects_garbage(self):
+        with self.assertRaises(ValueError):
+            parse_date("01/10/2025")
+
+    def test_regression_old_date_only_parse_would_crash(self):
+        # Documents the root cause the fix removes.
+        with self.assertRaises(ValueError):
+            datetime.strptime("2025-10-01 10:00:00", "%Y-%m-%d")
+
+
+class ComputeTradingDatesTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+        # Market calendar marking Oct 2 and 3 as trading days.
+        merged = self.tmp_path / "merged.jsonl"
+        merged.write_text(
+            json.dumps({"Time Series (Daily)": {"2025-10-02": {}, "2025-10-03": {}}}) + "\n",
+            encoding="utf-8",
+        )
+        self._patch = patch.object(price_tools, "get_merged_file_path", return_value=merged)
+        self._patch.start()
+
+    def tearDown(self):
+        self._patch.stop()
+        self.tmp.cleanup()
+
+    def _write_positions(self, dates):
+        position_file = self.tmp_path / "position.jsonl"
+        with open(position_file, "w", encoding="utf-8") as f:
+            for value in dates:
+                f.write(json.dumps({"date": value, "positions": {}}) + "\n")
+        return str(position_file)
+
+    def test_intraday_timestamps_do_not_crash(self):
+        position_file = self._write_positions(["2025-10-01 10:00:00"])
+        dates = compute_trading_dates(position_file, "2025-10-01", "2025-10-03", market="us")
+        self.assertEqual(dates, ["2025-10-02", "2025-10-03"])
+
+    def test_latest_processed_date_is_respected(self):
+        position_file = self._write_positions(["2025-10-01 10:00:00", "2025-10-02 11:00:00"])
+        dates = compute_trading_dates(position_file, "2025-10-01", "2025-10-03", market="us")
+        self.assertEqual(dates, ["2025-10-03"])
+
+    def test_missing_position_file_starts_from_init_date(self):
+        dates = compute_trading_dates(None, "2025-10-01", "2025-10-03", market="us")
+        self.assertEqual(dates, ["2025-10-02", "2025-10-03"])
+
+    def test_no_new_dates_returns_empty(self):
+        position_file = self._write_positions(["2025-10-03 10:00:00"])
+        self.assertEqual(compute_trading_dates(position_file, "2025-10-01", "2025-10-03", market="us"), [])
+
+    def test_non_trading_days_are_filtered_out(self):
+        # Oct 4 is absent from the calendar, so it must not appear.
+        position_file = self._write_positions(["2025-10-01 10:00:00"])
+        dates = compute_trading_dates(position_file, "2025-10-01", "2025-10-04", market="us")
+        self.assertNotIn("2025-10-04", dates)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/price_tools.py
+++ b/tools/price_tools.py
@@ -14,6 +14,7 @@ project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 from tools.general_tools import get_config_value
+from utils.date_utils import parse_date
 
 def _normalize_timestamp_str(ts: str) -> str:
     """
@@ -331,6 +332,50 @@ def is_trading_day(date: str, market: str = "us") -> bool:
     except Exception as e:
         print(f"⚠️  Error checking trading day: {e}")
         return False
+
+
+def compute_trading_dates(
+    position_file: Optional[str],
+    init_date: str,
+    end_date: str,
+    market: str = "us",
+) -> List[str]:
+    """Trading days in (last processed date, end_date], filtered by market calendar.
+
+    The latest processed date is read from position_file when it exists,
+    otherwise scheduling starts from init_date. Date fields are parsed with
+    parse_date, so both "YYYY-MM-DD" and "YYYY-MM-DD HH:MM:SS" are accepted
+    (issue #69: intraday timestamps in the data crashed date-only parsing).
+    """
+    max_date = None
+    if position_file and os.path.exists(position_file):
+        with open(position_file, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                doc = json.loads(line)
+                current_date = doc["date"]
+                if max_date is None or parse_date(current_date) > parse_date(max_date):
+                    max_date = current_date
+    if max_date is None:
+        max_date = init_date
+
+    # Iterate on calendar dates only; dropping any time component keeps the
+    # last day inclusive regardless of an intraday timestamp on max_date.
+    max_date_obj = parse_date(max_date).date()
+    end_date_obj = parse_date(end_date).date()
+    if end_date_obj <= max_date_obj:
+        return []
+
+    trading_dates: List[str] = []
+    current_date = max_date_obj + timedelta(days=1)
+    while current_date <= end_date_obj:
+        date_str = current_date.strftime("%Y-%m-%d")
+        if is_trading_day(date_str, market=market):
+            trading_dates.append(date_str)
+        current_date += timedelta(days=1)
+    return trading_dates
 
 
 def get_all_trading_days(market: str = "us") -> List[str]:


### PR DESCRIPTION
Addresses #69.

`get_trading_dates` crashed on timestamped position dates (`unconverted data remains`). Now parses them via the tolerant `parse_date`.
