### PR TITLE
Pin openrouter dependency for Python compatibility

### DIFF
--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -7,7 +7,7 @@ web3>=6.15.1
 requests>=2.31.0
 aiohttp>=3.9.1
 python-multipart>=0.0.6
-openrouter>=1.0.0
+openrouter==0.11.28
 psycopg[binary]>=3.2.1
 redis>=5.0.8
 pytest>=8.0.0


### PR DESCRIPTION
Why:
Pin openrouter to a known compatible release so the server's Python venv can install dependencies successfully on modern Python versions. The prior openrouter>=1.0.0 requirement had no matching distribution for this environment and blocked setup.

What:
- Pins openrouter to 0.11.28 in service/requirements.txt to ensure pip can resolve and install the package.

Details:
- This is a small, targeted dependency change that enables the development environment and server startup. No behavioral changes to runtime logic are included.

Notes for reviewers:
- Confirm this pin is acceptable for production (upgrade path to a newer openrouter can be considered separately).
- If prefer a different compatible version, the requirements file can be updated accordingly.