### PR TITLE
Add London Strategic Edge as an optional price provider for US stocks and crypto

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ DB_PATH=service/server/data/clawtrader.db
 ALPHA_VANTAGE_API_KEY=demo
 # Optional: enrich US stock market-intel snapshots with Adanos social/news/prediction-market sentiment.
 ADANOS_API_KEY=
+# Optional: London Strategic Edge unified market data. When set, LSE is tried
+# first for US stock and crypto prices; Alpha Vantage / yfinance / Hyperliquid
+# remain as automatic fallbacks. Free key: https://londonstrategicedge.com/data?ref=ai-trader
+LSE_API_KEY=
 
 # ==================== Frontend ====================
 # Frontend auto-refresh interval in milliseconds.
@@ -35,6 +39,7 @@ CLAWTRADER_CORS_ORIGINS=http://localhost:3000,https://ai4trade.ai
 ADANOS_API_BASE_URL=https://api.adanos.org
 ALPHA_VANTAGE_BASE_URL=https://www.alphavantage.co/query
 HYPERLIQUID_API_URL=https://api.hyperliquid.xyz/info
+LSE_API_BASE_URL=https://api.londonstrategicedge.com/iso
 POLYMARKET_GAMMA_BASE_URL=https://gamma-api.polymarket.com
 POLYMARKET_CLOB_BASE_URL=https://clob.polymarket.com
 

--- a/service/server/price_fetcher.py
+++ b/service/server/price_fetcher.py
@@ -31,6 +31,15 @@ HYPERLIQUID_API_URL = os.environ.get("HYPERLIQUID_API_URL", "https://api.hyperli
 # Polymarket public endpoints (no API key required for reads)
 POLYMARKET_GAMMA_BASE_URL = os.environ.get("POLYMARKET_GAMMA_BASE_URL", "https://gamma-api.polymarket.com").strip()
 POLYMARKET_CLOB_BASE_URL = os.environ.get("POLYMARKET_CLOB_BASE_URL", "https://clob.polymarket.com").strip()
+
+# London Strategic Edge (LSE) unified market data API (optional).
+# One key covers US stocks, ETFs and crypto with 1m/5m OHLCV candles.
+# When LSE_API_KEY is set, LSE is tried first for us-stock and crypto prices;
+# the existing Alpha Vantage / yfinance / Hyperliquid paths remain as automatic
+# fallbacks, so leaving the key unset changes nothing.
+# Free API key: https://londonstrategicedge.com/data?ref=ai-trader
+LSE_API_KEY = os.environ.get("LSE_API_KEY", "").strip()
+LSE_API_BASE_URL = os.environ.get("LSE_API_BASE_URL", "https://api.londonstrategicedge.com/iso").strip()
 PRICE_FETCH_TIMEOUT_SECONDS = float(os.environ.get("PRICE_FETCH_TIMEOUT_SECONDS", "10"))
 PRICE_FETCH_MAX_RETRIES = max(0, int(os.environ.get("PRICE_FETCH_MAX_RETRIES", "2")))
 PRICE_FETCH_BACKOFF_BASE_SECONDS = max(0.0, float(os.environ.get("PRICE_FETCH_BACKOFF_BASE_SECONDS", "0.35")))
@@ -112,8 +121,9 @@ def _request_json_with_retry(
     method: str,
     url: str,
     *,
-    params: Optional[dict] = None,
+    params: Optional[object] = None,
     json_payload: Optional[dict] = None,
+    headers: Optional[dict] = None,
 ) -> object:
     remaining = _provider_cooldown_remaining(provider)
     if remaining > 0:
@@ -125,9 +135,9 @@ def _request_json_with_retry(
     for attempt in range(attempts):
         try:
             if method == "POST":
-                resp = requests.post(url, json=json_payload, timeout=PRICE_FETCH_TIMEOUT_SECONDS)
+                resp = requests.post(url, json=json_payload, headers=headers, timeout=PRICE_FETCH_TIMEOUT_SECONDS)
             else:
-                resp = requests.get(url, params=params, timeout=PRICE_FETCH_TIMEOUT_SECONDS)
+                resp = requests.get(url, params=params, headers=headers, timeout=PRICE_FETCH_TIMEOUT_SECONDS)
 
             if resp.status_code in _RETRYABLE_STATUS_CODES:
                 resp.raise_for_status()
@@ -674,6 +684,111 @@ def _get_hyperliquid_candle_close(symbol: str, executed_at: str) -> Optional[flo
     return float(f"{closest:.6f}")
 
 
+def _lse_symbol_slug(symbol: str) -> str:
+    """
+    Map an instrument symbol to LSE's per-symbol 1m candle table slug.
+    Examples: 'BTC/USD' -> 'btc_usd', 'BRK.B' -> 'brk_b'.
+    """
+    return symbol.strip().lower().replace("/", "_").replace("-", "_").replace(".", "_")
+
+
+def _lse_get_json(table: str, params: list) -> object:
+    if not LSE_API_KEY or not LSE_API_BASE_URL:
+        raise RuntimeError("LSE_API_KEY is not configured")
+    url = f"{LSE_API_BASE_URL.rstrip('/')}/{table}"
+    return _request_json_with_retry(
+        "lse",
+        "GET",
+        url,
+        params=params,
+        headers={"x-api-key": LSE_API_KEY},
+    )
+
+
+def _lse_candle_close(table: str, target_utc: datetime, extra_params: Optional[list] = None) -> Optional[float]:
+    """
+    Latest candle close at-or-before target_utc from one LSE candle table.
+    Filters use PostgREST syntax; repeated `timestamp` params are AND'ed
+    server-side. The gte bound keeps the scan short: 7 days covers weekends
+    and market holidays for "price at time" lookups on non-24/7 instruments.
+    """
+    since = (target_utc - timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    until = target_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    params = list(extra_params or [])
+    params += [
+        ("timestamp", f"gte.{since}"),
+        ("timestamp", f"lte.{until}"),
+        ("order", "timestamp.desc"),
+        ("limit", "1"),
+    ]
+    rows = _lse_get_json(table, params)
+    if isinstance(rows, list) and rows and isinstance(rows[0], dict):
+        try:
+            price = float(rows[0].get("close"))
+        except (TypeError, ValueError):
+            return None
+        if price > 0:
+            return float(f"{price:.6f}")
+    return None
+
+
+def _lse_target_utc(executed_at: str) -> datetime:
+    # "now"-style queries normally arrive with a concrete timestamp, but be
+    # lenient: an unparseable executed_at falls back to the current time
+    # rather than failing the whole LSE path.
+    return _parse_executed_at_to_utc(executed_at) or datetime.now(UTC)
+
+
+def _get_lse_us_stock_price(symbol: str, executed_at: str) -> Optional[float]:
+    """
+    US stock/ETF price from LSE 1m candles. US listings live in
+    d_candles_<sym>; other instruments in candles_<sym>. The x_candles_5m
+    aggregate is the last resort so a thin 1m table still yields a price.
+    """
+    target_utc = _lse_target_utc(executed_at)
+    ticker = _normalize_yfinance_us_symbol(symbol)
+    if not ticker:
+        return None
+    slug = _lse_symbol_slug(ticker)
+    for table in (f"d_candles_{slug}", f"candles_{slug}"):
+        try:
+            price = _lse_candle_close(table, target_utc)
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else None
+            if status == 404:
+                # Symbol not in the LSE universe under this table name; try the
+                # next naming scheme before giving up.
+                continue
+            _price_log(f"[Price API] LSE HTTP {status} for {ticker}")
+            return None
+        except Exception as exc:
+            _price_log(f"[Price API] LSE error for {ticker}: {exc}")
+            return None
+        if price is not None:
+            return price
+    try:
+        return _lse_candle_close("x_candles_5m", target_utc, [("symbol", f"eq.{ticker}")])
+    except Exception as exc:
+        _price_log(f"[Price API] LSE 5m fallback error for {ticker}: {exc}")
+        return None
+
+
+def _get_lse_crypto_price(symbol: str, executed_at: str) -> Optional[float]:
+    """
+    Crypto price from LSE 1m candles. LSE quotes crypto as COIN/USD, so the
+    Hyperliquid coin normalization ('BTC-PERP' -> 'BTC') is reused here.
+    """
+    target_utc = _lse_target_utc(executed_at)
+    coin = _normalize_hyperliquid_symbol(symbol)
+    if not coin or ":" in coin:
+        return None  # dex/builder listings exist only on Hyperliquid
+    try:
+        return _lse_candle_close(f"candles_{_lse_symbol_slug(coin + '/USD')}", target_utc)
+    except Exception as exc:
+        _price_log(f"[Price API] LSE crypto error for {coin}: {exc}")
+        return None
+
+
 def get_price_from_market(
     symbol: str,
     executed_at: str,
@@ -701,19 +816,32 @@ def get_price_from_market(
             market = (market or "").strip().lower()
 
         if market == "crypto":
-            # Crypto pricing now uses Hyperliquid public endpoints.
-            # Try historical candle (when executed_at is provided), then fall back to mid price.
-            price = _get_hyperliquid_candle_close(symbol, executed_at) or _get_hyperliquid_mid_price(symbol)
+            # Crypto pricing: LSE candles first when a key is configured, then
+            # Hyperliquid public endpoints (historical candle, then mid price).
+            price = None
+            if LSE_API_KEY:
+                price = _get_lse_crypto_price(symbol, executed_at)
+                if price is None:
+                    _price_log(f"[Price API] LSE unavailable for {symbol}; falling back to Hyperliquid")
+            if price is None:
+                price = _get_hyperliquid_candle_close(symbol, executed_at) or _get_hyperliquid_mid_price(symbol)
         elif market == "polymarket":
             # Polymarket pricing uses public Gamma + CLOB endpoints.
             # We use the current orderbook mid price (paper trading).
             price = _get_polymarket_mid_price(symbol, token_id=token_id, outcome=outcome)
         elif market == "us-stock":
+            # US stock pricing: LSE candles first when a key is configured,
+            # then Alpha Vantage, then yfinance.
             price = None
-            if ALPHA_VANTAGE_API_KEY and ALPHA_VANTAGE_API_KEY != "demo":
-                price = _get_us_stock_price(symbol, executed_at)
-            else:
-                _price_log("Warning: ALPHA_VANTAGE_API_KEY not set, trying yfinance fallback")
+            if LSE_API_KEY:
+                price = _get_lse_us_stock_price(symbol, executed_at)
+                if price is None:
+                    _price_log(f"[Price API] LSE unavailable for {symbol}; falling back to Alpha Vantage/yfinance")
+            if price is None:
+                if ALPHA_VANTAGE_API_KEY and ALPHA_VANTAGE_API_KEY != "demo":
+                    price = _get_us_stock_price(symbol, executed_at)
+                else:
+                    _price_log("Warning: ALPHA_VANTAGE_API_KEY not set, trying yfinance fallback")
             if price is None:
                 _price_log(f"[Price API] Alpha Vantage unavailable for {symbol}; trying yfinance fallback")
                 price = _get_yfinance_us_stock_price(symbol, executed_at)

--- a/service/server/tests/test_price_fetcher.py
+++ b/service/server/tests/test_price_fetcher.py
@@ -120,5 +120,107 @@ class UsStockPriceTimezoneTests(unittest.TestCase):
         self.assertEqual(price, 0.4215)
 
 
+class LsePriceSourceTests(unittest.TestCase):
+    @staticmethod
+    def _http_error(status_code: int):
+        import requests
+
+        response = requests.Response()
+        response.status_code = status_code
+        return requests.HTTPError(response=response)
+
+    def test_us_stock_prefers_lse_when_key_set(self) -> None:
+        with patch.object(price_fetcher, "LSE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_get_lse_us_stock_price", return_value=101.5) as mock_lse, \
+             patch.object(price_fetcher, "ALPHA_VANTAGE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_get_us_stock_price", return_value=125.79) as mock_alpha, \
+             patch.object(price_fetcher, "_get_yfinance_us_stock_price", return_value=124.0) as mock_yfinance:
+            price = price_fetcher.get_price_from_market("AAPL", "2025-08-01T14:30:00Z", "us-stock")
+
+        self.assertEqual(price, 101.5)
+        mock_lse.assert_called_once_with("AAPL", "2025-08-01T14:30:00Z")
+        mock_alpha.assert_not_called()
+        mock_yfinance.assert_not_called()
+
+    def test_us_stock_falls_back_to_alpha_when_lse_returns_none(self) -> None:
+        with patch.object(price_fetcher, "LSE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_get_lse_us_stock_price", return_value=None) as mock_lse, \
+             patch.object(price_fetcher, "ALPHA_VANTAGE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_get_us_stock_price", return_value=125.79) as mock_alpha:
+            price = price_fetcher.get_price_from_market("AAPL", "2025-08-01T14:30:00Z", "us-stock")
+
+        self.assertEqual(price, 125.79)
+        mock_lse.assert_called_once_with("AAPL", "2025-08-01T14:30:00Z")
+        mock_alpha.assert_called_once_with("AAPL", "2025-08-01T14:30:00Z")
+
+    def test_us_stock_skips_lse_when_key_missing(self) -> None:
+        with patch.object(price_fetcher, "LSE_API_KEY", ""), \
+             patch.object(price_fetcher, "_get_lse_us_stock_price", return_value=101.5) as mock_lse, \
+             patch.object(price_fetcher, "ALPHA_VANTAGE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_get_us_stock_price", return_value=125.79):
+            price = price_fetcher.get_price_from_market("AAPL", "2025-08-01T14:30:00Z", "us-stock")
+
+        self.assertEqual(price, 125.79)
+        mock_lse.assert_not_called()
+
+    def test_crypto_prefers_lse_and_falls_back_to_hyperliquid(self) -> None:
+        with patch.object(price_fetcher, "LSE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_get_lse_crypto_price", return_value=64000.5) as mock_lse, \
+             patch.object(price_fetcher, "_get_hyperliquid_candle_close", return_value=63999.0) as mock_hl:
+            price = price_fetcher.get_price_from_market("BTC", "2025-08-01T14:30:00Z", "crypto")
+
+        self.assertEqual(price, 64000.5)
+        mock_lse.assert_called_once_with("BTC", "2025-08-01T14:30:00Z")
+        mock_hl.assert_not_called()
+
+        with patch.object(price_fetcher, "LSE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_get_lse_crypto_price", return_value=None), \
+             patch.object(price_fetcher, "_get_hyperliquid_candle_close", return_value=63999.0):
+            price = price_fetcher.get_price_from_market("BTC", "2025-08-01T14:30:00Z", "crypto")
+
+        self.assertEqual(price, 63999.0)
+
+    def test_lse_candle_close_queries_bounded_window(self) -> None:
+        rows = [{"timestamp": "2025-08-01T14:30:00+00:00", "close": 101.5, "symbol": "AAPL"}]
+        with patch.object(price_fetcher, "_lse_get_json", return_value=rows) as mock_get:
+            from datetime import datetime, timezone
+
+            target = datetime(2025, 8, 1, 14, 30, tzinfo=timezone.utc)
+            price = price_fetcher._lse_candle_close("d_candles_aapl", target)
+
+        self.assertEqual(price, 101.5)
+        table, params = mock_get.call_args.args
+        self.assertEqual(table, "d_candles_aapl")
+        self.assertIn(("timestamp", "lte.2025-08-01T14:30:00Z"), params)
+        self.assertIn(("timestamp", "gte.2025-07-25T14:30:00Z"), params)
+        self.assertIn(("order", "timestamp.desc"), params)
+        self.assertIn(("limit", "1"), params)
+
+    def test_lse_us_stock_tries_fallback_tables_on_404(self) -> None:
+        rows = [{"timestamp": "2025-08-01T14:30:00+00:00", "close": 99.25, "symbol": "AAPL"}]
+        with patch.object(price_fetcher, "LSE_API_KEY", "test-key"), \
+             patch.object(
+                 price_fetcher,
+                 "_request_json_with_retry",
+                 side_effect=[self._http_error(404), self._http_error(404), rows],
+             ) as mock_request:
+            price = price_fetcher._get_lse_us_stock_price("AAPL", "2025-08-01T14:30:00Z")
+
+        self.assertEqual(price, 99.25)
+        requested_urls = [call.args[2] for call in mock_request.call_args_list]
+        self.assertTrue(requested_urls[0].endswith("/d_candles_aapl"))
+        self.assertTrue(requested_urls[1].endswith("/candles_aapl"))
+        self.assertTrue(requested_urls[2].endswith("/x_candles_5m"))
+
+    def test_lse_crypto_maps_coin_to_usd_pair_table(self) -> None:
+        rows = [{"timestamp": "2025-08-01T14:30:00+00:00", "close": 1880.5, "symbol": "ETH/USD"}]
+        with patch.object(price_fetcher, "LSE_API_KEY", "test-key"), \
+             patch.object(price_fetcher, "_lse_get_json", return_value=rows) as mock_get:
+            price = price_fetcher._get_lse_crypto_price("ETH-PERP", "2025-08-01T14:30:00Z")
+
+        self.assertEqual(price, 1880.5)
+        self.assertEqual(mock_get.call_args.args[0], "candles_eth_usd")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds [London Strategic Edge](https://londonstrategicedge.com/data?ref=ai-trader) (LSE) market data as an optional primary price source. When `LSE_API_KEY` is set, US stock and crypto prices resolve from LSE's 1-minute OHLCV candles (with a 5m aggregate as last resort); the existing Alpha Vantage / yfinance / Hyperliquid paths remain as automatic fallbacks. With no key set, nothing changes.

**Why**: one free key covers both US stocks (3,900+ symbols) and crypto with consistent 1m candles, which removes the dependence on Alpha Vantage free-tier rate limits and yfinance scraping for deployments that want steadier pricing. The implementation reuses the existing retry/cooldown framework and symbol normalization, and fails open to the current providers on any error (404 for unlisted symbols, rate limits, timeouts), so it can never make pricing worse than today.

**Testing**: existing `tests/test_price_fetcher.py` passes unchanged, and this PR adds 7 unit tests covering provider ordering, no-key skip, fallback behavior, the bounded query window, table-name fallback on 404, and crypto symbol mapping. Also verified live against the LSE API: intraday and weekend "price at time" lookups, ETFs, dotted tickers (BRK.B), and BTC / BTC/USD / ETH-PERP symbol forms.

If useful for the update log: "Added optional London Strategic Edge (LSE) support for US stock and crypto prices. AI-Trader prefers LSE when an `LSE_API_KEY` is configured, and automatically falls back to Alpha Vantage / yfinance / Hyperliquid otherwise."

Happy to adjust anything about the integration (provider ordering, env naming, test coverage) to fit your preferences.