### PR TITLE
feat: add Atlas Cloud stock summary provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,15 @@ ALPHA_VANTAGE_API_KEY=demo
 # Optional: enrich US stock market-intel snapshots with Adanos social/news/prediction-market sentiment.
 ADANOS_API_KEY=
 
+# Optional AI-generated stock summaries. Atlas Cloud uses an OpenAI-compatible endpoint.
+ATLASCLOUD_API_KEY=
+ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro
+
+# Optional fallback summary provider when Atlas Cloud is not configured or unavailable.
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=
+
 # ==================== Frontend ====================
 # Frontend auto-refresh interval in milliseconds.
 VITE_REFRESH_INTERVAL=300000

--- a/service/server/market_intel.py
+++ b/service/server/market_intel.py
@@ -35,6 +35,19 @@ from database import get_db_connection
 ALPHA_VANTAGE_BASE_URL = os.getenv("ALPHA_VANTAGE_BASE_URL", "https://www.alphavantage.co/query").strip()
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "").strip()
 OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "").strip()
+ATLAS_CLOUD_API_KEY = (
+    os.getenv("ATLASCLOUD_API_KEY", "") or os.getenv("ATLAS_CLOUD_API_KEY", "")
+).strip()
+ATLAS_CLOUD_BASE_URL = (
+    os.getenv("ATLASCLOUD_BASE_URL", "")
+    or os.getenv("ATLAS_CLOUD_BASE_URL", "")
+    or "https://api.atlascloud.ai/v1"
+).strip().rstrip("/")
+ATLAS_CLOUD_MODEL = (
+    os.getenv("ATLASCLOUD_MODEL", "")
+    or os.getenv("ATLAS_CLOUD_MODEL", "")
+    or "deepseek-ai/deepseek-v4-pro"
+).strip()
 MARKET_NEWS_LOOKBACK_HOURS = int(os.getenv("MARKET_NEWS_LOOKBACK_HOURS", "48"))
 MARKET_NEWS_CATEGORY_LIMIT = int(os.getenv("MARKET_NEWS_CATEGORY_LIMIT", "12"))
 MARKET_NEWS_HISTORY_PER_CATEGORY = int(os.getenv("MARKET_NEWS_HISTORY_PER_CATEGORY", "96"))
@@ -470,7 +483,7 @@ def _alpha_vantage_get(params: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _extract_openrouter_text(response: Any) -> str:
+def _extract_chat_completion_text(response: Any) -> str:
     choices = getattr(response, "choices", None)
     if choices is None and isinstance(response, dict):
         choices = response.get("choices")
@@ -582,9 +595,6 @@ def _build_stock_analysis_fallback_summary(analysis: dict[str, Any]) -> str:
 
 def _generate_stock_analysis_summary(analysis: dict[str, Any]) -> str:
     fallback_summary = _build_stock_analysis_fallback_summary(analysis)
-    if not OPENROUTER_API_KEY or not OPENROUTER_MODEL or OpenRouter is None:
-        return fallback_summary
-
     prompt = (
         "Write one concise market snapshot paragraph in English for a trading dashboard.\n"
         "Rules:\n"
@@ -607,13 +617,38 @@ def _generate_stock_analysis_summary(analysis: dict[str, Any]) -> str:
         f"Risk factors: {json.dumps(analysis.get('risk_factors') or [], ensure_ascii=True)}\n"
     )
 
+    if ATLAS_CLOUD_API_KEY and ATLAS_CLOUD_MODEL:
+        try:
+            response = requests.post(
+                f"{ATLAS_CLOUD_BASE_URL}/chat/completions",
+                headers={
+                    "Authorization": f"Bearer {ATLAS_CLOUD_API_KEY}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": ATLAS_CLOUD_MODEL,
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 120,
+                },
+                timeout=20,
+            )
+            response.raise_for_status()
+            content = _extract_chat_completion_text(response.json())
+            if content:
+                return content[:500].strip()
+        except Exception:
+            pass
+
+    if not OPENROUTER_API_KEY or not OPENROUTER_MODEL or OpenRouter is None:
+        return fallback_summary
+
     try:
         with OpenRouter(api_key=OPENROUTER_API_KEY) as client:
             response = client.chat.send(
                 model=OPENROUTER_MODEL,
                 messages=[{"role": "user", "content": prompt}],
             )
-        content = _extract_openrouter_text(response)
+        content = _extract_chat_completion_text(response)
         return content[:500].strip() if content else fallback_summary
     except Exception:
         return fallback_summary

--- a/service/server/tests/test_market_intel.py
+++ b/service/server/tests/test_market_intel.py
@@ -175,6 +175,58 @@ class MarketIntelLatestPayloadTests(unittest.TestCase):
         self.assertEqual([item["symbol"] for item in payload["items"]], ["AAPL", "MSFT"])
 
 
+class StockAnalysisSummaryProviderTests(unittest.TestCase):
+    def _analysis(self) -> dict:
+        return {
+            "symbol": "AAPL",
+            "signal": "hold",
+            "trend_status": "constructive",
+            "signal_score": 1.5,
+            "current_price": 210.0,
+            "return_5d_pct": 1.2,
+            "return_20d_pct": 3.4,
+            "moving_averages": {"sma_20": 205.0},
+            "support_levels": [200.0],
+            "resistance_levels": [215.0],
+            "bullish_factors": ["Momentum improved."],
+            "risk_factors": ["Resistance is nearby."],
+        }
+
+    @patch("market_intel.requests.post")
+    def test_atlas_cloud_uses_openai_compatible_chat_completions(self, mock_post) -> None:
+        mock_post.return_value.json.return_value = {
+            "choices": [{"message": {"content": "Atlas generated summary."}}]
+        }
+        with patch.multiple(
+            market_intel,
+            ATLAS_CLOUD_API_KEY="atlas-test-key",
+            ATLAS_CLOUD_BASE_URL="https://api.atlascloud.ai/v1",
+            ATLAS_CLOUD_MODEL="deepseek-ai/deepseek-v4-pro",
+        ):
+            summary = market_intel._generate_stock_analysis_summary(self._analysis())
+
+        self.assertEqual(summary, "Atlas generated summary.")
+        mock_post.assert_called_once()
+        call = mock_post.call_args
+        self.assertEqual(call.args[0], "https://api.atlascloud.ai/v1/chat/completions")
+        self.assertEqual(call.kwargs["headers"]["Authorization"], "Bearer atlas-test-key")
+        self.assertEqual(call.kwargs["json"]["model"], "deepseek-ai/deepseek-v4-pro")
+        mock_post.return_value.raise_for_status.assert_called_once()
+
+    @patch("market_intel.requests.post", side_effect=RuntimeError("provider unavailable"))
+    def test_atlas_cloud_failure_keeps_local_fallback(self, _mock_post) -> None:
+        with patch.multiple(
+            market_intel,
+            ATLAS_CLOUD_API_KEY="atlas-test-key",
+            OPENROUTER_API_KEY="",
+            OPENROUTER_MODEL="",
+        ):
+            summary = market_intel._generate_stock_analysis_summary(self._analysis())
+
+        self.assertIn("AAPL", summary)
+        self.assertIn("setup", summary)
+
+
 class StockPriceMetadataTests(unittest.TestCase):
     """Coverage for _build_stock_price_metadata staleness classification.
 


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an OpenAI-compatible provider for generated stock analysis summaries
- support `ATLASCLOUD_*` and `ATLAS_CLOUD_*` environment aliases with a validated default model
- preserve the existing OpenRouter and deterministic local fallback paths
- add focused coverage for the Atlas request contract and failure fallback

## Validation

- `python3 -m pytest -q service/server/tests/test_market_intel.py service/server/tests/test_env_example.py` (`17 passed`)
- `python3 -m compileall -q service/server/market_intel.py service/server/tests/test_market_intel.py`
- `git diff --check`
- Atlas Cloud live `/v1/models`: HTTP 200, 121 models, including `deepseek-ai/deepseek-v4-pro`

Full `service/server/tests` collection is blocked on this machine's Python 3.9.6 because existing modules use Python 3.10 union syntax (`str | None`). The focused files above collect and pass.

No README, logo, sponsor, credits, or partner changes.
