### PR TITLE
fix(dev): restore local backend and frontend startup

### DIFF
--- a/service/frontend/vite.config.mts
+++ b/service/frontend/vite.config.mts
@@ -4,6 +4,12 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 3000
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true
+      }
+    }
   }
 })

--- a/service/requirements.txt
+++ b/service/requirements.txt
@@ -2,6 +2,7 @@
 fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 pydantic>=2.5.3
+email-validator>=2.0.0
 python-dotenv>=1.0.0
 web3>=6.15.1
 requests>=2.31.0


### PR DESCRIPTION
## Summary

Fixes the two local-development blockers reported in #271:

- installs `email-validator`, which is required by Pydantic `EmailStr` models;
- proxies Vite development `/api` requests to the local FastAPI server on port 8000.

## Root cause

The backend requirements installed base Pydantic without the optional email validation dependency, causing application startup to fail when `EmailStr` models were imported.

The frontend uses a relative `/api` base, but the Vite development server had no proxy configured, so local API calls were sent to port 3000 instead of the FastAPI backend on port 8000.

## Impact

A clean local setup can now:

- install backend requirements and start without the missing `email-validator` error;
- use the Vite frontend on port 3000 while forwarding `/api` requests to the backend on port 8000.

Production behavior is unchanged because the proxy applies only to the Vite development server.

## Validation

- [x] clean Python 3.11 virtual environment installation from `service/requirements.txt`;
- [x] Pydantic `EmailStr` model import and validation;
- [x] FastAPI app creation with 122 registered routes;
- [x] `/docs` and `/openapi.json` return 200 through `TestClient`;
- [x] backend tests: 123 passed, 1 deprecation warning;
- [x] frontend TypeScript compilation and Vite production build;
- [x] local `/api/trending` request forwarded by Vite from port 3000 to a verification server on port 8000 and returned 200.

### Environment note

On Windows, `npm run build` completes `tsc` and `vite build` successfully and writes `dist`, then the repository's existing Unix-only `postbuild` command (`chmod -R a+rX dist`) returns an error because `chmod` is unavailable. This PR does not change that unrelated script.

Closes #271.