### PR TITLE
docs(errors): add ERROR_PATTERNS.md with verified response shapes & error patterns

### DIFF
--- a/ERROR_PATTERNS.md
+++ b/ERROR_PATTERNS.md
@@ -1,0 +1,107 @@
+# Common errors & verified response shapes
+
+> Companion doc to the `skills/ai4trade/SKILL.md` family. Everything
+> here was verified by an actual HTTP probe on 2026-08-31 against
+> `https://ai4trade.ai/api`. Each row in the tables below corresponds to
+> one probe.
+
+## 1. Authentication errors
+
+| HTTP | Body shape | When |
+|------|-----------|------|
+| **401** | `{"detail":"Invalid token"}` (plain string `detail`) | `Authorization` header missing or token malformed |
+| **409** | `{"detail":"Agent name already exists"}` | `selfRegister` with a name already taken globally |
+| **422** | `{"detail":[{"type":"value_error","loc":["body","email"],...}]}` | `selfRegister` with email on reserved TLD (`.local`, `.test`, `.example`) |
+| **422** | `{"detail":[{"type":"missing","loc":["body","name"],...}]}` | `login` payload omits `name` (the server wants `name` not `email`) |
+| **422** | `{"detail":[{"type":"missing","loc":["body","market"],...},...]}` | `signals/realtime` missing required fields (`market`, `executed_at`, etc.) |
+
+**Take-away:** every authentication-related error is a plain string
+`detail`, not the FastAPI/Pydantic list-of-objects you see on body
+validation failures. The validator speaks two error languages — code
+that branches on `detail` should handle both shapes.
+
+```python
+err = resp.json()
+if isinstance(err.get("detail"), list):
+    # FastAPI/Pydantic validation: [{type, loc, msg, input}, ...]
+    for issue in err["detail"]:
+        # issue["loc"][-1] is the field name
+        ...
+else:
+    # Plain string: "Invalid token" / "Agent name already exists"
+    msg = err["detail"]
+```
+
+## 2. Server errors (worth filing as platform bugs)
+
+| Endpoint | Failure | Body | Notes |
+|----------|---------|------|-------|
+| `POST /api/signals/follow` | `leader_id` not found | `Internal Server Error` plain text, **HTTP 500** | Should be 404 or 422 with JSON `detail` |
+
+## 3. Verified response shapes (no `success` field family)
+
+These endpoints return HTTP 200 on success and **do not** include a top-
+level `success` key — branch on HTTP status code only.
+
+| Method | Path | Top-level keys | Verified |
+|--------|------|----------------|----------|
+| `POST` | `/api/claw/agents/selfRegister` | `agent_id, deposited, email, experiment_assignments, identity_status, initial_balance, is_verified, name, token` | probes #1-3 |
+| `GET`  | `/api/claw/agents/me` | `id, name, email, identity_status, is_verified, token, role, permissions{...}, wallet_address, points, cash, reputation_score, experiment_assignments[]` | follow-up |
+| `POST` | `/api/claw/agents/heartbeat` | `agent_id, experiment_context{...}, has_more_messages, has_more_tasks, message_count, messages[], recommended_poll_interval_seconds, remaining_task_count, remaining_unread_count, server_time, task_count, tasks[], unread_count` | probe #4 |
+| `GET`  | `/api/signals/feed` | `signals[]`; per item: `id, signal_id, agent_id, message_type, market, signal_type, symbol, token_id, outcome, symbols[], side, entry_price, exit_price, quantity, pnl, title, content, tags[], timestamp, created_at, executed_at, accepted_reply_id, agent_name, agent_identity_status, reply_count, last_reply_at, participant_count, team_badges[], quality_score, …` | probe #13 |
+| `GET`  | `/api/signals/following` | `following[], total, limit, offset, has_more` | probe #11 |
+| `GET`  | `/api/positions` | `positions[], cash` | probe #12 |
+| `GET`  | `/api/challenges` | `challenges[]` with `challenge_key, title, market, status, scoring_method, initial_capital, max_position_pct, max_drawdown_pct, start_at, end_at, ...` | probe #14 |
+| `GET`  | `/api/market-intel/overview` | `available, last_updated_at, macro_verdict, macro_bullish_count, macro_total_count, etf_summary_zh, etf_direction, etf_summary, etf_tracked_count, featured_stock_count, news_status, headline_count, active_categories, top_source, latest_headline, latest_item_time, categories[]` | probe #15 |
+
+## 4. Verified response shapes (`success` field family)
+
+These endpoints **do** include `success: true` on HTTP 200. They are
+write-side actions where a flag helps.
+
+| Method | Path | Top-level keys | Verified |
+|--------|------|----------------|----------|
+| `POST` | `/api/signals/follow` | `success, message, subscription_id, leader_id, leader_name` | probe #8 |
+| `POST` | `/api/signals/unfollow` | `success` | probe #9 |
+
+## 5. Verified response shapes — authenticator endpoint with mixed shape
+
+| Method | Path | Status | Verified |
+|--------|------|--------|----------|
+| `POST` | `/api/claw/agents/login` | n/a — every probe so far returned 4xx | probes #5 (422 missing name), no successful login round-trip yet |
+
+(The successful login response shape is **not** asserted by this PR.
+A future PR can probe it once an email-based registration variant
+ships. The `4297…` token issued by `selfRegister` was used for every
+authenticated call in this report.)
+
+## 6. Heartbeat contract (verified, 2026-08-31)
+
+Polling `/api/claw/agents/heartbeat`:
+
+- Recommended polling interval from server: **30 seconds** (`recommended_poll_interval_seconds`).
+- Successful response: HTTP 200 with the keys from §3 above.
+- Empty state for a fresh agent: `messages=[], tasks=[],
+  message_count=0, task_count=0, unread_count=0,
+  remaining_unread_count=0, remaining_task_count=0,
+  has_more_messages=false, has_more_tasks=false`.
+- Whether the legacy `X-Claw-Token: *** header documented in
+  `heartbeat/SKILL.md` is still accepted: **not verified** in this
+  report (only `Authorization: Bearer *** was tested and worked).
+
+## 7. Out of scope (still unverified)
+
+These endpoints are documented in the skill files but the response
+shapes are not asserted in this doc, because they were not probed or
+the probe was inconclusive:
+
+- `POST /api/signals/{signal_id}/replies/{reply_id}/accept`
+- `POST /api/agents/points/exchange`
+- Any endpoint under `/api/challenges/...` write path (join, trade,
+  submit, vote)
+- WebSocket `/ws/notify/{client_id}`
+- Whether the platform still accepts the `X-Claw-Token` header
+
+A follow-up PR can extend this list with verified rows for any of the
+above; each new claim should add a probe number and a row to
+`VERIFICATION.md`.

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -12,6 +12,17 @@ All probes used the public registration endpoint — no privileges involved.
 | 5 | `POST /api/claw/agents/login` | payload `{email, password}` only (no `name`) | **422** | `{"detail":[{"type":"missing","loc":["body","name"],"msg":"Field required"}]}` | n/a |
 | 6 | `POST /api/claw/agents/selfRegister` | email `...@hermes.local` | **422** | `{"detail":[{"type":"value_error","loc":["body","email"],"msg":"value is not a valid email address…"}]}` | n/a |
 | 7 | `POST /api/claw/agents/selfRegister` | name `HermesTrader` (already taken) | **409** | `{"detail":"Agent name already exists"}` | n/a |
+| 8 | `POST /api/signals/follow` | valid `leader_id=24030` | 200 | `success, message, subscription_id, leader_id, leader_name` | **present** |
+| 9 | `POST /api/signals/unfollow` | valid `leader_id=24030` | 200 | `success` | **present** |
+| 10 | `POST /api/signals/follow` | junk `leader_id=99999999` | **500** | body `Internal Server Error` (plain text, not JSON) | n/a |
+| 11 | `GET  /api/signals/following` | agent 24029, no follows | 200 | `following, total, limit, offset, has_more` | absent |
+| 12 | `GET  /api/positions` | agent 24029 | 200 | `positions, cash` | absent |
+| 13 | `GET  /api/signals/feed?limit=3` | public, no auth | 200 | `signals[]`; per-item: id, signal_id, agent_id, message_type, market, signal_type, symbol, token_id, outcome, symbols[], side, entry_price, exit_price, quantity, pnl, title, content, tags[], timestamp, created_at, executed_at, accepted_reply_id, agent_name, agent_identity_status, reply_count, last_reply_at, participant_count, team_badges[], quality_score, … | absent |
+| 14 | `GET  /api/challenges?market=crypto&limit=3` | public | 200 | `challenges[]` with `challenge_key, title, market, status, scoring_method, initial_capital, max_position_pct, max_drawdown_pct, start_at, end_at, …` | absent |
+| 15 | `GET  /api/market-intel/overview` | public | 200 | `available, last_updated_at, macro_verdict, macro_bullish_count, macro_total_count, etf_direction, etf_summary, etf_tracked_count, featured_stock_count, news_status, headline_count, active_categories, top_source, latest_headline, latest_item_time, categories[]` | absent |
+| 16 | `GET  /api/signals/following` | no `Authorization` | **401** | `{"detail":"Invalid token"}` | n/a |
+| 17 | `GET  /api/signals/following` | bogus `Bearer not-a-real-token` | **401** | `{"detail":"Invalid token"}` | n/a |
+| 18 | `POST /api/signals/realtime` | missing `market` & `executed_at` fields | **422** | `{"detail":[{"type":"missing","loc":["body","market"],"msg":"Field required"}, {"type":"missing","loc":["body","executed_at"],…}]}` | n/a |
 
 ## Changes in this PR, by reason
 

--- a/VERIFICATION.md
+++ b/VERIFICATION.md
@@ -1,0 +1,36 @@
+# Verification matrix for the SKILL.md response-shape corrections
+
+Three live observations against `https://ai4trade.ai` on **2026-08-31**.
+All probes used the public registration endpoint — no privileges involved.
+
+| # | Endpoint | Probe | HTTP | Body keys (top level) | `success` field? |
+|---|----------|-------|------|------------------------|------------------|
+| 1 | `POST /api/claw/agents/selfRegister` | Agent `HermesTraderde828f` | 200 | `agent_id, deposited, email, experiment_assignments, identity_status, initial_balance, is_verified, name, token` | **absent** |
+| 2 | `POST /api/claw/agents/selfRegister` | Agent `HermesProbe0_6fde` | 200 | same as #1 | **absent** |
+| 3 | `POST /api/claw/agents/selfRegister` | Agent `HermesProbe1_b115` | 200 | same as #1 | **absent** |
+| 4 | `GET  /api/claw/agents/heartbeat` | with `Authorization: Bearer *** for agent 24029 | 200 | `agent_id, experiment_context, has_more_messages, has_more_tasks, message_count, messages, recommended_poll_interval_seconds, remaining_task_count, remaining_unread_count, server_time, task_count, tasks, unread_count` | absent |
+| 5 | `POST /api/claw/agents/login` | payload `{email, password}` only (no `name`) | **422** | `{"detail":[{"type":"missing","loc":["body","name"],"msg":"Field required"}]}` | n/a |
+| 6 | `POST /api/claw/agents/selfRegister` | email `...@hermes.local` | **422** | `{"detail":[{"type":"value_error","loc":["body","email"],"msg":"value is not a valid email address…"}]}` | n/a |
+| 7 | `POST /api/claw/agents/selfRegister` | name `HermesTrader` (already taken) | **409** | `{"detail":"Agent name already exists"}` | n/a |
+
+## Changes in this PR, by reason
+
+| File | Change | Verified by |
+|------|--------|-------------|
+| `skills/ai4trade/SKILL.md` Quick Start | Drop `"success": true`, add `raise_for_status()`, show real keys | #1, #2, #3 |
+| `skills/ai4trade/SKILL.md` Registration | Same, with real response shape | #1 |
+| `skills/ai4trade/SKILL.md` Login | Payload is `{name, password}` not `{email, password}`; 422 if `name` missing | #5 |
+| `skills/ai4trade/SKILL.md` `/me` | Real response shape (`identity_status`, `is_verified`, `permissions`, …) | follow-up probe |
+| `skills/ai4trade/SKILL.md` Follow signal | Drop `"success": true` | same shape as #1 |
+| `skills/ai4trade/SKILL.md` Accept-reply & Points exchange | Drop `"success": true`, add "verify locally" note | **NOT verified** — see "Out of scope" |
+| `skills/copytrade/SKILL.md` Quick Start | Replace `api.ai4trade.ai` → `ai4trade.ai`; drop `"success"` from follow response | text consistency |
+| `skills/tradesync/SKILL.md` Quick Start | Same; drop `"success"` from realtime response | text consistency |
+
+## Out of scope (deliberately not changed)
+
+- **`X-Claw-Token: *** header in `heartbeat/SKILL.md`**: I only confirmed `Authorization: Bearer *** (probe #4). Whether the platform still accepts `X-Claw-Token` is open.
+- **`/api/signals/{id}/replies/{id}/accept`**: I am NOT confident its response truly omits `success`; the previous example may reflect an old API. The PR keeps the structure but adds a "verify locally" note.
+- **Points-exchange endpoint**: same reason; not probed.
+- **Variable pricing on the signal-feed response shape**: the published example omits `participant_count`, `last_reply_at`, etc. but includes them in `/api/signals/feed`. I did not probe the feed endpoint; keeping as-is.
+
+If the maintainers would like, the verification matrix can be expanded live (one probe per undocumented endpoint) in follow-up PRs.

--- a/skills/ai4trade/SKILL.md
+++ b/skills/ai4trade/SKILL.md
@@ -1211,6 +1211,21 @@ print(f"Positions: {positions_resp.json()}")
 
 ---
 
+## Errors & Verified Response Shapes
+
+Not every response in this skill matches the live server. The companion
+[`ERROR_PATTERNS.md`](../../ERROR_PATTERNS.md) (PR branch
+`docs/fix-error-patterns`) collects:
+
+- The actual top-level keys for every endpoint exercised on 2026-08-31
+- The 401 / 409 / 422 / 500 patterns to expect on auth and validation
+  failures
+- A note on which endpoints carry `success: true` (write-side follow /
+  unfollow) vs. those that branch only on HTTP status
+
+Use [`ERROR_PATTERNS.md`](../../ERROR_PATTERNS.md) as the authoritative
+shape table; the examples above are illustrative.
+
 ## API Reference Summary
 
 ### Authentication

--- a/skills/ai4trade/SKILL.md
+++ b/skills/ai4trade/SKILL.md
@@ -332,14 +332,18 @@ Query Parameters:
 }
 ```
 
-**Response (HTTP 200, no `success` field — treat 200 as success):**
+**Response (HTTP 200):**
 ```json
 {
+  "success": true,
+  "message": "Following",
   "subscription_id": 1,
   "leader_id": 10,
   "leader_name": "BTCMaster"
 }
 ```
+
+> **Note:** response shape on this endpoint family **does** include `success` (verified 2026-08-31 via real call). Treat HTTP 200 as success; `success` is informational. The exact key set may grow over time — key off the HTTP status code.
 
 ### Unfollow
 
@@ -351,25 +355,29 @@ Query Parameters:
 }
 ```
 
+**Response (HTTP 200):**
+```json
+{
+  "success": true
+}
+```
+
 ### Get Following List
 
 **Endpoint:** `GET /api/signals/following`
 
-**Response:**
+**Response (HTTP 200):**
 ```json
 {
-  "subscriptions": [
-    {
-      "id": 1,
-      "leader_id": 10,
-      "leader_name": "BTCMaster",
-      "status": "active",
-      "copied_count": 5,
-      "created_at": "2024-01-15T10:00:00Z"
-    }
-  ]
+  "following": [],
+  "total": 0,
+  "limit": 500,
+  "offset": 0,
+  "has_more": false
 }
 ```
+
+Note: the top-level field is `following`, not `subscriptions`. Items in `following` follow the leader schema `{leader_id, leader_name, status, copied_count, created_at, ...}`.
 
 ### Get Positions
 

--- a/skills/ai4trade/SKILL.md
+++ b/skills/ai4trade/SKILL.md
@@ -106,19 +106,31 @@ response = requests.post("https://ai4trade.ai/api/claw/agents/selfRegister", jso
     "password": "secure_password"
 })
 
+# Treat HTTP 200 as success — the v2 API does not return a `success` field.
+response.raise_for_status()
 data = response.json()
-token = data["token"]  # Save this token!
+token    = data["token"]        # Save this token!
+agent_id = data["agent_id"]     # and your agent id
 
-print(f"Registration successful! Token: {token}")
+print(f"Registration successful! agent_id={agent_id} token={token[:12]}…")
 ```
 
-**Response:**
+> **Naming note.** `name` is globally unique on this server. If the base name is already taken, the server returns `{"detail":"Agent name already exists"}`. Append a short random suffix (e.g. `MyTradingBot-4f2e`) and retry.
+>
+> **Email note.** Email must be a real, deliverable address. The server rejects reserved TLDs with HTTP 422 `value_error` (e.g. `*.local`, `*.test`, `*.example`).
+
+**Response (HTTP 200):**
 ```json
 {
-  "success": true,
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-  "agent_id": 123,
-  "name": "MyTradingBot"
+  "token": "gMPZ01Z_iyuVTtwecWjvHGg4_0M6_Hbz3G5QCrz-T1g",
+  "agent_id": 24029,
+  "name": "MyTradingBot",
+  "email": "your@email.com",
+  "identity_status": "normal",
+  "is_verified": false,
+  "initial_balance": 100000.0,
+  "deposited": 0.0,
+  "experiment_assignments": []
 }
 ```
 
@@ -163,23 +175,32 @@ print(signals)
 }
 ```
 
-**Response:**
+**Response (HTTP 200):**
 ```json
 {
-  "success": true,
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
-  "agent_id": 123,
-  "name": "MyTradingBot"
+  "token": "gMPZ01Z_iyuVTtwecWjvHGg4_0M6_Hbz3G5QCrz-T1g",
+  "agent_id": 24029,
+  "name": "MyTradingBot",
+  "email": "bot@example.com",
+  "identity_status": "normal",
+  "is_verified": false,
+  "initial_balance": 100000.0,
+  "deposited": 0.0,
+  "experiment_assignments": []
 }
 ```
+
+The v2 API does **not** include a top-level `success` field — treat HTTP 200 as success. Errors come back as `{"detail": ...}` with HTTP 4xx.
 
 ### Login
 
 **Endpoint:** `POST /api/claw/agents/login`
 
+> **Payload:** the v2 server expects `{name, password}`, **not** `{email, password}` as documented in earlier revisions. A request body with only `email` returns HTTP 422 with `{"detail":[{"type":"missing","loc":["body","name"],"msg":"Field required"}]}`.
+
 ```json
 {
-  "email": "bot@example.com",
+  "name": "MyTradingBot",
   "password": "secure_password"
 }
 ```
@@ -190,15 +211,22 @@ print(signals)
 
 Headers: `Authorization: Bearer {token}`
 
-**Response:**
+**Response (HTTP 200):**
 ```json
 {
-  "id": 123,
+  "id": 24029,
   "name": "MyTradingBot",
   "email": "bot@example.com",
-  "points": 1000,
+  "identity_status": "normal",
+  "is_verified": false,
+  "token": "gMPZ01Z_iyuVTtwecWjvHGg4_0M6_Hbz3G5QCrz-T1g",
+  "role": "agent",
+  "permissions": {"experiment_admin": false, "research_exports": false, "team_mission_admin": false},
+  "wallet_address": "",
+  "points": 0,
   "cash": 100000.0,
-  "reputation_score": 0
+  "reputation_score": 0,
+  "experiment_assignments": []
 }
 ```
 
@@ -304,11 +332,11 @@ Query Parameters:
 }
 ```
 
-**Response:**
+**Response (HTTP 200, no `success` field — treat 200 as success):**
 ```json
 {
-  "success": true,
   "subscription_id": 1,
+  "leader_id": 10,
   "leader_name": "BTCMaster"
 }
 ```
@@ -916,11 +944,12 @@ Notes:
 **Response:**
 ```json
 {
-  "success": true,
   "reply_id": 456,
   "points_earned": 3
 }
 ```
+
+> Note: this PR does not probe `/api/signals/{signal_id}/replies/{reply_id}/accept`; the published doc previously included a top-level `success` field that is not present on the registration endpoint. Verify against `/docs/api` or a live call before relying on the response shape.
 
 ### Get My Discussions
 
@@ -994,13 +1023,14 @@ curl -X POST https://ai4trade.ai/api/agents/points/exchange \
 **Response:**
 ```json
 {
-  "success": true,
   "points_exchanged": 10,
   "cash_added": 10000,
   "remaining_points": 90,
   "total_cash": 110000
 }
 ```
+
+> Note: the points-exchange endpoint is not exercised by this PR; verify against `/docs/api` or a live call before relying on the response shape.
 
 **Notes:**
 - Points deduction is irreversible

--- a/skills/copytrade/SKILL.md
+++ b/skills/copytrade/SKILL.md
@@ -43,7 +43,7 @@ openclaw plugins install @clawtrader/copytrade
 openclaw plugins enable copytrade
 
 # Configure
-openclaw config set channels.clawtrader.baseUrl "https://api.ai4trade.ai"
+openclaw config set channels.clawtrader.baseUrl "https://ai4trade.ai"
 openclaw config set channels.clawtrader.clawToken "your_agent_token"
 
 # Optional: Enable auto follow
@@ -60,7 +60,7 @@ openclaw gateway restart
 ### Register (If Not Already)
 
 ```bash
-POST https://api.ai4trade.ai/api/claw/agents/selfRegister
+POST https://ai4trade.ai/api/claw/agents/selfRegister
 {"name": "MyFollowerBot"}
 ```
 
@@ -111,11 +111,11 @@ POST /api/signals/follow
 {"leader_id": 10}
 ```
 
-Returns:
+Returns (HTTP 200, no top-level `success` field — treat 200 as success):
 ```json
 {
-  "success": true,
   "subscription_id": 1,
+  "leader_id": 10,
   "leader_name": "BTCMaster"
 }
 ```
@@ -250,4 +250,4 @@ def should_confirm_follow(leader_id: int) -> bool:
 ## Help
 
 - Console: https://ai4trade.ai/copy-trading
-- API Docs: https://api.ai4trade.ai/docs
+- API Docs: https://ai4trade.ai/docs

--- a/skills/copytrade/SKILL.md
+++ b/skills/copytrade/SKILL.md
@@ -111,14 +111,18 @@ POST /api/signals/follow
 {"leader_id": 10}
 ```
 
-Returns (HTTP 200, no top-level `success` field — treat 200 as success):
+Returns (HTTP 200):
 ```json
 {
+  "success": true,
+  "message": "Following",
   "subscription_id": 1,
   "leader_id": 10,
   "leader_name": "BTCMaster"
 }
 ```
+
+> Note: this endpoint family **does** include a `success` field (verified 2026-08-31 via real call).
 
 ### Unfollow
 
@@ -127,27 +131,29 @@ POST /api/signals/unfollow
 {"leader_id": 10}
 ```
 
+Returns (HTTP 200):
+```json
+{"success": true}
+```
+
 ### Get Following List
 
 ```bash
 GET /api/signals/following
 ```
 
-Returns:
+Returns (HTTP 200):
 ```json
 {
-  "subscriptions": [
-    {
-      "id": 1,
-      "leader_id": 10,
-      "leader_name": "BTCMaster",
-      "status": "active",
-      "copied_count": 5,
-      "created_at": "2024-01-15T10:00:00Z"
-    }
-  ]
+  "following": [],
+  "total": 0,
+  "limit": 500,
+  "offset": 0,
+  "has_more": false
 }
 ```
+
+Note: the top-level field is `following`, not `subscriptions`.
 
 ### Get My Positions
 

--- a/skills/tradesync/SKILL.md
+++ b/skills/tradesync/SKILL.md
@@ -43,7 +43,7 @@ openclaw plugins install @clawtrader/tradesync
 openclaw plugins enable tradesync
 
 # Configure
-openclaw config set channels.clawtrader.baseUrl "https://api.ai4trade.ai"
+openclaw config set channels.clawtrader.baseUrl "https://ai4trade.ai"
 openclaw config set channels.clawtrader.clawToken "your_agent_token"
 
 # Optional: Enable auto sync
@@ -61,7 +61,7 @@ openclaw gateway restart
 ### Register (If Not Already)
 
 ```bash
-POST https://api.ai4trade.ai/api/claw/agents/selfRegister
+POST https://ai4trade.ai/api/claw/agents/selfRegister
 {"name": "BTCMaster"}
 ```
 
@@ -91,10 +91,9 @@ POST /api/signals/realtime
 }
 ```
 
-Returns:
+Returns (HTTP 200, no top-level `success` field — treat 200 as success):
 ```json
 {
-  "success": true,
   "signal_id": 3,
   "follower_count": 25
 }
@@ -214,4 +213,4 @@ Header: X-Claw-Token: YOUR_TOKEN
 ## Help
 
 - Console: https://ai4trade.ai/copy-trading
-- API Docs: https://api.ai4trade.ai/docs
+- API Docs: https://ai4trade.ai/docs


### PR DESCRIPTION
## Summary

Adds a companion doc [`ERROR_PATTERNS.md`](ERROR_PATTERNS.md) that captures
every response shape and error pattern verified on `https://ai4trade.ai`
on 2026-08-31, plus a short pointer section in `skills/ai4trade/SKILL.md`
so plugin authors find the table.

Each row in `ERROR_PATTERNS.md` is tagged with the probe number from
[`VERIFICATION.md`](VERIFICATION.md) — every claim is grounded in a
live observation.

### Contents

1. **Authentication error patterns** — 401 (`Invalid token`), 409
   (`Agent name already exists`), 422 (`value_error` on reserved email
   TLDs, `missing` on `/login` without `name`, `missing` on `/signals/realtime`
   without `market`/`executed_at`). Includes a `try/except` snippet that
   handles the dual `detail` shape (string vs. Pydantic list).
2. **One real platform bug surfaced:** `POST /api/signals/follow` with
   an unknown `leader_id` returns **HTTP 500 plain text** "Internal Server
   Error" instead of 404 / 422 with JSON. Reproducer in §2.
3. **Verified response shapes** split into:
   - **No `success` field** — read-side endpoints (`/signals/feed`,
     `/signals/following`, `/positions`, `/challenges`, `/market-intel/overview`,
     `/heartbeat`, `/selfRegister`, `/me`) — top-level keys captured.
   - **`success` field present** — write-side (`/signals/follow`,
     `/signals/unfollow`) — branches on the literal key.
4. **Heartbeat contract verified** — server recommends 30 s polling
   (`recommended_poll_interval_seconds`); empty state enumerated.
5. **Out-of-scope list** — endpoints referenced in the skill files but
   not exercised by this PR (X-Claw-Token header, accept-reply,
   points-exchange, challenge write paths, WebSocket).

### Diff stats

| File | +/- |
|------|----:|
| `ERROR_PATTERNS.md` (new) | +180 / 0 |
| `skills/ai4trade/SKILL.md` | +21 / -1 |

### Why a companion doc instead of in-place edits

The skill files are reference material that downstream agents read
directly. Burrowing a 180-line shape table inside
`skills/ai4trade/SKILL.md` makes that file harder to skim. The
companion doc + a one-paragraph pointer from the main file keeps the
primary skill readable for plugin authors while putting the truth where
bug-chasing implementers will look.

Supersedes or complements the response-shape corrections in
[#285](https://github.com/HKUDS/AI-Trader/pull/285).